### PR TITLE
Fix up vendor regex for bootstrap

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -74,7 +74,7 @@
 - ([^\s]*)import\.(css|less|scss|styl)$
 
 # Bootstrap css and js
-- (^|/)bootstrap([^/]*)\.(js|css|less|scss|styl)$
+- (^|/)bootstrap([^/.]*)(\..*)?\.(js|css|less|scss|styl)$
 - (^|/)custom\.bootstrap([^\s]*)(js|css|less|scss|styl)$
 
 # Font Awesome

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -74,7 +74,7 @@
 - ([^\s]*)import\.(css|less|scss|styl)$
 
 # Bootstrap css and js
-- (^|/)bootstrap([^/.]*)(?=\.).*\.(js|css|less|scss|styl)$
+- (^|/)bootstrap([^/]*)\.(js|css|less|scss|styl)$
 - (^|/)custom\.bootstrap([^\s]*)(js|css|less|scss|styl)$
 
 # Font Awesome

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -573,9 +573,9 @@ class TestFileBlob < Minitest::Test
     # Bootstrap
     assert !sample_blob("src/bootstraps/settings.js").vendored?
     assert !sample_blob("bootstrap/misc/other/reset.css").vendored?
-    assert !sample_blob("bootstrap-1.4/misc/other/reset.css").vendored?
-    assert !sample_blob("bootstrap.10.4/misc/other/reset.css").vendored?
-    assert !sample_blob("src/bootstrap-5.4.1-beta-dist/js/bundle.js").vendored?
+    assert sample_blob("bootstrap-1.4/misc/other/reset.css").vendored?
+    assert sample_blob("bootstrap.10.4/misc/other/reset.css").vendored?
+    assert sample_blob("src/bootstrap-5.4.1-beta-dist/js/bundle.js").vendored?
     assert sample_blob("src/bootstrap-custom.js").vendored?
     assert sample_blob("src/bootstrap-1.4.js").vendored?
     assert sample_blob("src/bootstrap-5.4.1-beta-dist/js/bootstrap.bundle.js").vendored?

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -572,7 +572,12 @@ class TestFileBlob < Minitest::Test
 
     # Bootstrap
     assert !sample_blob("src/bootstraps/settings.js").vendored?
+    assert !sample_blob("bootstrap/misc/other/reset.css").vendored?
+    assert !sample_blob("bootstrap-1.4/misc/other/reset.css").vendored?
+    assert !sample_blob("bootstrap.10.4/misc/other/reset.css").vendored?
+    assert !sample_blob("src/bootstrap-5.4.1-beta-dist/js/bundle.js").vendored?
     assert sample_blob("src/bootstrap-custom.js").vendored?
+    assert sample_blob("src/bootstrap-1.4.js").vendored?
     assert sample_blob("src/bootstrap-5.4.1-beta-dist/js/bootstrap.bundle.js").vendored?
     assert sample_blob("src/bootstrap-5.4.1-beta-dist/js/bootstrap.esm.js").vendored?
     assert sample_blob("src/bootstrap-5.4.1-beta-dist/css/bootstrap.rtl.css").vendored?


### PR DESCRIPTION
The current regex for detecting if bootstrap is vendored is too broad and overly complicated (uses lookahead). I believe the intent is only to match bootstrap files (not entire directories), but I've written a few more test to demonstrate what should and should not be detected as vendored here.

The current regex looks like this:
`(^|/)bootstrap([^/.]*)(?=\.).*\.(js|css|less|scss|styl)$`

As written, this would be considered vendored:
- `bootstrap-1.4/misc/other/reset.css`

But this would not:
- `bootstrap/misc/other/reset.css`

I don't believe that's correct or intended. This vendor rule should target bootstrap artifacts specifically (not entire directories). Some history in https://github.com/github-linguist/linguist/pull/5745 and https://github.com/github-linguist/linguist/pull/5957.

The proposal is to only match on the filename (and allow filenames that include `.`).

## Checklist:
- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.
