### PR TITLE
Create action/workflow for running Harvester periodically

### DIFF
--- a/.github/workflows/harvest.yml
+++ b/.github/workflows/harvest.yml
@@ -1,0 +1,27 @@
+name: Harvest
+
+on:
+  workflow_dispatch:
+  schedule:
+    - 0 4 * * *
+
+jobs:
+  harvest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: pjquirk/harvest-action@main
+        name: Harvest extension candidates
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          candidatesFile: ./candidates.json
+          outputFile: ./extensions.md
+
+      - uses: EndBug/add-and-commit@2d77fa2c79bc4ea3abc933ecf12c270a5dc536b2
+        with:
+          message: "Updating extensions table"
+          add: ./extensions.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a workflow that runs an adapted version of "Harvester" to collect the number of hist/repos for a given extension/query.

## Description
Keeping track of the usage of a language is heavily manual process, see for example #4219.  This monitoring is done by a tool known as [Harvester](https://github.com/Alhadis/Harvester), which uses the github.com search page to look for the total number of hits across unique repositories.

This workflow uses [an action](https://github.com/pjquirk/harvest-action/) that does the same thing, using the actual REST APIs instead of the browser, which allows us to more easily automate the work.  The action expects a JSON file that contains the search terms to process, and generates a markdown file with the results.  

Example input:
```json
[
  {
    "pr": 4827,
    "extensions": [
      {
        "extension": "kql"
      },
      {
        "extension": "kusto"
      },
      {
        "extension": "csl",
        "extendedSearch": "where+NOT+xml"
      }
    ]
  }
]
```

Example output:

| Extension | Total Hits | Unique Repositories | PR |
| --- | --- | --- | --- |
[kql](https://github.com/search?q=extension:kql+NOT+nothack) | 1007 | 66 | [4827](https://github.com/github/linguist/pull/4827)
[kusto](https://github.com/search?q=extension:kusto+NOT+nothack) | 65 | 19 | [4827](https://github.com/github/linguist/pull/4827)
[csl](https://github.com/search?q=extension:csl+where+NOT+xml) | 558 | 80 | [4827](https://github.com/github/linguist/pull/4827)

This came out of a [discussion in a PR](https://github.com/github/linguist/pull/4827#issuecomment-746557932).

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - `N/A`: I have added or updated the tests for the new or changed functionality.

