### PR TITLE
languages: ClojureDart support `.cljd`

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1091,6 +1091,7 @@ Clojure:
   - ".boot"
   - ".cl2"
   - ".cljc"
+  - ".cljd"
   - ".cljs"
   - ".cljs.hl"
   - ".cljscm"


### PR DESCRIPTION
## Description
we are developing clojuredart, a transporter from clojure to dart, we use the extension `.cljd`

ref https://github.com/Tensegritics/ClojureDart

cc @cgrand @dupuchba

## Checklist:
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.cljd
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/avelino/phanpy-app
    - Sample license(s): MIT
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.