### PR TITLE
Add `hosts` to Host file aliases

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2847,6 +2847,8 @@ Hosts File:
   filenames:
   - HOSTS
   - hosts
+  aliases:
+  - hosts
   tm_scope: source.hosts
   ace_mode: text
   language_id: 231021894


### PR DESCRIPTION
## Description
I couldn't get `[attr]hosts linguist-detectable linguist-language=hosts` to have any effect on files in [my repo](https://github.com/DandelionSprout/adfilt/blob/master/.gitattributes), so I took a guess that something seemed off with Linguist-Language's accepted values.

*(Checklist removed as it doesn't apply)*