### PR TITLE
Make regexps in `heuristics.yml` more portable

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -64,7 +64,7 @@ disambiguations:
 - extensions: ['.app']
   rules:
   - language: Erlang
-    pattern: '(?m)^\{\s*(?:application|''application'')\s*,\s*(?:[a-z]+[\w@]*|''[^'']+'')\s*,\s*\[.*?\]\s*\}\.[ \t]*$'
+    pattern: '^\{\s*(?:application|''application'')\s*,\s*(?:[a-z]+[\w@]*|''[^'']+'')\s*,\s*\[(?:.|\n)*\]\s*\}\.[ \t]*$'
 - extensions: ['.as']
   rules:
   - language: ActionScript
@@ -218,7 +218,7 @@ disambiguations:
   - language: Erlang
     pattern: '^\s*(?:%%|main\s*\(.*?\)\s*->)'
   - language: JavaScript
-    pattern: '(?m:\/\/|("|'')use strict\1|export\s+default\s|\/\*.*?\*\/)'
+    pattern: '\/\/|("|'')use strict\1|export\s+default\s|\/\*(?:.|\n)*?\*\/'
 - extensions: ['.ex']
   rules:
   - language: Elixir
@@ -609,7 +609,7 @@ disambiguations:
 - extensions: ['.rpy']
   rules:
   - language: Python
-    pattern: '(?m:^(import|from|class|def)\s)'
+    pattern: '^(import|from|class|def)\s'
   - language: "Ren'Py"
 - extensions: ['.rs']
   rules:
@@ -675,7 +675,7 @@ disambiguations:
 - extensions: ['.stl']
   rules:
   - language: STL
-    pattern: '\A\s*solid(?=$|\s)(?m:.*?)^endsolid(?:$|\s)'
+    pattern: '\A\s*solid(?=$|\s)(?:.|\n)*?^endsolid(?:$|\s)'
 - extensions: ['.sw']
   rules:
   - language: Sway

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -145,7 +145,7 @@ disambiguations:
   - language: Visual Basic 6.0
     and:
     - named_pattern: vb-class
-    - pattern: '^\s*BEGIN\R\s*MultiUse\s*=.*\R\s*Persistable\s*='
+    - pattern: '^\s*BEGIN\r?\n\s*MultiUse\s*=.*\r?\n\s*Persistable\s*='
   - language: VBA
     named_pattern: vb-class  
   - language: TeX
@@ -675,7 +675,7 @@ disambiguations:
 - extensions: ['.stl']
   rules:
   - language: STL
-    pattern: '\A\s*solid(?=$|\s)(?m:.*?)\Rendsolid(?:$|\s)'
+    pattern: '\A\s*solid(?=$|\s)(?m:.*?)^endsolid(?:$|\s)'
 - extensions: ['.sw']
   rules:
   - language: Sway
@@ -752,7 +752,7 @@ disambiguations:
 - extensions: ['.url']
   rules:
   - language: INI
-    pattern: '^\[InternetShortcut\]\R(?>[^\s\[][^\n]*\R)*URL='
+    pattern: '^\[InternetShortcut\]\r?\n(?>[^\s\[][^\n]*\r?\n)*URL='
 - extensions: ['.v']
   rules:
   - language: Coq

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -169,7 +169,7 @@ disambiguations:
 - extensions: ['.csl']
   rules:
   - language: XML
-    pattern: '(?i:^\s*(\<\?xml|xmlns))'
+    pattern: '(?i:^\s*(<\?xml|xmlns))'
   - language: Kusto
     pattern: '(^\|\s*(where|extend|project|limit|summarize))|(^\.\w+)'
 - extensions: ['.d']
@@ -290,7 +290,7 @@ disambiguations:
 - extensions: ['.gml']
   rules:
   - language: XML
-    pattern: '(?i:^\s*(\<\?xml|xmlns))'
+    pattern: '(?i:^\s*(<\?xml|xmlns))'
   - language: Graph Modeling Language
     pattern: '(?i:^\s*(graph|node)\s+\[$)'
   - language: Gerber Image

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -64,7 +64,7 @@ disambiguations:
 - extensions: ['.app']
   rules:
   - language: Erlang
