### PR TITLE
Change C++ color to match the official logo

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -674,7 +674,7 @@ C++:
   ace_mode: c_cpp
   codemirror_mode: clike
   codemirror_mime_type: text/x-c++src
-  color: "#f34b7d"
+  color: "#004482"
   aliases:
   - cpp
   extensions:


### PR DESCRIPTION
## Description
The color is made to be close to the official logo of C++ (instead of the current pink).

See https://isocpp.org/ for the logo.

![image](https://user-images.githubusercontent.com/14205339/150406049-59bf7eb1-1bba-4f29-b119-2b07217c9dfa.png)

New color:
![Screenshot_20220120_221200](https://user-images.githubusercontent.com/14205339/150406249-43d05e28-7eaf-4a67-8232-7359b4424435.png)

![Screenshot_20220120_221326](https://user-images.githubusercontent.com/14205339/150406464-b3e64cac-3225-4ea4-a2df-5fb887deea75.png)


## Checklist:

- [x] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [x] I have obtained agreement from the wider language community on this color change.
    - [Reddit Poll](https://www.reddit.com/r/cpp/comments/s8s6ru/should_the_color_of_the_github_languages_stripe/)