### PR TITLE
Add `rust-script` to Rust interpreters

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6013,6 +6013,8 @@ Rust:
   ace_mode: rust
   codemirror_mode: rust
   codemirror_mime_type: text/x-rustsrc
+  interpreters:
+  - rust-script
   language_id: 327
 SAS:
   type: programming

--- a/samples/Rust/base64url
+++ b/samples/Rust/base64url
@@ -1,0 +1,33 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [dependencies]
+//! base64-url = "1.1"
+//! ```
+
+use std::env;
+use std::io;
+use std::io::{Read, Write};
+
+fn main() -> io::Result<()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 || (args[1] != "decode" && args[1] != "encode") {
+        println!("Error: Specify either 'decode' or 'encode' as first and only argument");
+        ::std::process::exit(1);
+    }
+
+    if args[1] == "decode" {
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer)?;
+        let decoded = base64_url::decode(&buffer).expect("Error decoding");
+        io::stdout().write(&decoded).unwrap();
+        io::stdout().flush().unwrap();
+        println!("");
+    } else {
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer)?;
+        let encoded = base64_url::encode(&buffer);
+        println!("{}", encoded);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Detect [rust-script](https://rust-script.org/) files as rust source code.

## Description
Detect files using the [rust-script](https://rust-script.org/) interpreter as Rust source code. Asked for [here](https://github.com/fornwall/rust-script/issues/87). See [this GitHub search](https://github.com/search?q=%22%2Fusr%2Fbin%2Fenv+rust-script%22&type=code) for examples of usage.

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.