-    pattern: '^\{\s*(?:application|''application'')\s*,\s*(?:[a-z]+[\w@]*|''[^'']+'')\s*,\s*\[(?:.|\n)*\]\s*\}\.[ \t]*$'
+    pattern: '^\{\s*(?:application|''application'')\s*,\s*(?:[a-z]+[\w@]*|''[^'']+'')\s*,\s*\[(?:.|[\r\n])*\]\s*\}\.[ \t]*$'
 - extensions: ['.as']
   rules:
   - language: ActionScript
@@ -218,7 +218,7 @@ disambiguations:
   - language: Erlang
     pattern: '^\s*(?:%%|main\s*\(.*?\)\s*->)'
   - language: JavaScript
-    pattern: '\/\/|("|'')use strict\1|export\s+default\s|\/\*(?:.|\n)*?\*\/'
+    pattern: '\/\/|("|'')use strict\1|export\s+default\s|\/\*(?:.|[\r\n])*?\*\/'
 - extensions: ['.ex']
   rules:
   - language: Elixir
@@ -675,7 +675,7 @@ disambiguations:
 - extensions: ['.stl']
   rules:
   - language: STL
-    pattern: '\A\s*solid(?=$|\s)(?:.|\n)*?^endsolid(?:$|\s)'
+    pattern: '\A\s*solid(?=$|\s)(?:.|[\r\n])*?^endsolid(?:$|\s)'
 - extensions: ['.sw']
   rules:
   - language: Sway

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -145,7 +145,7 @@ disambiguations:
   - language: Visual Basic 6.0
     and:
     - named_pattern: vb-class
-    - pattern: '^\s*BEGIN\r?\n\s*MultiUse\s*=.*\r?\n\s*Persistable\s*='
+    - pattern: '^\s*BEGIN(?:\r?\n|\r)\s*MultiUse\s*=.*(?:\r?\n|\r)\s*Persistable\s*='
   - language: VBA
     named_pattern: vb-class  
   - language: TeX
@@ -752,7 +752,7 @@ disambiguations:
 - extensions: ['.url']
   rules:
   - language: INI
-    pattern: '^\[InternetShortcut\]\r?\n(?>[^\s\[][^\n]*\r?\n)*URL='
+    pattern: '^\[InternetShortcut\](?:\r?\n|\r)(?>[^\s\[][^\n]*(?:\r?\n|\r))*URL='
 - extensions: ['.v']
   rules:
   - language: Coq

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -64,17 +64,17 @@ disambiguations:
 - extensions: ['.app']
   rules:
   - language: Erlang
-    pattern: '(?m)^{\s*(?:application|''application'')\s*,\s*(?:[a-z]+[\w@]*|''[^'']+'')\s*,\s*\[.*?\]\s*}\.[ \t]*$'
+    pattern: '(?m)^\{\s*(?:application|''application'')\s*,\s*(?:[a-z]+[\w@]*|''[^'']+'')\s*,\s*\[.*?\]\s*\}\.[ \t]*$'
 - extensions: ['.as']
   rules:
   - language: ActionScript
-    pattern: '^\s*(?:package(?:\s+[\w.]+)?\s+(?:{|$)|import\s+[\w.*]+\s*;|(?=.*?(?:intrinsic|extends))(intrinsic\s+)?class\s+[\w<>.]+(?:\s+extends\s+[\w<>.]+)?|(?:(?:public|protected|private|static)\s+)*(?:(?:var|const|local)\s+\w+\s*:\s*[\w<>.]+(?:\s*=.*)?\s*;|function\s+\w+\s*\((?:\s*\w+\s*:\s*[\w<>.]+\s*(,\s*\w+\s*:\s*[\w<>.]+\s*)*)?\)))'
+    pattern: '^\s*(?:package(?:\s+[\w.]+)?\s+(?:\{|$)|import\s+[\w.*]+\s*;|(?=.*?(?:intrinsic|extends))(intrinsic\s+)?class\s+[\w<>.]+(?:\s+extends\s+[\w<>.]+)?|(?:(?:public|protected|private|static)\s+)*(?:(?:var|const|local)\s+\w+\s*:\s*[\w<>.]+(?:\s*=.*)?\s*;|function\s+\w+\s*\((?:\s*\w+\s*:\s*[\w<>.]+\s*(,\s*\w+\s*:\s*[\w<>.]+\s*)*)?\)))'
 - extensions: ['.asc']
   rules:
   - language: Public Key
     pattern: '^(----[- ]BEGIN|ssh-(rsa|dss)) '
   - language: AsciiDoc
