### PR TITLE
Update CODEOWNERS, gem metadata and enable CI for merge queues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 # All pull requests need to be reviewed by someone from GitHub.
-# @github/linguist is a GitHub maintained team.
 #
-*     @github/linguist
+*     @github-linguist/github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - master
+  merge_group:
 
 permissions:
   contents: read

--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -7,10 +7,10 @@ Gem::Specification.new do |s|
   s.description = 'We use this library at GitHub to detect blob languages, highlight code, ignore binary files, suppress generated files in diffs, and generate language breakdown graphs.'
 
   s.authors  = "GitHub"
-  s.homepage = "https://github.com/github/linguist"
+  s.homepage = "https://github.com/github-linguist/linguist"
   s.license  = "MIT"
   s.metadata = {
-    "github_repo" => "ssh://github.com/github/linguist"
+    "github_repo" => "ssh://github.com/github-linguist/linguist"
   }
 
   s.files = Dir['{lib,ext}/**/*', 'grammars/*', 'LICENSE'] - Dir['lib/linguist/linguist.{so,bundle}']


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

This PR involves a few miscellaneous admin changes. It...

- updates the CODEOWNERS to use a new team I've created for GitHub members as we can no longer rely on the `@github/linguist` team
- updates the gem metadata to use the new URL location
- adds `merge_group` to the list of "events" when CI will be triggers. This is so we can take advantage of [merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).

## Checklist:

[ Removed as it doesn't apply ]
