### PR TITLE
Add language: Mojo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -899,6 +899,9 @@
 [submodule "vendor/grammars/mlir-grammar"]
 	path = vendor/grammars/mlir-grammar
 	url = https://github.com/jpienaar/mlir-grammar
+[submodule "vendor/grammars/mojo-syntax"]
+	path = vendor/grammars/mojo-syntax
+	url = https://github.com/modularml/mojo-syntax.git
 [submodule "vendor/grammars/monkey"]
 	path = vendor/grammars/monkey
 	url = https://github.com/gingerbeardman/monkey.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -845,6 +845,8 @@ vendor/grammars/mint-vscode:
 - source.mint
 vendor/grammars/mlir-grammar:
 - source.mlir
+vendor/grammars/mojo-syntax:
+- source.mojo
 vendor/grammars/monkey:
 - source.monkey
 vendor/grammars/moonscript-tmbundle:

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -472,6 +472,12 @@ disambiguations:
   - language: Modula-2
     pattern: '^\s*(?i:MODULE|END) [\w\.]+;'
   - language: [Linux Kernel Module, AMPL]
+- extensions: ['.mojo']
+  rules:
+  - language: Mojo
+    pattern: '^\s*(alias|def|from|fn|import|struct|trait)\s'
+  - language: XML
+    pattern: '^\s*<\?xml'
 - extensions: ['.ms']
   rules:
   - language: Roff

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4329,6 +4329,16 @@ Module Management System:
   tm_scope: none
   ace_mode: text
   language_id: 235
+Mojo:
+  type: programming
+  color: "#ff4c1f"
+  extensions:
+  - ".mojo"
+  ace_mode: python
+  codemirror_mode: python
+  codemirror_mime_type: text/x-python
+  tm_scope: source.mojo
+  language_id: 1045019587
 Monkey:
   type: programming
   extensions:
@@ -7854,6 +7864,7 @@ XML:
   - ".mjml"
   - ".mm"
   - ".mod"
+  - ".mojo"
   - ".mxml"
   - ".natvis"
   - ".ncl"

--- a/samples/Mojo/Bool.mojo
+++ b/samples/Mojo/Bool.mojo
@@ -1,0 +1,31 @@
+alias OurTrue = OurBool(__mlir_attr.`true`)
+alias OurFalse: OurBool = __mlir_attr.`false`
+
+
+@register_passable("trivial")
+struct OurBool:
+    var value: __mlir_type.i1
+
+    fn __init__() -> Self:
+        return OurFalse
+
+    fn __init__(value: __mlir_type.i1) -> Self:
+        return Self {value: value}
+
+    fn __bool__(self) -> Bool:
+        return Bool(self.value)
+
+    fn __mlir_i1__(self) -> __mlir_type.i1:
+        return self.value
+
+    fn __eq__(self, rhs: OurBool) -> Self:
+        let lhsIndex = __mlir_op.`index.casts`[_type : __mlir_type.index](self.value)
+        let rhsIndex = __mlir_op.`index.casts`[_type : __mlir_type.index](rhs.value)
+        return Self(
+            __mlir_op.`index.cmp`[pred : __mlir_attr.`#index<cmp_predicate eq>`](
+                lhsIndex, rhsIndex
+            )
+        )
+
+    fn __invert__(self) -> Self:
+        return OurFalse if self == OurTrue else OurTrue

