### PR TITLE
Cross-validation script: Add filter for extensions

### DIFF
--- a/script/cross-validation
+++ b/script/cross-validation
@@ -13,11 +13,14 @@ STDOUT.sync = true
 STDERR.sync = true
 
 def print_usage(out)
-  out.puts "Usage: #{$PROGRAM_NAME} [--all] [--test]"
+  out.puts "Usage: #{$PROGRAM_NAME} [--all] [--extensions=<list>] [--test]"
   out.puts ''
   out.puts 'Performs leave-one-out cross-validation of the classifier.'
   out.puts 'By default, outputs results only for samples with ambiguous extensions.'
   out.puts 'If the --all flag is given, all samples and languages are considered.'
+  out.puts ''
+  out.puts 'If the --extensions option is used, only the extensions specified in the comma-seperated list will be considered.'
+  out.puts 'Extensions in the list must include the starting dot.'
   out.puts ''
   out.puts 'The --test flag can be used to verify that the number of errors is acceptable.'
 end
@@ -29,12 +32,15 @@ end
 
 $all = false
 $test = false
-ARGV.each do |arg|
+$exts = []
+ARGV.each_with_index do |arg, index|
   case arg
   when '--all'
     $all = true
   when '--test'
     $test = true
+  when /^--extensions=(.*)$/
+    $exts = $1.delete("'\"").split(',').map(&:strip)
   else
     STDERR.puts "Invalid command line argument: #{arg}"
     STDERR.puts ''
@@ -69,6 +75,11 @@ end
 
 def eval(sample)
   return nil if $skip_extensions.include? sample[:extname]
+
+  # Apply extensions list filter
+  if $exts.any? && !$exts.include?(File.extname(sample[:path]))
+    return nil
+  end
 
   # If --all is set, use all languages. Otherwise, get only languages that are
   # ambiguous in terms of filename and extension.


### PR DESCRIPTION
Allowing the use of the cross-validation script with an extensions filter to make the script run faster.
Especially useful when testing multiple samples.

Related comment : https://github.com/github-linguist/linguist/pull/6476#issuecomment-1645991813
> > It would help if I could run the test script on only the .bs files (or only the Bluespec BH directory) -- any advice on how to do that?
> 
> It's too late for this PR since the sample-related issue is resolved, but I had to do this recently as well when having to fix a classifier issue with namely `.bas` and `.cls` files. The branch with that feature is this here https://github.com/DecimalTurn/linguist/tree/cross-validation-filter
> 
> The syntax to apply the extensions filter is to pass the `--extensions` option with extensions (including the dot) seperated by a comma.
> ```
> bundle exec script/cross-validation --extensions=.bas,.cls
> or
> bundle exec script/cross-validation --extensions=".bas, .cls"
> ```