### PR TITLE
Add `.scalafix.conf` and `.scalafmt.conf` to HOCON filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2611,6 +2611,9 @@ HOCON:
   color: "#9ff8ee"
   extensions:
   - ".hocon"
+  filenames:
+  - .scalafix.conf
+  - .scalafmt.conf
   tm_scope: source.hocon
   ace_mode: text
   language_id: 679725279

--- a/samples/HOCON/filenames/.scalafix.conf
+++ b/samples/HOCON/filenames/.scalafix.conf
@@ -1,0 +1,19 @@
+rules = [
+  ExplicitResultTypes,
+  OrganizeImports
+]
+
+ExplicitResultTypes {
+  unsafeShortenNames = true
+}
+OrganizeImports {
+ groupedImports = Explode
+ expandRelative = true
+ removeUnused = true # done already by RemoveUnused rule
+ groups = [
+   "re:javax?\\."
+   "scala."
+   "scala.meta."
+   "*"
+ ]
+}

--- a/samples/HOCON/filenames/.scalafmt.conf
+++ b/samples/HOCON/filenames/.scalafmt.conf
@@ -1,0 +1,14 @@
+version=3.7.3
+runner.dialect = scala213
+project.git = true
+project.excludeFilters = [
+  scalafmt-benchmarks/src/resources,
+  sbt-test
+  bin/issue
+]
+align.preset = none
+# Disabled in default since this operation is potentially
+# dangerous if you define your own stripMargin with different
+# semantics from the stdlib stripMargin.
+assumeStandardLibraryStripMargin = true
+onTestFailure = "To fix this, run ./scalafmt from the project root directory"


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
Hi, this PR adds `.scalafix.conf` and `.scalafmt.conf` to the list of `HOCON` language filenames.  
## Description

[Scalaformat](https://scalameta.org/scalafmt/docs/configuration.html) and [Scalafix](https://scalacenter.github.io/scalafix/docs/users/configuration.html) both use HOCON as their configuration language, and are currently AFAICS not highlighted in any way.

Thanks!
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new ~extension~ filename to a language.**
  - [x] The new ~extension~ filename is used in hundreds of repositories on GitHub.com
    - Search results for each ~extension~ filename:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=path%3A*.scalafmt.conf&type=code
      - https://github.com/search?q=path%3A*.scalafix.conf&type=code
  - [x] I have included a real-world usage sample for all ~extensions~ filenames added in this PR:
    - Sample source(s):
      - https://github.com/scalameta/scalafmt/blob/master/.scalafmt.conf
      - https://github.com/scalacenter/scalafix/blob/main/.scalafix.conf
    - Sample license(s):
      - https://github.com/scalameta/scalafmt/blob/master/LICENCE.md
      - https://github.com/scalacenter/scalafix/blob/main/LICENSE.md
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.