--- a/samples/Mojo/Matmul.mojo
+++ b/samples/Mojo/Matmul.mojo
@@ -1,0 +1,152 @@
+from autotune import autotune, search
+from algorithm import parallelize, Static2DTileUnitFunc as Tile2DFunc, vectorize_unroll
+from benchmark import Benchmark
+from sys.intrinsics import strided_load
+from utils.list import VariadicList
+from math import div_ceil, min
+from memory import memset_zero
+from memory.unsafe import DTypePointer, Pointer
+from random import rand, random_float64
+from sys.info import simdwidthof
+from time import now
+
+
+struct Matrix:
+    var data: DTypePointer[DType.float32]
+    var rows: Int
+    var cols: Int
+
+    fn __init__(inout self, rows: Int, cols: Int):
+        self.data = DTypePointer[DType.float32].alloc(rows * cols)
+        rand(self.data, rows * cols)
+        self.rows = rows
+        self.cols = cols
+
+    fn __del__(owned self):
+        self.data.free()
+
+    fn zero(inout self):
+        memset_zero(self.data, self.rows * self.cols)
+
+    @always_inline
+    fn __getitem__(self, y: Int, x: Int) -> Float32:
+        return self.load[1](y, x)
+
+    @always_inline
+    fn load[nelts: Int](self, y: Int, x: Int) -> SIMD[DType.float32, nelts]:
+        return self.data.simd_load[nelts](y * self.cols + x)
+
+    @always_inline
+    fn __setitem__(self, y: Int, x: Int, val: Float32):
+        return self.store[1](y, x, val)
+
+    @always_inline
+    fn store[nelts: Int](self, y: Int, x: Int, val: SIMD[DType.float32, nelts]):
+        self.data.simd_store[nelts](y * self.cols + x, val)
+
+
+alias matmul_fn_sig_type = fn (Matrix, Matrix, Matrix) -> None
+
+
+# Perform 2D tiling on the iteration space defined by end_x and end_y.
+fn tile[tiled_fn: Tile2DFunc, tile_x: Int, tile_y: Int](end_x: Int, end_y: Int):
+    # Note: this assumes that ends are multiples of the tiles.
+    for y in range(0, end_y, tile_y):
+        for x in range(0, end_x, tile_x):
+            tiled_fn[tile_x, tile_y](x, y)
+
+
+alias nelts = simdwidthof[DType.float32]()  # The SIMD vector width.
+
+
+# Autotune the tile size used in the matmul.
+@adaptive
+fn matmul_autotune_impl(C: Matrix, A: Matrix, B: Matrix):
+    @parameter
+    fn calc_row(m: Int):
+        @parameter
+        fn calc_tile[tile_x: Int, tile_y: Int](x: Int, y: Int):
+            for k in range(y, y + tile_y):
+
+                @parameter
+                fn dot[
+                    nelts: Int,
+                ](n: Int):
+                    C.store[nelts](
+                        m,
+                        n + x,
+                        C.load[nelts](m, n + x) + A[m, k] * B.load[nelts](k, n + x),
+                    )
+
+                vectorize_unroll[nelts, tile_x // nelts, dot](tile_x)
+
+        # Instead of hardcoding to tile_size = 4, search for the fastest
+        # tile size by evaluting this function as tile size varies.
+        alias tile_size = autotune(1, 2, 4, 8, 16, 32)
+        tile[calc_tile, nelts * tile_size, tile_size](A.cols, C.cols)
+
+    parallelize[calc_row](C.rows)
+
+
+fn matmul_evaluator(funcs: Pointer[matmul_fn_sig_type], size: Int) -> Int:
+    print("matmul_evaluator, number of candidates: ", size)
+
+    let eval_begin: Int = now()
+
+    # This size is picked at random, in real code we could use a real size
+    # distribution here.
+    let M = 512
+    let N = 512
+    let K = 512
+    print("Optimizing for size:", M, "x", N, "x", K)
+
+    var best_idx: Int = -1
+    var best_time: Int = -1
+
+    alias eval_iterations = 10
+    alias eval_samples = 10
+
+    var C = Matrix(M, N)
+    var A = Matrix(M, K)
+    var B = Matrix(K, N)
+    let Cptr = Pointer[Matrix].address_of(C).address
+    let Aptr = Pointer[Matrix].address_of(A).address
+    let Bptr = Pointer[Matrix].address_of(B).address
+
+    # Find the function that's the fastest on the size we're optimizing for
+    for f_idx in range(size):
+        let func = funcs.load(f_idx)
+
+        @always_inline
+        @parameter
+        fn wrapper():
+            func(C, A, B)
+
+        let cur_time = Benchmark(1, 100_000, 500_000_000, 1000_000_000).run[wrapper]()
+
+        if best_idx < 0:
+            best_idx = f_idx
+            best_time = cur_time
+        if best_time > cur_time:
+            best_idx = f_idx
+            best_time = cur_time
+
+    let eval_end: Int = now()
+    # Prevent matrices from being destroyed before we finished benchmarking them.
+    _ = A.data
+    _ = B.data
+    _ = C.data
+    print("Time spent in matmul_evaluator, ms:", (eval_end - eval_begin) // 1000000)
+    print("Best candidate idx:", best_idx)
+    return best_idx
+
+
+fn matmul_autotune(C: Matrix, A: Matrix, B: Matrix):
+    alias best_impl: matmul_fn_sig_type
+    search[
+        matmul_fn_sig_type,
+        VariadicList(matmul_autotune_impl.__adaptive_set),
+        matmul_evaluator -> best_impl
+    ]()
+    # Run the best candidate
+    return best_impl(C, A, B)

--- a/samples/XML/Example.mojo
+++ b/samples/XML/Example.mojo
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="Example" board="Mojo V3" language="Lucid">
+</project>

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -695,6 +695,13 @@ class TestHeuristics < Minitest::Test
     })
   end
 
