### PR TITLE
Add `.teamcity` to vendored folders

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -388,3 +388,6 @@
 
 # obsidian.md settings
 - (^|/)\.obsidian/
+
+# teamcity CI configuration
+- (^|/)\.teamcity/

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -580,10 +580,15 @@ class TestFileBlob < Minitest::Test
     # GitHub.com
     assert sample_blob(".github/CODEOWNERS").vendored?
     assert sample_blob(".github/workflows/test.yml").vendored?
-    
+
     # obsidian.md settings
     assert sample_blob(".obsidian/app.json").vendored?
     assert sample_blob(".obsidian/plugins/templater-obsidian/main.js").vendored?
+
+    # teamcity ci configuration
+    assert sample_blob(".teamcity/Project_Name_CI/Project.kt").vendored?
+    assert sample_blob(".teamcity/Project_Name_CI/settings.kts").vendored?
+    assert sample_blob(".teamcity/Project_Name_CI/patches/projects/3b71d400-c5d6-4628-8164-c50b1254cf1d.kts").vendored?
   end
 
   def test_documentation


### PR DESCRIPTION
## Description
Teamcity has a mode to store project settings in the repo. This creates a folder in the repo root called [.teamcity](https://www.jetbrains.com/help/teamcity/storing-project-settings-in-version-control.html) that can contain a lot of kotlin files that skews language reporting

## Checklist:

- [X] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [X] I have added or updated the tests for the new or changed functionality.
