### PR TITLE
Change source of "Adblock Filter List" grammar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -199,7 +199,7 @@
 	url = https://github.com/technosophos/Vala-TMBundle
 [submodule "vendor/grammars/VscodeAdblockSyntax"]
 	path = vendor/grammars/VscodeAdblockSyntax
-	url = https://github.com/ameshkov/VscodeAdblockSyntax.git
+	url = https://github.com/AdguardTeam/VscodeAdblockSyntax.git
 [submodule "vendor/grammars/WhileySyntaxBundle"]
 	path = vendor/grammars/WhileySyntaxBundle
 	url = https://github.com/Whiley/WhileySyntaxBundle.git

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -25,7 +25,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **ATS:** [steinwaywhw/ats-mode-sublimetext](https://github.com/steinwaywhw/ats-mode-sublimetext)
 - **ActionScript:** [simongregory/actionscript3-tmbundle](https://github.com/simongregory/actionscript3-tmbundle)
 - **Ada:** [textmate/ada.tmbundle](https://github.com/textmate/ada.tmbundle)
-- **Adblock Filter List:** [ameshkov/VscodeAdblockSyntax](https://github.com/ameshkov/VscodeAdblockSyntax)
+- **Adblock Filter List:** [AdguardTeam/VscodeAdblockSyntax](https://github.com/AdguardTeam/VscodeAdblockSyntax)
 - **Adobe Font Metrics:** [Alhadis/language-fontforge](https://github.com/Alhadis/language-fontforge)
 - **Agda:** [agda/agda-github-syntax-highlighting](https://github.com/agda/agda-github-syntax-highlighting)
 - **Alloy:** [macekond/Alloy.tmbundle](https://github.com/macekond/Alloy.tmbundle)


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
We moved the adblock syntax highlighter repo under the company organization, and this PR specifies the new location for proper Linguist integration. In addition, we changed the format of the grammar from `JSON` to [`YAML-TMLanguage`](https://github.com/AdguardTeam/VscodeAdblockSyntax/blob/master/syntaxes/adblock.yaml-tmlanguage), although if I understand everything correctly, this is a [supported format](https://github.com/github-linguist/linguist/discussions/6222#discussioncomment-4565760) that can be natively parsed by Linguist, and there is no further action from our side.

If you still need any action / information from us, feel free to ask in the comments.

Thank you!

CC @ameshkov

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am changing the source of a syntax highlighting grammar**
  - Old: https://github.com/ameshkov/VscodeAdblockSyntax
  - New: https://github.com/AdguardTeam/VscodeAdblockSyntax

