### PR TITLE
Add stanfunctions extension to Stan

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5833,6 +5833,7 @@ Stan:
   color: "#b2011d"
   extensions:
   - ".stan"
+  - ".stanfunctions"
   ace_mode: text
   tm_scope: source.stan
   language_id: 356

--- a/samples/Stan/unit_johnson_lpdf.stanfunctions
+++ b/samples/Stan/unit_johnson_lpdf.stanfunctions
@@ -1,0 +1,6 @@
+real unit_johnson_lpdf(vector x, real mu, real sigma) {
+  int N = num_elements(x);
+  return N * log(sigma)
+         - sum(log(x) + log1m(x) + 0.5 * log1p(square(logit(x))))
+         + std_normal_lpdf(mu + sigma * asinh(logit(x)) | );
+}


### PR DESCRIPTION
Stan now allows the ending `.stanfunctions` 

PR in Stan that allows this: https://github.com/stan-dev/stanc3/pull/1022

Repo using them example: https://github.com/spinkney/helpful_stan_functions/blob/main/functions/distribution/unit_johnson_su.stanfunctions

## Checklist:
- [x] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language: