### PR TITLE
Update Ruby versions used for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.1', '3.0', '2.7', '2.6' ]
+        ruby: [ '3.2', '3.1', '3.0' ]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby
@@ -56,7 +56,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.2'
         bundler-cache: true
     - name: Build
       run: bundle exec rake samples


### PR DESCRIPTION
## Description

This PR updates the Ruby versions used for testing. Ruby 2.6 and 2.7 are now EoL and 3.2 has been released.

## Checklist:

[ Removed as it's not applicable ]
