### PR TITLE
Add language support for Go workspaces

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2434,8 +2434,11 @@ Go Checksums:
   aliases:
   - go.sum
   - go sum
+  - go.work.sum
+  - go work sum
   filenames:
   - go.sum
+  - go.work.sum
   tm_scope: go.sum
   ace_mode: text
   language_id: 1054391671

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2450,6 +2450,17 @@ Go Module:
   tm_scope: go.mod
   ace_mode: text
   language_id: 947461016
+Go Workspace:
+  type: data
+  color: "#00ADD8"
+  aliases:
+  - go.work
+  - go work
+  filenames:
+  - go.work
+  tm_scope: go.mod
+  ace_mode: text
+  language_id: 934546256
 Godot Resource:
   type: data
   color: "#355570"

--- a/samples/Go Checksums/filenames/go.work.sum
+++ b/samples/Go Checksums/filenames/go.work.sum
@@ -1,0 +1,2 @@
+github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=

--- a/samples/Go Workspace/filenames/go.work
+++ b/samples/Go Workspace/filenames/go.work
@@ -1,0 +1,8 @@
+go 1.19
+
+use (
+	./api
+	./pkg/featureflags
+	./pkg/libhelm
+	./third_party/digest
+)

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -206,6 +206,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Go:** [tree-sitter/tree-sitter-go](https://github.com/tree-sitter/tree-sitter-go) 🐌
 - **Go Checksums:** [golang/vscode-go](https://github.com/golang/vscode-go)
 - **Go Module:** [golang/vscode-go](https://github.com/golang/vscode-go)
+- **Go Workspace:** [golang/vscode-go](https://github.com/golang/vscode-go)
 - **Godot Resource:** [godotengine/godot-vscode-plugin](https://github.com/godotengine/godot-vscode-plugin)
 - **Golo:** [TypeUnsafe/sublime-golo](https://github.com/TypeUnsafe/sublime-golo)
 - **Gosu:** [jpcamara/Textmate-Gosu-Bundle](https://github.com/jpcamara/Textmate-Gosu-Bundle)


### PR DESCRIPTION
## Description
Adds support for Go workspace ([`go.work`](https://go.dev/blog/get-familiar-with-workspaces#workspaces)) files.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3Ago.work.sum
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/portainer/portainer/blob/develop/go.work.sum
    - Sample license(s): zlib License
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A%2F%28%5E%7C%5C%2F%29go%5C.work%24%2F
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/portainer/portainer/blob/develop/go.work
    - Sample license(s): zlib License
  - [ ] I have included a syntax highlighting grammar: [URL to grammar repo]
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
     - Hex value: `#00ADD8`
     - Rationale: To match other Go language files <!-- Please specify why you chose this colour (if it was randomly selected, please say so); it helps arbitrate future requests to change a language's colour -->
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.