### PR TITLE
Add `.txx` extension to C++

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -758,6 +758,7 @@ C++:
   - ".re"
   - ".tcc"
   - ".tpp"
+  - ".txx"
   language_id: 43
 C-ObjDump:
   type: data

--- a/samples/C++/search.txx
+++ b/samples/C++/search.txx
@@ -1,0 +1,132 @@
+
+#ifdef __DEBUG__
+#ifndef __DEBUG_PAR__
+#define __DEBUG_PAR__
+#endif
+#endif
+
+/**
+@file search.txx
+@brief Parallel Search Function
+@author Rahul S. Sampath, rahul.sampath@gmail.com
+*/
+
+namespace par {
+	
+	template <typename T>
+	int maxLowerBound(const std::vector<T> & keys, const std::vector<T> & searchList,
+std::vector<T> & results, MPI_Comm comm) {
+		PROF_SEARCH_BEGIN
+
+		int rank, npes;
+
+		MPI_Comm_size(comm, &npes);
+		MPI_Comm_rank(comm, &rank);
+
+		// allocate memory for the mins array
+		std::vector<T> mins (npes);
+		assert(!searchList.empty());
+
+		par::MPI_Allgather<T>( &(*searchList.begin()), &(*mins.begin()), 1, comm);
+
+		//For each key decide which processor to send to
+		unsigned int *part = new unsigned int[keys.size()];
+		for ( unsigned int i=0; i<keys.size(); i++ ) {
+			//maxLB returns the smallest index in a sorted array such that a[ind] <= key and  a[index +1] > key
+			bool found = par::maxLowerBound<T>(mins,keys[i], part+i);
+			if ( !found ) {
+				//This key is smaller than the mins from every processor.
+				//No point in searching.
+				part[i] = rank;
+			}
+		}
+		mins.clear();
+
+		int *numKeysSend = new int[npes];
+		int *numKeysRecv = new int[npes];
+		for ( int i=0; i<npes; i++ )
+			numKeysSend[i] = 0;
+		// calculate the number of keys to send ...
+		for ( unsigned int i=0; i<keys.size(); i++ )
+			numKeysSend[part[i]]++;
+
+		// Now do an All2All to get numKeysRecv
+		par::MPI_Alltoall(numKeysSend, 1, MPI_INT, numKeysRecv, 1, MPI_INT, comm);
+
+		unsigned int totalKeys=0;	// total number of local keys ...
+		for ( int i=0; i<npes; i++ )
+			totalKeys += numKeysRecv[i];
+
+		// create the send and recv buffers ...
+		std::vector<T> sendK (keys.size());
+		std::vector<T> recvK (totalKeys);
+		// the mapping ..
+		unsigned int * comm_map = new unsigned int [keys.size()];
+
+		// Now create sendK
+		int *sendOffsets = new int[npes]; sendOffsets[0] = 0;
+		int *recvOffsets = new int[npes]; recvOffsets[0] = 0;
+		int *numKeysTmp = new int[npes]; numKeysTmp[0] = 0; 
+
+		// compute offsets ...
+		for ( int i=1; i<npes; i++ ) {
+			sendOffsets[i] = sendOffsets[i-1] + numKeysSend[i-1];
+			recvOffsets[i] = recvOffsets[i-1] + numKeysRecv[i-1];
+			numKeysTmp[i] = 0; 
+		}
+
+		for ( unsigned int i=0; i< keys.size(); i++ ) {
+			unsigned int ni = numKeysTmp[part[i]];
+			numKeysTmp[part[i]]++;
+			// set entry ...
+			sendK[sendOffsets[part[i]] + ni] = keys[i];
+			// save mapping .. will need it later ...
+			comm_map[i] = sendOffsets[part[i]] + ni;
+		}
+		delete [] part;
+		delete [] numKeysTmp;
+
+
+		par::MPI_Alltoallv_sparse((void *)&(*sendK.begin()), numKeysSend,
+                sendOffsets,par::Mpi_datatype<T>::value(), 
+                &(*recvK.begin()), numKeysRecv, recvOffsets,
+                par::Mpi_datatype<T>::value(), comm);
+
+
+		std::vector<T>  resSend (totalKeys);
+		std::vector<T>  resRecv (keys.size());
+
+		//Final local search.
+		for ( unsigned int i=0; i<totalKeys;i++) {
+			unsigned int idx;
+			bool found = par::maxLowerBound<T>( searchList, recvK[i], &idx );
+			if(found) {
+				resSend[i] = searchList[idx];
+			}
+		}//end for i
+
+		//Exchange Results
+		//Return what you received in the earlier communication.
+		par::MPI_Alltoallv_sparse((void*)&(*resSend.begin()), numKeysRecv,
+                recvOffsets,par::Mpi_datatype<T>::value(), 
+                &(*resRecv.begin()), numKeysSend, sendOffsets,
+                par::Mpi_datatype<T>::value(), comm);
+
+		delete [] sendOffsets;
+		delete [] recvOffsets;
+		delete [] numKeysSend;
+		delete [] numKeysRecv;
+
+		for ( unsigned int i=0; i < keys.size(); i++ ) {
+			results[i] = resRecv[comm_map[i]];  
+		}//end for
+
+		// Clean up ...
+		delete [] comm_map;
+
+		PROF_SEARCH_END
+	}
+
+
+}//end namespace
+

