### PR TITLE
Add WGSL support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1320,3 +1320,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/wgsl-grammar"]
+	path = vendor/grammars/wgsl-grammar
+	url = https://github.com/joaogabrielzo/wgsl-grammar.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1179,6 +1179,8 @@ vendor/grammars/vue-syntax-highlight:
 - text.html.vue
 vendor/grammars/wdl-sublime-syntax-highlighter:
 - source.wdl
+vendor/grammars/wgsl-grammar:
+- source.wgsl
 vendor/grammars/witcherscript-grammar:
 - source.witcherscript
 vendor/grammars/wollok-sublime:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7469,6 +7469,14 @@ Wget Config:
   tm_scope: source.wgetrc
   ace_mode: text
   language_id: 668457123
+WGSL:
+  type: programming
+  color: "#1a5e9a"
+  extensions:
+  - ".wgsl"
+  tm_scope: source.wgsl
+  ace_mode: wgsl
+  language_id: 836605993
 Whiley:
   type: programming
   color: "#d5c397"


### PR DESCRIPTION
## Checklist:
- [x] I am adding a new language.
  - [x] The extension of the new language is used in hundreds of repositories on [GitHub.com](http://github.com/).
    - Search results for each extension:
      - https://github.com/search?q=path%3A*.wgsl&type=code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [Bevy's Example](https://github.com/bevyengine/bevy/blob/latest/assets/shaders/animate_shader.wgsl)
    - Sample license(s):
      - MIT 
  - [x] I have included a syntax highlighting grammar: [wgsl-grammar](https://github.com/joaogabrielzo/wgsl-grammar)
  - [x] I have added a color
    - Hex value: #1a5e9a
    - Rationale: Blue is a present color in the WebGPU logo.  This shade is used in the official WGSL doc.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.