### PR TITLE
Add RBS language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1242,6 +1242,9 @@
 [submodule "vendor/grammars/vscode-proto3"]
 	path = vendor/grammars/vscode-proto3
 	url = https://github.com/zxh0/vscode-proto3
+[submodule "vendor/grammars/vscode-rbs-syntax"]
+	path = vendor/grammars/vscode-rbs-syntax
+	url = https://github.com/soutaro/vscode-rbs-syntax.git
 [submodule "vendor/grammars/vscode-scala-syntax"]
 	path = vendor/grammars/vscode-scala-syntax
 	url = https://github.com/scala/vscode-scala-syntax

--- a/grammars.yml
+++ b/grammars.yml
@@ -1119,6 +1119,8 @@ vendor/grammars/vscode-procfile:
 vendor/grammars/vscode-proto3:
 - markdown.codeblock.proto
 - source.proto
+vendor/grammars/vscode-rbs-syntax:
+- source.rbs
 vendor/grammars/vscode-scala-syntax:
 - source.scala
 vendor/grammars/vscode-singularity:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5514,7 +5514,9 @@ RAML:
   language_id: 308
 RBS:
   type: data
-  ace_mode: text
+  ace_mode: ruby
+  codemirror_mode: ruby
+  codemirror_mime_type: text/x-ruby
   extensions:
   - ".rbs"
   color: "#701516"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5674,6 +5674,14 @@ Raw token data:
   tm_scope: none
   ace_mode: text
   language_id: 318
+RBS:
+  type: programming
+  ace_mode: text
+  extensions:
+  - ".rbs"
+  color: "#701516"
+  group: Ruby
+  language_id: 899227493
 ReScript:
   type: programming
   color: "#ed5051"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5512,6 +5512,15 @@ RAML:
   extensions:
   - ".raml"
   language_id: 308
+RBS:
+  type: programming
+  ace_mode: text
+  extensions:
+  - ".rbs"
+  color: "#701516"
+  tm_scope: source.rbs
+  group: Ruby
+  language_id: 899227493
 RDoc:
   type: prose
   color: "#701516"
@@ -5674,15 +5683,6 @@ Raw token data:
   tm_scope: none
   ace_mode: text
   language_id: 318
-RBS:
-  type: programming
-  ace_mode: text
-  extensions:
-  - ".rbs"
-  color: "#701516"
-  tm_scope: source.rbs
-  group: Ruby
-  language_id: 899227493
 ReScript:
   type: programming
   color: "#ed5051"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5680,6 +5680,7 @@ RBS:
   extensions:
   - ".rbs"
   color: "#701516"
+  tm_scope: source.rbs
   group: Ruby
   language_id: 899227493
 ReScript:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5513,7 +5513,7 @@ RAML:
   - ".raml"
   language_id: 308
 RBS:
-  type: programming
+  type: data
   ace_mode: text
   extensions:
   - ".rbs"

--- a/samples/RBS/cli.rbs
+++ b/samples/RBS/cli.rbs
@@ -1,0 +1,83 @@
+module RBS
+  class CLI
+    class LibraryOptions
+      attr_accessor core_root: Pathname?
+      attr_accessor config_path: Pathname?
+
+      attr_reader libs: Array[String]
+      attr_reader dirs: Array[String]
+      attr_reader repos: Array[String]
+
+      def initialize: () -> void
+
+      def loader: () -> EnvironmentLoader
+
+      def setup_library_options: (OptionParser) -> OptionParser
+    end
+
+    interface _IO
+      def puts: (*untyped) -> void
+
+      def print: (*untyped) -> void
+
+      def flush: () -> void
+    end
+
+    attr_reader stdout: _IO
+    attr_reader stderr: _IO
+
+    # The copy of `args` passed to `run`.
+    #
+    # `OptionParser#order!` mutates given `arg`, the `run_***` actions should read `original_args` to get the original commandline arguments.
+    #
+    # Returns `nil` if called before `#run` call.
+    #
+    attr_reader original_args: Array[String]
+
+    def initialize: (stdout: IO, stderr: IO) -> void
+
+    COMMANDS: Array[Symbol]
+
+    def library_parse: (OptionParser, options: LibraryOptions) -> void
+
+    def parse_logging_options: (OptionParser) -> void
+
+    def has_parser?: () -> bool
+
+    def run: (Array[String] args) -> void
+
+    def run_ast: (Array[String], LibraryOptions) -> void
+
+    def run_list: (Array[String], LibraryOptions) -> void
+
+    def run_ancestors: (Array[String], LibraryOptions) -> void
+
+    def run_methods: (Array[String], LibraryOptions) -> void
+
+    def run_method: (Array[String], LibraryOptions) -> void
+
+    def run_validate: (Array[String], LibraryOptions) -> void
+
+    def run_constant: (Array[String], LibraryOptions) -> void
+
+    def run_paths: (Array[String], LibraryOptions) -> void
+
+    def run_prototype: (Array[String], LibraryOptions) -> void
+
+    def run_prototype_file: (String format, Array[String]) -> void
+
+    def run_vendor: (Array[String], LibraryOptions) -> void
+
+    def run_parse: (Array[String], LibraryOptions) -> void
+
+    def run_test: (Array[String], LibraryOptions) -> void
+
+    def run_collection: (Array[String], LibraryOptions) -> void
+
+    def run_annotate: (Array[String], top) -> void
+
+    def test_opt: (LibraryOptions) -> String?
+
+    def collection_options: (Array[String]) -> OptionParser
+  end
+end

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -436,6 +436,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Quake:** [newgrammars/quake](https://github.com/newgrammars/quake)
 - **R:** [textmate/r.tmbundle](https://github.com/textmate/r.tmbundle)
 - **RAML:** [atom/language-yaml](https://github.com/atom/language-yaml)
+- **RBS:** [soutaro/vscode-rbs-syntax](https://github.com/soutaro/vscode-rbs-syntax)
 - **RDoc:** [joshaven/RDoc.tmbundle](https://github.com/joshaven/RDoc.tmbundle)
 - **REALbasic:** [peters-ben-0007/VBDotNetSyntax](https://github.com/peters-ben-0007/VBDotNetSyntax)
 - **REXX:** [mblocker/rexx-sublime](https://github.com/mblocker/rexx-sublime)

--- a/vendor/licenses/git_submodule/vscode-rbs-syntax.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-rbs-syntax.dep.yml
@@ -1,0 +1,31 @@
+---
+name: vscode-rbs-syntax
+version: 164e36d3d39c0f187a04f7370cea7ba22453b662
+type: git_submodule
+homepage: https://github.com/soutaro/vscode-rbs-syntax.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2019 Seiei Miyagi and Soutaro Matsumoto
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
This pull request adds the RBS language. RBS (RuBy Signature) is a language to describe the structure of Ruby programs and has been developed and maintained by the Ruby official team.

Closes #6368

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=path%3A**%2F%3F*.rbs
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/ruby/rbs/blob/ff85396bb230a9fce11b84ce79b4ba92900d0e6b/sig/cli.rbs
    - Sample license(s):
      - https://github.com/ruby/rbs/blob/ff85396bb230a9fce11b84ce79b4ba92900d0e6b/COPYING
  - [x] I have included a syntax highlighting grammar: https://github.com/soutaro/vscode-rbs-syntax
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#701516`
    - Rationale: RBS is strongly integrated with Ruby and usually is used together. So, it makes sense to adopt the same color as Ruby.
    - https://github.com/github/linguist/blob/5a0c74277548122267d84283910abd5e0b89380e/lib/linguist/languages.yml#L5943
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
