### PR TITLE
Add grammar for LOLCODE

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,6 +52,9 @@
 [submodule "vendor/grammars/JSyntax"]
 	path = vendor/grammars/JSyntax
 	url = https://github.com/tikkanz/JSyntax
+[submodule "vendor/grammars/LOLCODE-grammar-vscode"]
+	path = vendor/grammars/LOLCODE-grammar-vscode
+	url = https://github.com/KrazIvan/LOLCODE-grammar-vscode.git
 [submodule "vendor/grammars/Ligo-grammar"]
 	path = vendor/grammars/Ligo-grammar
 	url = https://github.com/pewulfman/Ligo-grammar.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -41,6 +41,8 @@ vendor/grammars/Isabelle.tmbundle:
 - source.isabelle.theory
 vendor/grammars/JSyntax:
 - source.j
+vendor/grammars/LOLCODE-grammar-vscode:
+- source.lolcode
 vendor/grammars/Ligo-grammar:
 - source.jsligo
 - source.ligo

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3540,7 +3540,7 @@ LOLCODE:
   extensions:
   - ".lol"
   color: "#cc9900"
-  tm_scope: none
+  tm_scope: source.lolcode
   ace_mode: text
   language_id: 192
 LSL:

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -287,6 +287,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Kusto:** [mmanela/kusto-sublime](https://github.com/mmanela/kusto-sublime)
 - **LFE:** [textmate/lisp.tmbundle](https://github.com/textmate/lisp.tmbundle)
 - **LLVM:** [whitequark/llvm.tmbundle](https://github.com/whitequark/llvm.tmbundle)
+- **LOLCODE:** [KrazIvan/LOLCODE-grammar-vscode](https://github.com/KrazIvan/LOLCODE-grammar-vscode)
 - **LSL:** [textmate/secondlife-lsl.tmbundle](https://github.com/textmate/secondlife-lsl.tmbundle)
 - **LTspice Symbol:** [Alhadis/language-pcb](https://github.com/Alhadis/language-pcb)
 - **LabVIEW:** [textmate/xml.tmbundle](https://github.com/textmate/xml.tmbundle)

--- a/vendor/licenses/git_submodule/LOLCODE-grammar-vscode.dep.yml
+++ b/vendor/licenses/git_submodule/LOLCODE-grammar-vscode.dep.yml
@@ -1,0 +1,31 @@
+---
+name: LOLCODE-grammar-vscode
+version: 2091c60ebe0b20e169853e5a0385b4bfb54c86f0
+type: git_submodule
+homepage: https://github.com/KrazIvan/LOLCODE-grammar-vscode.git
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |-
+    MIT License
+
+    Copyright (c) 2023 Ivan Shabalin
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
Made a grammar for LOLCODE since it doesn't have it. MIT-licensed.

## Checklist:
- [ ] **I am changing the source of a syntax highlighting grammar**
  - Old: None.
  - New: https://github.com/KrazIvan/LOLCODE-grammar-vscode