+  def test_mojo_by_heuristics
+    assert_heuristics({
+      "Mojo" => all_fixtures("Mojo", "*.mojo"),
+      "XML" => all_fixtures("XML", "*.mojo"),
+    })
+  end
+
   def test_ms_by_heuristics
     assert_heuristics({
       "Roff" => all_fixtures("Roff", "*.ms"),

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -348,6 +348,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Modelica:** [BorisChumichev/modelicaSublimeTextPackage](https://github.com/BorisChumichev/modelicaSublimeTextPackage)
 - **Modula-2:** [harogaston/Sublime-Modula-2](https://github.com/harogaston/Sublime-Modula-2)
 - **Modula-3:** [newgrammars/m3](https://github.com/newgrammars/m3)
+- **Mojo:** [modularml/mojo-syntax](https://github.com/modularml/mojo-syntax)
 - **Monkey:** [gingerbeardman/monkey.tmbundle](https://github.com/gingerbeardman/monkey.tmbundle)
 - **Monkey C:** [ghisguth/vscode-monkey-c](https://github.com/ghisguth/vscode-monkey-c)
 - **MoonScript:** [leafo/moonscript-tmbundle](https://github.com/leafo/moonscript-tmbundle)

--- a/vendor/licenses/git_submodule/mojo-syntax.dep.yml
+++ b/vendor/licenses/git_submodule/mojo-syntax.dep.yml
@@ -1,0 +1,33 @@
+---
+name: mojo-syntax
+version: a2241dda06d9a20503394c3affa606114d007049
+type: git_submodule
+homepage: https://github.com/modularml/mojo-syntax.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License
+
+    Copyright (c) 2022-present Modular Inc.  https://www.modular.com
+    Copyright (c) 2015-present MagicStack Inc.  http://magic.io
+    Copyright (c) 2015-present Microsoft Corporation
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []


### PR DESCRIPTION
Add a new programming language to Linguist, named Mojo, for file extensions `.mojo` and `.🔥`. You can learn more about Mojo at https://docs.modular.com/mojo/.

<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

Mojo is a new programming language developed by me ([Chris Lattner](https://en.wikipedia.org/wiki/Chris_Lattner)) and my amazing team at [Modular](http://modular.com/).

Because it's a brand new language, it does not meet linguist's requirements for broad use on GitHub. The team and I thought that we'd send this anyway, to see if an exception could be made, based on the success and widespread use on GitHub of some of my other programming languages (LLVM IR, MLIR, Swift). If that's not possible, no worries, and thanks for your time!

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new language.**
  - [ ] ~The extension of the new language is used in hundreds of repositories on GitHub.com.~ As explained above, this is a new language without extensive usage yet.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?q=path%3A*.mojo&type=code
      -  [https://github.com/search?q=path%3A*.🔥&type=code](https://github.com/search?q=path%3A*.%F0%9F%94%A5&type=code)
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - `Matmul.mojo` is adapted from https://docs.modular.com/mojo/notebooks/Matmul.html
      - `Bool.🔥` is adapted from https://docs.modular.com/mojo/notebooks/BoolMLIR.html
    - Sample license(s):
  - [x] I have included a syntax highlighting grammar: https://github.com/modularml/mojo-syntax
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#ff4c1f`
    - Rationale: <!-- Please specify why you chose this color (if it was randomly selected, please say so); it helps arbitrate future requests to change a language's color --> This color invokes the 🔥 emoji that is used for the language's branding, and as a supported file extension.
  - [ ] ~I have updated the heuristics to distinguish my language from others using the same extension.~ No other language in this repository uses the `.mojo` or `.🔥` file extensions, so I did not add a heuristic.