-    pattern: '^[=-]+(\s|\n)|{{[A-Za-z]'
+    pattern: '^[=-]+(\s|\n)|\{\{[A-Za-z]'
   - language: AGS Script
     pattern: '^(\/\/.+|((import|export)\s+)?(function|int|float|char)\s+((room|repeatedly|on|game)_)?([A-Za-z]+[A-Za-z_0-9]+)\s*[;\(])'
 - extensions: ['.asm']
@@ -149,7 +149,7 @@ disambiguations:
   - language: VBA
     named_pattern: vb-class  
   - language: TeX
-    pattern: '^\s*\\(?:NeedsTeXFormat|ProvidesClass){'
+    pattern: '^\s*\\(?:NeedsTeXFormat|ProvidesClass)\{'
   - language: ObjectScript
     pattern: '^Class\s'
 - extensions: ['.cmp']
@@ -161,7 +161,7 @@ disambiguations:
   - language: Smalltalk
     pattern: '![\w\s]+methodsFor: '
   - language: 'C#'
-    pattern: '^\s*(using\s+[A-Z][\s\w.]+;|namespace\s*[\w\.]+\s*({|;)|\/\/)'
+    pattern: '^\s*(using\s+[A-Z][\s\w.]+;|namespace\s*[\w\.]+\s*(\{|;)|\/\/)'
 - extensions: ['.csc']
   rules:
   - language: GSC
@@ -177,10 +177,10 @@ disambiguations:
   - language: D
     # see http://dlang.org/spec/grammar
     # ModuleDeclaration | ImportDeclaration | FuncDeclaration | unittest
-    pattern: '^module\s+[\w.]*\s*;|import\s+[\w\s,.:]*;|\w+\s+\w+\s*\(.*\)(?:\(.*\))?\s*{[^}]*}|unittest\s*(?:\(.*\))?\s*{[^}]*}'
+    pattern: '^module\s+[\w.]*\s*;|import\s+[\w\s,.:]*;|\w+\s+\w+\s*\(.*\)(?:\(.*\))?\s*\{[^}]*\}|unittest\s*(?:\(.*\))?\s*\{[^}]*\}'
   - language: DTrace
     # see http://dtrace.org/guide/chp-prog.html, http://dtrace.org/guide/chp-profile.html, http://dtrace.org/guide/chp-opt.html
-    pattern: '^(\w+:\w*:\w*:\w*|BEGIN|END|provider\s+|(tick|profile)-\w+\s+{[^}]*}|#pragma\s+D\s+(option|attributes|depends_on)\s|#pragma\s+ident\s)'
+    pattern: '^(\w+:\w*:\w*:\w*|BEGIN|END|provider\s+|(tick|profile)-\w+\s+\{[^}]*\}|#pragma\s+D\s+(option|attributes|depends_on)\s|#pragma\s+ident\s)'
   - language: Makefile
     # path/target : dependency \
     # target : \
@@ -198,8 +198,8 @@ disambiguations:
   - language: E
     pattern:
     - '^\s*(def|var)\s+(.+):='
-    - '^\s*(def|to)\s+(\w+)(\(.+\))?\s+{'
-    - '^\s*(when)\s+(\(.+\))\s+->\s+{'
+    - '^\s*(def|to)\s+(\w+)(\(.+\))?\s+\{'
+    - '^\s*(when)\s+(\(.+\))\s+->\s+\{'
   - language: Eiffel
     pattern:
     - '^\s*\w+\s*(?:,\s*\w+)*[:]\s*\w+\s'
@@ -254,7 +254,7 @@ disambiguations:
   - language: VBA
     and:
     - named_pattern: vb-form
-    - pattern: '^\s*Begin\s+{[0-9A-Z\-]*}\s?'
+    - pattern: '^\s*Begin\s+\{[0-9A-Z\-]*\}\s?'
   - language: Visual Basic 6.0
     and:
     - named_pattern: vb-form
