### PR TITLE
Update Erlang color to match the official logo

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1520,7 +1520,7 @@ EmberScript:
   language_id: 103
 Erlang:
   type: programming
-  color: "#B83998"
+  color: "#A90533"
   extensions:
   - ".erl"
   - ".app.src"


### PR DESCRIPTION
## Description
Update the color associated with Erlang, to match the same "dark red(ish)" used by the Erlang logo on https://www.erlang.org/

From: `#b83998`
To: `#a90533`

## Checklist:
- [x] **I am changing the color associated with a language**
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [Erlang Slack](erlanger.slack.com.), general channel ([message link](https://erlanger.slack.com/archives/C055DJA49/p1623011205155200))
    - /r/erlang subreddit ([post link](https://www.reddit.com/r/erlang/comments/nwx78a/github_linguist_update_erlang_color_to_match_the/))
    - https://www.erlang.org/