--- a/samples/C++/target.txx
+++ b/samples/C++/target.txx
@@ -1,0 +1,171 @@
+// file      : libbuild2/target.txx -*- C++ -*-
+// license   : MIT; see accompanying LICENSE file
+
+#include <libbuild2/scope.hxx>
+#include <libbuild2/diagnostics.hxx>
+
+namespace build2
+{
+  template <const char* ext>
+  const char*
+  target_extension_fix (const target_key& tk, const scope*)
+  {
+    // A generic file target type doesn't imply any extension while a very
+    // specific one (say man1) may have a fixed extension. So if one wasn't
+    // specified set it to fixed ext rather than unspecified. For file{}
+    // itself we make it empty which means we treat file{foo} as file{foo.}.
+    //
+    return tk.ext ? tk.ext->c_str () : ext;
+  }
+
+  template <const char* ext>
+  bool
+  target_pattern_fix (const target_type&,
+                      const scope&,
+                      string& v,
+                      optional<string>& e,
+                      const location& l,
+                      bool r)
+  {
+    if (r)
+    {
+      // If we get called to reverse then it means we've added the extension
+      // in the first place.
+      //
+      assert (e);
+      e = nullopt;
+    }
+    else
+    {
+      e = target::split_name (v, l);
+
+      // We only add our extension if there isn't one already.
+      //
+      if (!e)
+      {
+        e = ext;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  inline optional<string>
+  target_extension_var_impl (const target_type& tt,
+                             const string& tn,
+                             const scope& s,
+                             const char* def)
+  {
+    // Include target type/pattern-specific variables.
+    //
+    // Note that we know this is not dir{} or fsdir{} and that the extension
+    // is not part of the match (see variable_type_map::find() for details).
+    //
+    if (auto l = s.lookup (*s.ctx.var_extension, tt, tn))
+    {
+      // Help the user here and strip leading '.' from the extension.
+      //
+      const string& e (cast<string> (l));
+      return !e.empty () && e.front () == '.' ? string (e, 1) : e;
+    }
+
+    return def != nullptr ? optional<string> (def) : nullopt;
+  }
+
+  template <const char* def>
+  optional<string>
+  target_extension_var (const target_key& tk,
+                        const scope& s,
+                        const char*,
+                        bool)
+  {
+    return target_extension_var_impl (*tk.type, *tk.name, s, def);
+  }
+
+  template <const char* def>
+  bool
+  target_pattern_var (const target_type& tt,
+                      const scope& s,
+                      string& v,
+                      optional<string>& e,
+                      const location& l,
+                      bool r)
+  {
+    if (r)
+    {
+      // If we get called to reverse then it means we've added the extension
+      // in the first place.
+      //
+      assert (e);
+      e = nullopt;
+    }
+    else
+    {
+      e = target::split_name (v, l);
+
+      // We only add our extension if there isn't one already.
+      //
+      if (!e)
+      {
+        // Use empty name as a target since we only want target type/pattern-
+        // specific variables that match any target ('*' but not '*.txt').
+        //
+        if ((e = target_extension_var_impl (tt, string (), s, def)))
+          return true;
+      }
+    }
+
+    return false;
+  }
+
+  // dir
+  //
+  template <typename K>
+  const target* dir::
+  search_implied (const scope& bs, const K& k, tracer& trace)
+  {
+    using namespace butl;
+
+    // See if we have any prerequisites.
+    //
+    prerequisites_type ps (collect_implied (bs));
+
+    if (ps.empty ())
+      return nullptr;
+
+    l5 ([&]{trace << "implying buildfile for " << k;});
+
+    // We behave as if this target was explicitly mentioned in the (implied)
+    // buildfile. Thus not implied.
+    //
+    target& t (bs.ctx.targets.insert (dir::static_type,
+                                      bs.out_path (),
+                                      dir_path (),
+                                      string (),
+                                      nullopt,
+                                      target_decl::real,
+                                      trace).first);
+    t.prerequisites (move (ps));
+    return &t;
+  }
+
+  // exe
+  //
+  template <typename T>
+  const T* exe::
+  lookup_metadata (const char* var) const
+  {
+    if (auto* ns = cast_null<names> (vars[ctx.var_export_metadata]))
+    {
+      // Metadata variable prefix must be in the second name.
+      //
+      if (ns->size () < 2 || !(*ns)[1].simple ())
+        fail << "invalid metadata variable prefix in target " << *this;
+
+      return cast_null<T> (vars[(*ns)[1].value + '.' + var]);
+    }
+
+    return nullptr;
+  }
+}

--- a/samples/C++/vtkSparseArray.txx
+++ b/samples/C++/vtkSparseArray.txx
@@ -1,0 +1,618 @@
+/*=========================================================================
+
+  Program:   Visualization Toolkit
+  Module:    vtkSparseArray.txx
+
+-------------------------------------------------------------------------
+  Copyright 2008 Sandia Corporation.
+  Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+  the U.S. Government retains certain rights in this software.
+-------------------------------------------------------------------------
+
+  Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
+  All rights reserved.
+  See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+
+#ifndef vtkSparseArray_txx
+#define vtkSparseArray_txx
+
+#include <algorithm>
+#include <limits>
+
+VTK_ABI_NAMESPACE_BEGIN
+template <typename T>
+vtkSparseArray<T>* vtkSparseArray<T>::New()
+{
+  // Don't use object factory macros on templates, it'll confuse the object
+  // factory.
+  vtkSparseArray<T>* ret = new vtkSparseArray<T>;
+  ret->InitializeObjectBase();
+  return ret;
+}
+
+template <typename T>
+void vtkSparseArray<T>::PrintSelf(ostream& os, vtkIndent indent)
+{
+  vtkSparseArray<T>::Superclass::PrintSelf(os, indent);
+}
+
+template <typename T>
+bool vtkSparseArray<T>::IsDense()
+{
+  return false;
+}
+
+template <typename T>
+const vtkArrayExtents& vtkSparseArray<T>::GetExtents()
+{
+  return this->Extents;
+}
+
+template <typename T>
+typename vtkSparseArray<T>::SizeT vtkSparseArray<T>::GetNonNullSize()
+{
+  return this->Values.size();
+}
+
+template <typename T>
+void vtkSparseArray<T>::GetCoordinatesN(SizeT n, vtkArrayCoordinates& coordinates)
+{
+  coordinates.SetDimensions(this->GetDimensions());
+  for (DimensionT i = 0; i != this->GetDimensions(); ++i)
+    coordinates[i] = this->Coordinates[i][n];
+}
+
+template <typename T>
+vtkArray* vtkSparseArray<T>::DeepCopy()
+{
+  ThisT* const copy = ThisT::New();
+
+  copy->SetName(this->GetName());
+  copy->Extents = this->Extents;
+  copy->DimensionLabels = this->DimensionLabels;
+  copy->Coordinates = this->Coordinates;
+  copy->Values = this->Values;
+  copy->NullValue = this->NullValue;
+
+  return copy;
+}
+
+template <typename T>
+const T& vtkSparseArray<T>::GetValue(CoordinateT i)
+{
+  if (1 != this->GetDimensions())
+  {
+    vtkErrorMacro(<< "Index-array dimension mismatch.");
+    return this->NullValue;
+  }
+
+  // Do a naive linear-search for the time-being ...
+  for (vtkIdType row = 0; row != static_cast<vtkIdType>(this->Values.size()); ++row)
+  {
+    if (i != this->Coordinates[0][row])
+      continue;
+
+    return this->Values[row];
+  }
+
+  return this->NullValue;
+}
+
+template <typename T>
+const T& vtkSparseArray<T>::GetValue(CoordinateT i, CoordinateT j)
+{
+  if (2 != this->GetDimensions())
+  {
+    vtkErrorMacro(<< "Index-array dimension mismatch.");
+    return this->NullValue;
+  }
+
+  // Do a naive linear-search for the time-being ...
+  for (vtkIdType row = 0; row != static_cast<vtkIdType>(this->Values.size()); ++row)
+  {
+    if (i != this->Coordinates[0][row])
+      continue;
+
+    if (j != this->Coordinates[1][row])
+      continue;
+
+    return this->Values[row];
+  }
+
+  return this->NullValue;
+}
+
+template <typename T>
+const T& vtkSparseArray<T>::GetValue(CoordinateT i, CoordinateT j, CoordinateT k)
+{
+  if (3 != this->GetDimensions())
+  {
+    vtkErrorMacro(<< "Index-array dimension mismatch.");
+    return this->NullValue;
+  }
+
+  // Do a naive linear-search for the time-being ...
+  for (vtkIdType row = 0; row != static_cast<vtkIdType>(this->Values.size()); ++row)
+  {
+    if (i != this->Coordinates[0][row])
+      continue;
+
+    if (j != this->Coordinates[1][row])
+      continue;
+
+    if (k != this->Coordinates[2][row])
+      continue;
+
+    return this->Values[row];
+  }
+
+  return this->NullValue;
+}
+
+template <typename T>
+const T& vtkSparseArray<T>::GetValue(const vtkArrayCoordinates& coordinates)
+{
+  if (coordinates.GetDimensions() != this->GetDimensions())
+  {
+    vtkErrorMacro(<< "Index-array dimension mismatch.");
+    return this->NullValue;
+  }
+
+  // Do a naive linear-search for the time-being ...
+  for (vtkIdType row = 0; row != static_cast<vtkIdType>(this->Values.size()); ++row)
+  {
+    for (DimensionT column = 0; column != this->GetDimensions(); ++column)
+    {
+      if (coordinates[column] != this->Coordinates[column][row])
+        break;
+
+      if (column + 1 == this->GetDimensions())
+        return this->Values[row];
+    }
+  }
+
+  return this->NullValue;
+}
+
+template <typename T>
+const T& vtkSparseArray<T>::GetValueN(SizeT n)
+{
+  return this->Values[n];
+}
+
+template <typename T>
+void vtkSparseArray<T>::SetValue(CoordinateT i, const T& value)
+{
+  if (1 != this->GetDimensions())
+  {
+    vtkErrorMacro(<< "Index-array dimension mismatch.");
+    return;
+  }
+
+  // Do a naive linear-search for the time-being ...
+  for (vtkIdType row = 0; row != static_cast<vtkIdType>(this->Values.size()); ++row)
+  {
+    if (i != this->Coordinates[0][row])
+      continue;
+
+    this->Values[row] = value;
+    return;
+  }
+
+  // Element doesn't already exist, so add it to the end of the list ...
+  this->AddValue(i, value);
+}
+
+template <typename T>
+void vtkSparseArray<T>::SetValue(CoordinateT i, CoordinateT j, const T& value)
+{
+  if (2 != this->GetDimensions())
+  {
+    vtkErrorMacro(<< "Index-array dimension mismatch.");
+    return;
+  }
+
+  // Do a naive linear-search for the time-being ...
+  for (vtkIdType row = 0; row != static_cast<vtkIdType>(this->Values.size()); ++row)
+  {
+    if (i != this->Coordinates[0][row])
+      continue;
+
+    if (j != this->Coordinates[1][row])
+      continue;
+
+    this->Values[row] = value;
+    return;
+  }
+
+  // Element doesn't already exist, so add it to the end of the list ...
+  this->AddValue(i, j, value);
+}
+
+template <typename T>
+void vtkSparseArray<T>::SetValue(CoordinateT i, CoordinateT j, CoordinateT k, const T& value)
+{
+  if (3 != this->GetDimensions())
+  {
+    vtkErrorMacro(<< "Index-array dimension mismatch.");
+    return;
+  }
+
+  // Do a naive linear-search for the time-being ...
+  for (vtkIdType row = 0; row != static_cast<vtkIdType>(this->Values.size()); ++row)
+  {
+    if (i != this->Coordinates[0][row])
+      continue;
+
+    if (j != this->Coordinates[1][row])
+      continue;
+
+    if (k != this->Coordinates[2][row])
+      continue;
+
+    this->Values[row] = value;
+    return;
+  }
+
+  // Element doesn't already exist, so add it to the end of the list ...
+  this->AddValue(i, j, k, value);
+}
+
+template <typename T>
+void vtkSparseArray<T>::SetValue(const vtkArrayCoordinates& coordinates, const T& value)
+{
+  if (coordinates.GetDimensions() != this->GetDimensions())
+  {
+    vtkErrorMacro(<< "Index-array dimension mismatch.");
+    return;
+  }
+
+  // Do a naive linear-search for the time-being ...
+  for (vtkIdType row = 0; row != static_cast<vtkIdType>(this->Values.size()); ++row)
+  {
+    for (DimensionT column = 0; column != this->GetDimensions(); ++column)
+    {
+      if (coordinates[column] != this->Coordinates[column][row])
+        break;
+
+      if (column + 1 == this->GetDimensions())
+      {
+        this->Values[row] = value;
+        return;
+      }
+    }
+  }
+
+  // Element doesn't already exist, so add it to the end of the list ...
+  this->AddValue(coordinates, value);
+}
+
+template <typename T>
+void vtkSparseArray<T>::SetValueN(SizeT n, const T& value)
+{
+  this->Values[n] = value;
+}
+
+template <typename T>
+void vtkSparseArray<T>::SetNullValue(const T& value)
+{
+  this->NullValue = value;
+}
+
+template <typename T>
+const T& vtkSparseArray<T>::GetNullValue()
+{
+  return this->NullValue;
+}
+
+template <typename T>
+void vtkSparseArray<T>::Clear()
+{
+  for (DimensionT column = 0; column != this->GetDimensions(); ++column)
+    this->Coordinates[column].clear();
+
+  this->Values.clear();
+}
+
+/// Predicate object for use with std::sort().  Given a vtkArraySort object that defines which array
+/// dimensions will be sorted in what order, SortCoordinates is used to establish a sorted order for
+/// the values stored in vtkSparseArray. Note that SortCoordinates never actually modifies its
+/// inputs.
+struct SortCoordinates
+{
+  SortCoordinates(const vtkArraySort& sort, const std::vector<std::vector<vtkIdType>>& coordinates)
+    : Sort(&sort)
+    , Coordinates(&coordinates)
+  {
+  }
+
+  bool operator()(const vtkIdType lhs, const vtkIdType rhs) const
+  {
+    const vtkArraySort& sort = *this->Sort;
+    const std::vector<std::vector<vtkIdType>>& coordinates = *this->Coordinates;
+
+    for (vtkIdType i = 0; i != sort.GetDimensions(); ++i)
+    {
+      if (coordinates[sort[i]][lhs] == coordinates[sort[i]][rhs])
+        continue;
+
+      return coordinates[sort[i]][lhs] < coordinates[sort[i]][rhs];
+    }
+
+    return false;
+  }
+
+  const vtkArraySort* Sort;
+  const std::vector<std::vector<vtkIdType>>* Coordinates;
+};
+
+template <typename T>
+void vtkSparseArray<T>::Sort(const vtkArraySort& sort)
+{
+  if (sort.GetDimensions() < 1)
+  {
+    vtkErrorMacro(<< "Sort must order at least one dimension.");
+    return;
+  }
+
+  for (DimensionT i = 0; i != sort.GetDimensions(); ++i)
+  {
+    if (sort[i] < 0 || sort[i] >= this->GetDimensions())
+    {
+      vtkErrorMacro(<< "Sort dimension out-of-bounds.");
+      return;
+    }
+  }
+
+  const SizeT count = this->GetNonNullSize();
+  std::vector<DimensionT> sort_order(count);
+  for (SizeT i = 0; i != count; ++i)
+    sort_order[i] = static_cast<DimensionT>(i);
+  std::sort(sort_order.begin(), sort_order.end(), SortCoordinates(sort, this->Coordinates));
+
+  std::vector<DimensionT> temp_coordinates(count);
+  for (DimensionT j = 0; j != this->GetDimensions(); ++j)
+  {
+    for (SizeT i = 0; i != count; ++i)
+      temp_coordinates[i] = this->Coordinates[j][sort_order[i]];
+    std::swap(temp_coordinates, this->Coordinates[j]);
+  }
+
+  std::vector<T> temp_values(count);
+  for (SizeT i = 0; i != count; ++i)
+    temp_values[i] = this->Values[sort_order[i]];
+  std::swap(temp_values, this->Values);
+}
+
+template <typename T>
+std::vector<typename vtkSparseArray<T>::CoordinateT> vtkSparseArray<T>::GetUniqueCoordinates(
+  DimensionT dimension)
+{
+  if (dimension < 0 || dimension >= this->GetDimensions())
+  {
+    vtkErrorMacro(<< "Dimension out-of-bounds.");
+    return std::vector<CoordinateT>();
+  }
+
+  std::vector<CoordinateT> results(this->Coordinates[dimension]);
+  std::sort(results.begin(), results.end());
+  results.erase(std::unique(results.begin(), results.end()), results.end());
+  return results;
+}
+
+template <typename T>
+const typename vtkSparseArray<T>::CoordinateT* vtkSparseArray<T>::GetCoordinateStorage(
+  DimensionT dimension) const
+{
+  if (dimension < 0 || dimension >= this->GetDimensions())
+  {
+    vtkErrorMacro(<< "Dimension out-of-bounds.");
+    return nullptr;
+  }
+
+  return &this->Coordinates[dimension][0];
+}
+
+template <typename T>
+typename vtkSparseArray<T>::CoordinateT* vtkSparseArray<T>::GetCoordinateStorage(
+  DimensionT dimension)
+{
+  if (dimension < 0 || dimension >= this->GetDimensions())
+  {
+    vtkErrorMacro(<< "Dimension out-of-bounds.");
+    return nullptr;
+  }
+
+  return &this->Coordinates[dimension][0];
+}
+
+template <typename T>
+const T* vtkSparseArray<T>::GetValueStorage() const
+{
+  return &(this->Values[0]);
+}
+
+template <typename T>
+T* vtkSparseArray<T>::GetValueStorage()
+{
+  return &this->Values[0];
+}
+
+template <typename T>
+void vtkSparseArray<T>::ReserveStorage(SizeT value_count)
+{
+  for (DimensionT dimension = 0; dimension != this->GetDimensions(); ++dimension)
+    this->Coordinates[dimension].resize(value_count);
+
+  this->Values.resize(value_count);
+}
+
+template <typename T>
+void vtkSparseArray<T>::SetExtentsFromContents()
+{
+  vtkArrayExtents new_extents;
+
+  const vtkIdType row_begin = 0;
+  const vtkIdType row_end = row_begin + static_cast<vtkIdType>(this->Values.size());
+  const DimensionT dimension_count = this->GetDimensions();
+  for (DimensionT dimension = 0; dimension != dimension_count; ++dimension)
+  {
+    vtkIdType range_begin = std::numeric_limits<vtkIdType>::max();
+    vtkIdType range_end = -std::numeric_limits<vtkIdType>::max();
+    for (vtkIdType row = row_begin; row != row_end; ++row)
+    {
+      range_begin = std::min(range_begin, this->Coordinates[dimension][row]);
+      range_end = std::max(range_end, this->Coordinates[dimension][row] + 1);
+    }
+    new_extents.Append(vtkArrayRange(range_begin, range_end));
+  }
+
+  this->Extents = new_extents;
+}
+
+template <typename T>
+void vtkSparseArray<T>::SetExtents(const vtkArrayExtents& extents)
+{
+  if (extents.GetDimensions() != this->GetDimensions())
+  {
+    vtkErrorMacro(<< "Extent-array dimension mismatch.");
+    return;
+  }
+
+  this->Extents = extents;
+}
+
+template <typename T>
+void vtkSparseArray<T>::AddValue(CoordinateT i, const T& value)
+{
+  this->AddValue(vtkArrayCoordinates(i), value);
+}
+
+template <typename T>
+void vtkSparseArray<T>::AddValue(CoordinateT i, CoordinateT j, const T& value)
+{
+  this->AddValue(vtkArrayCoordinates(i, j), value);
+}
+
+template <typename T>
+void vtkSparseArray<T>::AddValue(CoordinateT i, CoordinateT j, CoordinateT k, const T& value)
+{
+  this->AddValue(vtkArrayCoordinates(i, j, k), value);
+}
+
+template <typename T>
+void vtkSparseArray<T>::AddValue(const vtkArrayCoordinates& coordinates, const T& value)
+{
+  if (coordinates.GetDimensions() != this->GetDimensions())
+  {
+    vtkErrorMacro(<< "Index-array dimension mismatch.");
+    return;
+  }
+
+  this->Values.push_back(value);
+
+  for (DimensionT i = 0; i != coordinates.GetDimensions(); ++i)
+    this->Coordinates[i].push_back(coordinates[i]);
+}
+
+template <typename T>
+bool vtkSparseArray<T>::Validate()
+{
+  vtkIdType duplicate_count = 0;
+  vtkIdType out_of_bound_count = 0;
+
+  const vtkIdType dimensions = this->GetDimensions();
+  const vtkIdType count = this->GetNonNullSize();
+
+  // Create an arbitrary sorted order for our coordinates ...
+  vtkArraySort sort;
+  sort.SetDimensions(dimensions);
+  for (vtkIdType i = 0; i != dimensions; ++i)
+    sort[i] = i;
+
+  std::vector<vtkIdType> sort_order(count);
+  for (vtkIdType i = 0; i != count; ++i)
+    sort_order[i] = i;
+
+  std::sort(sort_order.begin(), sort_order.end(), SortCoordinates(sort, this->Coordinates));
+
+  // Now, look for duplicates ...
+  for (vtkIdType i = 0; i + 1 < count; ++i)
+  {
+    vtkIdType j;
+    for (j = 0; j != dimensions; ++j)
+    {
+      if (this->Coordinates[j][sort_order[i]] != this->Coordinates[j][sort_order[i + 1]])
+        break;
+    }
+    if (j == dimensions)
+    {
+      duplicate_count += 1;
+    }
+  }
+
+  // Look for out-of-bound coordinates ...
+  for (vtkIdType i = 0; i != count; ++i)
+  {
+    for (vtkIdType j = 0; j != dimensions; ++j)
+    {
+      if (this->Coordinates[j][i] < this->Extents[j].GetBegin() ||
+        this->Coordinates[j][i] >= this->Extents[j].GetEnd())
+      {
+        ++out_of_bound_count;
+        break;
+      }
+    }
+  }
+
+  if (duplicate_count)
+  {
+    vtkErrorMacro(<< "Array contains " << duplicate_count << " duplicate coordinates.");
+  }
+
+  if (out_of_bound_count)
+  {
+    vtkErrorMacro(<< "Array contains " << out_of_bound_count << " out-of-bound coordinates.");
+  }
+
+  return (0 == duplicate_count) && (0 == out_of_bound_count);
+}
+
+template <typename T>
+vtkSparseArray<T>::vtkSparseArray()
+  : NullValue(T())
+{
+}
+
+template <typename T>
+vtkSparseArray<T>::~vtkSparseArray() = default;
+
+template <typename T>
+void vtkSparseArray<T>::InternalResize(const vtkArrayExtents& extents)
+{
+  this->Extents = extents;
+  this->DimensionLabels.resize(extents.GetDimensions(), {});
+  this->Coordinates.resize(extents.GetDimensions());
+  this->Values.resize(0);
+}
+
+template <typename T>
+void vtkSparseArray<T>::InternalSetDimensionLabel(DimensionT i, const vtkStdString& label)
+{
+  this->DimensionLabels[i] = label;
+}
+
+template <typename T>
+vtkStdString vtkSparseArray<T>::InternalGetDimensionLabel(DimensionT i)
+{
+  return this->DimensionLabels[i];
+}
+
+VTK_ABI_NAMESPACE_END
+#endif


### PR DESCRIPTION
Include support for the ".txx" file extension, which has been commonly used for C++ template implementation across various build systems. https://github.com/build2/bdep/pull/5

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - .txx - https://github.com/search?q=path%3A*.txx&type=code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/build2/build2/blob/a1a01cbce316c5da7aa94e6b6a71eae98bffed1c/libbuild2/target.txx#L4
      - https://github.com/Kitware/VTK/blob/6d5a55c728ee132a818da88ad48af899c9baa6ec/Common/Core/vtkSparseArray.txx#L4
      - https://github.com/hsundar/dendro/blob/f3337fc933ffaca885bf159548dfb224dbac5cbe/include/par/search.txx#L4
    - Sample license(s): MIT, 3-BSD, GPL2 respectively
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