@@ -272,7 +272,7 @@ disambiguations:
 - extensions: ['.ftl']
   rules:
   - language: FreeMarker
-    pattern: '^(?:<|[a-zA-Z-][a-zA-Z0-9_-]+[ \t]+\w)|\${\w+[^\n]*?}|^[ \t]*(?:<#--.*?-->|<#([a-z]+)(?=\s|>)[^>]*>.*?</#\1>|\[#--.*?--\]|\[#([a-z]+)(?=\s|\])[^\]]*\].*?\[#\2\])'
+    pattern: '^(?:<|[a-zA-Z-][a-zA-Z0-9_-]+[ \t]+\w)|\$\{\w+[^\n]*?\}|^[ \t]*(?:<#--.*?-->|<#([a-z]+)(?=\s|>)[^>]*>.*?</#\1>|\[#--.*?--\]|\[#([a-z]+)(?=\s|\])[^\]]*\].*?\[#\2\])'
   - language: Fluent
     pattern: '^-?[a-zA-Z][a-zA-Z0-9_-]* *=|\{\$-?[a-zA-Z][-\w]*(?:\.[a-zA-Z][-\w]*)?\}'
 - extensions: ['.g']
@@ -347,21 +347,21 @@ disambiguations:
     pattern: '^<\?(?:php)?'
   - language: SourcePawn
     pattern:
-    - '^public\s+(?:SharedPlugin(?:\s+|:)__pl_\w+\s*=(?:\s*{)?|(?:void\s+)?__pl_\w+_SetNTVOptional\(\)(?:\s*{)?)'
+    - '^public\s+(?:SharedPlugin(?:\s+|:)__pl_\w+\s*=(?:\s*\{)?|(?:void\s+)?__pl_\w+_SetNTVOptional\(\)(?:\s*\{)?)'
     - '^methodmap\s+\w+\s+<\s+\w+'
     - '^\s*MarkNativeAsOptional\s*\('
   - language: NASL
     pattern:
     - '^\s*include\s*\(\s*(?:"|'')[\\/\w\-\.:\s]+\.(?:nasl|inc)\s*(?:"|'')\s*\)\s*;'
     - '^\s*(?:global|local)_var\s+(?:\w+(?:\s*=\s*[\w\-"'']+)?\s*)(?:,\s*\w+(?:\s*=\s*[\w\-"'']+)?\s*)*+\s*;'
-    - '^\s*namespace\s+\w+\s*{'
-    - '^\s*object\s+\w+\s*(?:extends\s+\w+(?:::\w+)?)?\s*{'
-    - '^\s*(?:public\s+|private\s+|\s*)function\s+\w+\s*\([\w\s,]*\)\s*{'
+    - '^\s*namespace\s+\w+\s*\{'
+    - '^\s*object\s+\w+\s*(?:extends\s+\w+(?:::\w+)?)?\s*\{'
+    - '^\s*(?:public\s+|private\s+|\s*)function\s+\w+\s*\([\w\s,]*\)\s*\{'
   - language: POV-Ray SDL
     pattern: '^\s*#(declare|local|macro|while)\s'
   - language: Pascal
     pattern:
-    - '(?i:^\s*{\$(?:mode|ifdef|undef|define)[ ]+[a-z0-9_]+})'
+    - '(?i:^\s*\{\$(?:mode|ifdef|undef|define)[ ]+[a-z0-9_]+\})'
     - '^\s*end[.;]\s*$'
 - extensions: ['.json']
   rules:
@@ -383,7 +383,7 @@ disambiguations:
 - extensions: ['.ls']
   rules:
   - language: LoomScript
-    pattern: '^\s*package\s*[\w\.\/\*\s]*\s*{'
+    pattern: '^\s*package\s*[\w\.\/\*\s]*\s*\{'
   - language: LiveScript
 - extensions: ['.lsp', '.lisp']
   rules:
@@ -408,7 +408,7 @@ disambiguations:
   - language: MATLAB
     pattern: '^\s*%'
   - language: Limbo
-    pattern: '^\w+\s*:\s*module\s*{'
+    pattern: '^\w+\s*:\s*module\s*\{'
 - extensions: ['.m4']
   rules:
   - language: M4Sugar
