### PR TITLE
Add support for Ruby Option Lists

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4858,6 +4858,8 @@ Option List:
   - ackrc
   filenames:
   - ".ackrc"
+  - ".rspec"
+  - ".yardopts"
   - ackrc
   - mocha.opts
   tm_scope: source.opts

--- a/samples/Option List/filenames/.rspec
+++ b/samples/Option List/filenames/.rspec
@@ -1,0 +1,3 @@
+--order rand
+--warnings
+--require spec_helper

--- a/samples/Option List/filenames/.yardopts
+++ b/samples/Option List/filenames/.yardopts
@@ -1,0 +1,26 @@
+--protected
+--no-private
+--embed-mixin ClassMethods
+--exclude /server/templates/
+--exclude /yard/rubygems/
+--asset docs/images:images
+--tag yard.signature:"YARD Tag Signature"
+--type-name-tag yard.tag:"YARD Tag"
+--type-name-tag yard.directive:"YARD Directive"
+--hide-tag yard.tag
+--hide-tag yard.directive
+--hide-tag yard.signature
+--load ./docs/templates/plugin.rb
+-
+CHANGELOG.md
+docs/WhatsNew.md
+docs/GettingStarted.md
+docs/Tags.md
+docs/Overview.md
+docs/CodeObjects.md
+docs/Parser.md
+docs/Handlers.md
+docs/TagsArch.md
+docs/Templates.md
+LICENSE
+LEGAL


### PR DESCRIPTION
This adds support for files that contain command-line options used by RSpec and Yard.

## Description

- [`.rspec` documentation](https://rspec.info/documentation/3.12/rspec-core/#store-command-line-options-rspec)
- [`.yardopts` documentation](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md#yardopts-options-file)

## Checklist:

- [x] **I am adding a new ~~extension~~ filename to a language.**
  - [x] The new ~~extension~~ filename is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - [`.rspec` (2.6k)](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A%2F%28%5E%7C%5C%2F%29%5C.rspec%24%2F+--require)
      - [`.yardopts` (1.8k)](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A%2F%28%5E%7C%5C%2F%29%5C.yardopts%24%2F+--title)
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [`.rspec`](https://github.com/rspec/rspec-core/blob/81589709e88db1ec2537faee3a7f4a43c7d9aac1/.rspec)
      - [`.yardopts`](https://github.com/lsegal/yard/blob/698b22cc2340230856ab17a25cfefa889f1c8289/.yardopts)
    - Sample license(s):
      - [MIT (`.rspec`)](https://github.com/rspec/rspec-core/blob/81589709e88db1ec2537faee3a7f4a43c7d9aac1/LICENSE.md)
      - [MIT (`.yardopts`)](https://github.com/lsegal/yard/blob/698b22cc2340230856ab17a25cfefa889f1c8289/LICENSE)
  - [ ] ~~I have included a change to the heuristics to distinguish my language from others using the same extension.~~ No other uses of these filenames AFAIK