### PR TITLE
Add support for WebAssembly Interface Types

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1254,6 +1254,9 @@
 [submodule "vendor/grammars/vscode-vlang"]
 	path = vendor/grammars/vscode-vlang
 	url = https://github.com/0x9ef/vscode-vlang
+[submodule "vendor/grammars/vscode-wit"]
+	path = vendor/grammars/vscode-wit
+	url = https://github.com/bytecodealliance/vscode-wit.git
 [submodule "vendor/grammars/vscode-wren"]
 	path = vendor/grammars/vscode-wren
 	url = https://github.com/Nelarius/vscode-wren.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1127,6 +1127,8 @@ vendor/grammars/vscode-slice:
 - source.slice
 vendor/grammars/vscode-vlang:
 - source.v
+vendor/grammars/vscode-wit:
+- source.wit
 vendor/grammars/vscode-wren:
 - source.wren
 vendor/grammars/vscode-yara:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7339,6 +7339,18 @@ WebAssembly:
   codemirror_mode: commonlisp
   codemirror_mime_type: text/x-common-lisp
   language_id: 956556503
+WebAssembly Interface Type:
+  type: data
+  color: "#6250e7"
+  extensions:
+  - ".wit"
+  aliases:
+  - wit
+  ace_mode: text
+  tm_scope: source.wit
+  codemirror_mode: webidl
+  codemirror_mime_type: text/x-webidl
+  language_id: 134534086
 WebIDL:
   type: programming
   extensions:
@@ -7409,18 +7421,6 @@ Windows Registry Entries:
   codemirror_mode: properties
   codemirror_mime_type: text/x-properties
   language_id: 969674868
-WebAssembly Interface Type:
-  type: data
-  color: "#6250e7"
-  extensions:
-  - ".wit"
-  aliases:
-  - wit
-  ace_mode: text
-  tm_scope: source.wit
-  codemirror_mode: webidl
-  codemirror_mime_type: text/x-webidl
-  language_id: 134534086
 Witcher Script:
   type: programming
   color: "#ff0000"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7418,8 +7418,8 @@ WebAssembly Interface Type:
   - wit
   ace_mode: text
   tm_scope: source.wit
-  codemirror_mode: clike
-  codemirror_mime_type: text/x-csrc
+  codemirror_mode: webidl
+  codemirror_mime_type: text/x-webidl
   language_id: 134534086
 Witcher Script:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7409,6 +7409,18 @@ Windows Registry Entries:
   codemirror_mode: properties
   codemirror_mime_type: text/x-properties
   language_id: 969674868
+WebAssembly Interface Type:
+  type: programming
+  color: "#6250e7"
+  extensions:
+  - ".wit"
+  aliases:
+  - wit
+  ace_mode: text
+  tm_scope: source.wit
+  codemirror_mode: clike
+  codemirror_mime_type: text/x-csrc
+  language_id: 134534086
 Witcher Script:
   type: programming
   color: "#ff0000"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7410,7 +7410,7 @@ Windows Registry Entries:
   codemirror_mime_type: text/x-properties
   language_id: 969674868
 WebAssembly Interface Type:
-  type: programming
+  type: data
   color: "#6250e7"
   extensions:
   - ".wit"