@@ -568,7 +568,7 @@ disambiguations:
 - extensions: ['.q']
   rules:
   - language: q
-    pattern: '((?i:[A-Z.][\w.]*:{)|(^|\n)\\(cd?|d|l|p|ts?) )'
+    pattern: '((?i:[A-Z.][\w.]*:\{)|(^|\n)\\(cd?|d|l|p|ts?) )'
   - language: HiveQL
     pattern: '(?i:SELECT\s+[\w*,]+\s+FROM|(CREATE|ALTER|DROP)\s(DATABASE|SCHEMA|TABLE))'
 - extensions: ['.qs']
@@ -589,7 +589,7 @@ disambiguations:
     pattern:
     - '^\s*module\s+type\s'
     - '^\s*(?:include|open)\s+\w+\s*;\s*$'
-    - '^\s*let\s+(?:module\s\w+\s*=\s*{|\w+:\s+.*=.*;\s*$)'
+    - '^\s*let\s+(?:module\s\w+\s*=\s*\{|\w+:\s+.*=.*;\s*$)'
   - language: C++
     pattern:
     - '^\s*#(?:(?:if|ifdef|define|pragma)\s+\w|\s*include\s+<[^>]+>)'
@@ -666,7 +666,7 @@ disambiguations:
   - language: StringTemplate
     pattern: '\$\w+[($]|(.)!\s*.+?\s*!\1|<!\s*.+?\s*!>|\[!\s*.+?\s*!\]|\{!\s*.+?\s*!\}'
   - language: Smalltalk
-    pattern: '\A\s*[\[{(^"''\w#]|[a-zA-Z_]\w*\s*:=\s*[a-zA-Z_]\w*|class\s*>>\s*[a-zA-Z_]\w*|^[a-zA-Z_]\w*\s+[a-zA-Z_]\w*:|^Class\s*{|if(?:True|False):\s*\['
+    pattern: '\A\s*[\[{(^"''\w#]|[a-zA-Z_]\w*\s*:=\s*[a-zA-Z_]\w*|class\s*>>\s*[a-zA-Z_]\w*|^[a-zA-Z_]\w*\s+[a-zA-Z_]\w*:|^Class\s*\{|if(?:True|False):\s*\['
 - extensions: ['.star']
   rules:
   - language: STAR
@@ -777,7 +777,7 @@ disambiguations:
   - language: DirectX 3D File
     pattern:  '^xof 030(2|3)(?:txt|bin|tzip|bzip)\b'
   - language: RPC
-    pattern: '\b(program|version)\s+\w+\s*{|\bunion\s+\w+\s+switch\s*\('
+    pattern: '\b(program|version)\s+\w+\s*\{|\bunion\s+\w+\s+switch\s*\('
   - language: Logos
     pattern: '^%(end|ctor|hook|group)\b'
   - language: Linker Script


### PR DESCRIPTION
## Description

Hi. My team is porting Linguist to Rust, and we'd like to reuse the regular expressions in heuristics.yml.

They contain a few Rubyisms—a fairly small number relative to the whole file, but enough that we have to deal with them somehow.

We'd like to upstream the changes, in the hope that other projects (like go-enry) can benefit. These changes make the regexps more compatible with languages like JavaScript, Go, Python, and Rust, without affecting the behavior.

In this PR:

- Change `{` to `\{` in many rules. Curly braces are special characters in regexps. The Ruby docs actually say that they have to be escaped, but the implementation silently allows it if you don't. Other languages are stricter, though.
- Change `\<` to `<` in two rules.
- Change `\R` to `\r?\n` in two rules, and reword a third to avoid it. The meaning of `\R` in Ruby includes a few more characters than `\r?\n`, so this is a slight change in behavior, but it's very unlikely that any files of these particular types are using `\v` or `\f`, or Unicode paragraph separators, etc. as line breaks in practice.
- Remove uses of `(?m)` because it's not portable — it means one thing in Ruby and a totally different thing in Python, Rust, and JavaScript. The behavior of the regexps has not been changed, though; when removing `(?m)` I also replaced `.` with `(?:.|\n)` or some other equivalent formula. (This didn't make any regexps much longer, happily.)

This doesn't make _all_ of the regexes portable to all languages, but it's an easy big improvement.

## Checklist:

N/A