### PR TITLE
Add `proto` alias for protobuf

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5282,6 +5282,7 @@ Propeller Spin:
 Protocol Buffer:
   type: data
   aliases:
+  - proto
   - protobuf
   - Protocol Buffers
   extensions:


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
proto is the extension for protobuf files, and is used in [other](https://github.com/shikijs/shiki/blob/44b9b0c458744267d824a8283eac4d6393f65013/packages/shiki/src/languages.ts#L104) syntax highlighters as the language id.

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

Just adding the alias so that the `proto` language id can be used for code fences.

## Checklist:

None of the below checklist items seem to apply