### PR TITLE
Remove `\R` in VB6 heuristic

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -145,7 +145,7 @@ disambiguations:
   - language: Visual Basic 6.0
     and:
     - named_pattern: vb-class
-    - pattern: '^\s*BEGIN\R\s*MultiUse\s*=.*\R\s*Persistable\s*='
+    - pattern: '^\s*BEGIN\r?\n\s*MultiUse\s*=.*\r?\n\s*Persistable\s*='
   - language: VBA
     named_pattern: vb-class  
   - language: TeX


### PR DESCRIPTION
This PR fixes an issue with the presence of `\R` in regex patterns in go-enry. https://github.com/go-enry/go-enry/pull/160
It preserves the original intention of https://github.com/github-linguist/linguist/pull/6155 while not preventing go-enry from upgrading to the latest version of Linguist.