--- a/samples/WebAssembly Interface Type/wasi-io.wit
+++ b/samples/WebAssembly Interface Type/wasi-io.wit
@@ -1,0 +1,259 @@
+// From: https://github.com/WebAssembly/wasi-io/tree/e6bcf18ac5e2d2deee5016fc4b6e260fc14d4bdc/wit 
+
+default world example-world {
+    import streams: self.streams
+}
+
+/// WASI I/O is an I/O abstraction API which is currently focused on providing
+/// stream types.
+///
+/// In the future, the component model is expected to add built-in stream types;
+/// when it does, they are expected to subsume this API.
+default interface streams {
+    use self.poll.{pollable}
+
+    /// An error type returned from a stream operation. Currently this
+    /// doesn't provide any additional information.
+    record stream-error {}
+
+    /// An input bytestream. In the future, this will be replaced by handle
+    /// types.
+    ///
+    /// This conceptually represents a `stream<u8, _>`. It's temporary
+    /// scaffolding until component-model's async features are ready.
+    ///
+    /// `input-stream`s are *non-blocking* to the extent practical on underlying
+    /// platforms. I/O operations always return promptly; if fewer bytes are
+    /// promptly available than requested, they return the number of bytes promptly
+    /// available, which could even be zero. To wait for data to be available,
+    /// use the `subscribe-to-input-stream` function to obtain a `pollable` which
+    /// can be polled for using `wasi_poll`.
+    ///
+    /// And at present, it is a `u32` instead of being an actual handle, until
+    /// the wit-bindgen implementation of handles and resources is ready.
+    ///
+    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
+    type input-stream = u32
+
+    /// Read bytes from a stream.
+    ///
+    /// This function returns a list of bytes containing the data that was
+    /// read, along with a bool which, when true, indicates that the end of the
+    /// stream was reached. The returned list will contain up to `len` bytes; it
+    /// may return fewer than requested, but not more.
+    ///
+    /// Once a stream has reached the end, subsequent calls to read or
+    /// `skip` will always report end-of-stream rather than producing more
+    /// data.
+    ///
+    /// If `len` is 0, it represents a request to read 0 bytes, which should
+    /// always succeed, assuming the stream hasn't reached its end yet, and
+    /// return an empty list.
+    ///
+    /// The len here is a `u64`, but some callees may not be able to allocate
+    /// a buffer as large as that would imply.
+    /// FIXME: describe what happens if allocation fails.
+    read: func(
+        this: input-stream,
+        /// The maximum number of bytes to read
+        len: u64
+    ) -> result<tuple<list<u8>, bool>, stream-error>
+
+    /// Read bytes from a stream, with blocking.
+    ///
+    /// This is similar to `read`, except that it blocks until at least one
+    /// byte can be read.
+    blocking-read: func(
+        this: input-stream,
+        /// The maximum number of bytes to read
+        len: u64
+    ) -> result<tuple<list<u8>, bool>, stream-error>
+
+    /// Skip bytes from a stream.
+    ///
+    /// This is similar to the `read` function, but avoids copying the
+    /// bytes into the instance.
+    ///
+    /// Once a stream has reached the end, subsequent calls to read or
+    /// `skip` will always report end-of-stream rather than producing more
+    /// data.
+    ///
+    /// This function returns the number of bytes skipped, along with a bool
+    /// indicating whether the end of the stream was reached. The returned
+    /// value will be at most `len`; it may be less.
+    skip: func(
+        this: input-stream,
+        /// The maximum number of bytes to skip.
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Skip bytes from a stream, with blocking.
+    ///
+    /// This is similar to `skip`, except that it blocks until at least one
+    /// byte can be consumed.
+    blocking-skip: func(
+        this: input-stream,
+        /// The maximum number of bytes to skip.
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Create a `pollable` which will resolve once either the specified stream
+    /// has bytes available to read or the other end of the stream has been
+    /// closed.
+    subscribe-to-input-stream: func(this: input-stream) -> pollable
+
+    /// Dispose of the specified `input-stream`, after which it may no longer
+    /// be used.
+    drop-input-stream: func(this: input-stream)
+
+    /// An output bytestream. In the future, this will be replaced by handle
+    /// types.
+    ///
+    /// This conceptually represents a `stream<u8, _>`. It's temporary
+    /// scaffolding until component-model's async features are ready.
+    ///
+    /// `output-stream`s are *non-blocking* to the extent practical on
+    /// underlying platforms. Except where specified otherwise, I/O operations also
+    /// always return promptly, after the number of bytes that can be written
+    /// promptly, which could even be zero. To wait for the stream to be ready to
+    /// accept data, the `subscribe-to-output-stream` function to obtain a
+    /// `pollable` which can be polled for using `wasi_poll`.
+    ///
+    /// And at present, it is a `u32` instead of being an actual handle, until
+    /// the wit-bindgen implementation of handles and resources is ready.
+    ///
+    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
+    type output-stream = u32
+
+    /// Write bytes to a stream.
+    ///
+    /// This function returns a `u64` indicating the number of bytes from
+    /// `buf` that were written; it may be less than the full list.
+    write: func(
+        this: output-stream,
+        /// Data to write
+        buf: list<u8>
+    ) -> result<u64, stream-error>
+
+    /// Write bytes to a stream, with blocking.
+    ///
+    /// This is similar to `write`, except that it blocks until at least one
+    /// byte can be written.
+    blocking-write: func(
+        this: output-stream,
+        /// Data to write
+        buf: list<u8>
+    ) -> result<u64, stream-error>
+
+    /// Write multiple zero bytes to a stream.
+    ///
+    /// This function returns a `u64` indicating the number of zero bytes
+    /// that were written; it may be less than `len`.
+    write-zeroes: func(
+        this: output-stream,
+        /// The number of zero bytes to write
+        len: u64
+    ) -> result<u64, stream-error>
+
+    /// Write multiple zero bytes to a stream, with blocking.
+    ///
+    /// This is similar to `write-zeroes`, except that it blocks until at least
+    /// one byte can be written.
+    blocking-write-zeroes: func(
+        this: output-stream,
+        /// The number of zero bytes to write
+        len: u64
+    ) -> result<u64, stream-error>
+
+    /// Read from one stream and write to another.
+    ///
+    /// This function returns the number of bytes transferred; it may be less
+    /// than `len`.
+    ///
+    /// Unlike other I/O functions, this function blocks until all the data
+    /// read from the input stream has been written to the output stream.
+    splice: func(
+        this: output-stream,
+        /// The stream to read from
+        src: input-stream,
+        /// The number of bytes to splice
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Read from one stream and write to another, with blocking.
+    ///
+    /// This is similar to `splice`, except that it blocks until at least
+    /// one byte can be read.
+    blocking-splice: func(
+        this: output-stream,
+        /// The stream to read from
+        src: input-stream,
+        /// The number of bytes to splice
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Forward the entire contents of an input stream to an output stream.
+    ///
+    /// This function repeatedly reads from the input stream and writes
+    /// the data to the output stream, until the end of the input stream
+    /// is reached, or an error is encountered.
+    ///
+    /// Unlike other I/O functions, this function blocks until the end
+    /// of the input stream is seen and all the data has been written to
+    /// the output stream.
+    ///
+    /// This function returns the number of bytes transferred.
+    forward: func(
+        this: output-stream,
+        /// The stream to read from
+        src: input-stream
+    ) -> result<u64, stream-error>
+
+    /// Create a `pollable` which will resolve once either the specified stream
+    /// is ready to accept bytes or the other end of the stream has been closed.
+    subscribe-to-output-stream: func(this: output-stream) -> pollable
+
+    /// Dispose of the specified `output-stream`, after which it may no longer
+    /// be used.
+    drop-output-stream: func(this: output-stream)
+}
+
+/// A poll API intended to let users wait for I/O events on multiple handles
+/// at once.
+default interface poll {
+    /// A "pollable" handle.
+    ///
+    /// This is conceptually represents a `stream<_, _>`, or in other words,
+    /// a stream that one can wait on, repeatedly, but which does not itself
+    /// produce any data. It's temporary scaffolding until component-model's
+    /// async features are ready.
+    ///
+    /// And at present, it is a `u32` instead of being an actual handle, until
+    /// the wit-bindgen implementation of handles and resources is ready.
+    ///
+    /// `pollable` lifetimes are not automatically managed. Users must ensure
+    /// that they do not outlive the resource they reference.
+    ///
+    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
+    type pollable = u32
+
+    /// Dispose of the specified `pollable`, after which it may no longer
+    /// be used.
+    drop-pollable: func(this: pollable)
+
+    /// Poll for completion on a set of pollables.
+    ///
+    /// The "oneoff" in the name refers to the fact that this function must do a
+    /// linear scan through the entire list of subscriptions, which may be
+    /// inefficient if the number is large and the same subscriptions are used
+    /// many times. In the future, this is expected to be obsoleted by the
+    /// component model async proposal, which will include a scalable waiting
+    /// facility.
+    ///
+    /// Note that the return type would ideally be `list<bool>`, but that would
+    /// be more difficult to polyfill given the current state of `wit-bindgen`.
+    /// See <https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061>
+    /// for details.  For now, we use zero to mean "not ready" and non-zero to
+    /// mean "ready".
+    poll-oneoff: func(in: list<pollable>) -> list<u8>
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -571,6 +571,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Wavefront Object:** [Alhadis/language-wavefront](https://github.com/Alhadis/language-wavefront)
 - **Web Ontology Language:** [textmate/xml.tmbundle](https://github.com/textmate/xml.tmbundle)
 - **WebAssembly:** [Alhadis/language-webassembly](https://github.com/Alhadis/language-webassembly)
+- **WebAssembly Interface Type:** [bytecodealliance/vscode-wit](https://github.com/bytecodealliance/vscode-wit)
 - **WebIDL:** [andik/IDL-Syntax](https://github.com/andik/IDL-Syntax)
 - **WebVTT:** [Alhadis/language-subtitles](https://github.com/Alhadis/language-subtitles)
 - **Wget Config:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)

--- a/vendor/licenses/git_submodule/vscode-wit.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-wit.dep.yml
@@ -1,0 +1,228 @@
+---
+name: vscode-wit
+version: 3585bde571d1838522fa96f7593d5625f41ce8d8
+type: git_submodule
+homepage: https://github.com/bytecodealliance/vscode-wit.git
+license: apache-2.0
+licenses:
+- sources: LICENSE
+  text: |2
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+
+       END OF TERMS AND CONDITIONS
+
+       APPENDIX: How to apply the Apache License to your work.
+
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "[]"
+          replaced with your own identifying information. (Don't include
+          the brackets!)  The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+
+       Copyright [yyyy] [name of copyright owner]
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+
+    --- LLVM Exceptions to the Apache 2.0 License ----
+
+    As an exception, if, as a result of your compiling your source code, portions
+    of this Software are embedded into an Object form of such source code, you
+    may redistribute such embedded portions in such Object form without complying
+    with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+    In addition, if you combine or link compiled forms of this Software with
+    software that is licensed under the GPLv2 ("Combined Software") and if a
+    court of competent jurisdiction determines that the patent provision (Section
+    3), the indemnity provision (Section 9) or other Section of the License
+    conflicts with the conditions of the GPLv2, you may retroactively and
+    prospectively choose to deem waived or otherwise exclude such Section(s) of
+    the License, but only in their entirety and only with respect to the Combined
+    Software.
+notices: []

--- a/vendor/licenses/git_submodule/vscode-wit.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-wit.dep.yml
@@ -1,9 +1,9 @@
 ---
 name: vscode-wit
-version: 3585bde571d1838522fa96f7593d5625f41ce8d8
+version: 24e281807992601cb13738edf062961eca9b7f44
 type: git_submodule
 homepage: https://github.com/bytecodealliance/vscode-wit.git
-license: apache-2.0
+license: other
 licenses:
 - sources: LICENSE
   text: |2

--- a/vendor/licenses/git_submodule/vscode-wit.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-wit.dep.yml
@@ -3,7 +3,7 @@ name: vscode-wit
 version: 24e281807992601cb13738edf062961eca9b7f44
 type: git_submodule
 homepage: https://github.com/bytecodealliance/vscode-wit.git
-license: other
+license: apache-2.0
 licenses:
 - sources: LICENSE
   text: |2


### PR DESCRIPTION
## Description

Add support for WebAssembly Interface Type (WIT):
https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  https://github.com/search?q=path%3A*.wit&type=code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/WebAssembly/wasi-io/tree/e6bcf18ac5e2d2deee5016fc4b6e260fc14d4bdc/wit
    - Sample license(s): Apache 2.0
  - [x] I have included a syntax highlighting grammar: https://github.com/bytecodealliance/vscode-wit
  - [x] I have added a color
    - Hex value: `#6250e7`
    - Rationale: Based on the WebAssembly logo
