### PR TITLE
Create devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+# Available versions: https://github.com/devcontainers/images/tree/main/src/ruby
+FROM mcr.microsoft.com/devcontainers/ruby
+RUN apt update && apt install -y cmake

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,6 @@
       "extensions": ["EditorConfig.EditorConfig", "rebornix.Ruby"]
     }
   },
-  "postCreateCommand": "script/bootstrap",
+  "postCreateCommand": ".devcontainer/postCreate.sh",
   "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
       "extensions": ["EditorConfig.EditorConfig", "rebornix.Ruby", "redhat.vscode-yaml"]
     }
   },
+  "onCreateCommand": "./script/bootstrap",
   "postCreateCommand": ".devcontainer/postCreate.sh",
   "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "Ruby",
+  // Available versions: https://github.com/devcontainers/images/tree/main/src/ruby
+  "image": "mcr.microsoft.com/devcontainers/ruby",
+  "customizations": {
+    "codespaces": {
+      "openFiles": ["CONTRIBUTING.md", "lib/linguist/languages.yml"]
+    },
+    "vscode": {
+      "extensions": ["EditorConfig.EditorConfig", "rebornix.Ruby"]
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,10 +9,17 @@
   },
   "customizations": {
     "codespaces": {
-      "openFiles": ["CONTRIBUTING.md", "lib/linguist/languages.yml"]
+      "openFiles": [
+        "CONTRIBUTING.md",
+        "lib/linguist/languages.yml"
+      ]
     },
     "vscode": {
-      "extensions": ["EditorConfig.EditorConfig", "rebornix.Ruby", "redhat.vscode-yaml"]
+      "extensions": [
+        "EditorConfig.EditorConfig",
+        "rebornix.Ruby",
+        "redhat.vscode-yaml"
+      ]
     }
   },
   "onCreateCommand": "./script/bootstrap",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,12 @@
 {
   "name": "Ruby",
-  // Available versions: https://github.com/devcontainers/images/tree/main/src/ruby
-  "image": "mcr.microsoft.com/devcontainers/ruby",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/go:1": {}
+  },
   "customizations": {
     "codespaces": {
       "openFiles": ["CONTRIBUTING.md", "lib/linguist/languages.yml"]
@@ -10,5 +15,6 @@
       "extensions": ["EditorConfig.EditorConfig", "rebornix.Ruby"]
     }
   },
+  "postCreateCommand": "script/bootstrap",
   "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
       "openFiles": ["CONTRIBUTING.md", "lib/linguist/languages.yml"]
     },
     "vscode": {
-      "extensions": ["EditorConfig.EditorConfig", "rebornix.Ruby"]
+      "extensions": ["EditorConfig.EditorConfig", "rebornix.Ruby", "redhat.vscode-yaml"]
     }
   },
   "postCreateCommand": ".devcontainer/postCreate.sh",

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
-./script/bootstrap
 git remote add linguist https://github.com/github-linguist/linguist
 git fetch linguist v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-./scripts/bootstrap
+./script/bootstrap
 git remote add linguist https://github.com/github-linguist/linguist
 git fetch linguist v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+./scripts/bootstrap
+git remote add linguist https://github.com/github-linguist/linguist
+git fetch linguist v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Fix syntax highlighting for devcontainer files
+.devcontainer/*.json linguist-language=JSON-with-Comments


### PR DESCRIPTION
## Description

See https://github.com/github-linguist/linguist/discussions/6473

Currently, prebuilds are available from [my fork](https://github.com/spenserblack/github-linguist/tree/devcontainer), built from the `devcontainer` branch. Hopefully none of the reviewers of this PR are in East Asia, because that's the one region I didn't enable in order to save on storage usage 🙃 

This will probably need some further changes. Some things I can think of off the top of my head are
- Do we want to use a specific Ruby version, or just stick with the latest?
- Any additional desired VS Code extensions or settings?
- Right now `script/bootstrap` is a post-create command, and it can apparently hit 100% CPU usage with a 2-core codespace. Should the min requirements be specified as 4-core?

## Checklist:

(Don't think any of the checkboxes apply, sorry if one does)