### PR TITLE
Bump mocha dependency version

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'minitest', '~> 5.15'
   s.add_development_dependency 'rake-compiler', '~> 0.9'
-  s.add_development_dependency 'mocha', '~> 1.3'
+  s.add_development_dependency 'mocha', '~> 2.1'
   s.add_development_dependency 'plist', '~>3.1'
   s.add_development_dependency 'pry', '~> 0.14'
   s.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

Bumping the minimum version of mocha used for testing.

This is needed because Mocha < 2.1.0 is not compatible with Minitest 5.19.0 and later: https://github.com/freerange/mocha/issues/614

This will address these test failures:

```
[...]
/home/runner/work/linguist/linguist/vendor/bundle/ruby/3.1.0/gems/mocha-1.16.1/lib/mocha/integration/mini_test/adapter.rb:26:in `included': uninitialized constant MiniTest (NameError)

          Mocha::ExpectationErrorFactory.exception_class = ::MiniTest::Assertion
                                                           ^^^^^^^^^^
Did you mean?  Minitest
	from /home/runner/work/linguist/linguist/vendor/bundle/ruby/3.1.0/gems/mocha-1.16.1/lib/mocha/integration/mini_test.rb:50:in `include'
	from /home/runner/work/linguist/linguist/vendor/bundle/ruby/3.1.0/gems/mocha-1.16.1/lib/mocha/integration/mini_test.rb:50:in `activate'
	from /home/runner/work/linguist/linguist/vendor/bundle/ruby/3.1.0/gems/mocha-1.16.1/lib/mocha/minitest.rb:5:in `<top (required)>'
	from /home/runner/work/linguist/linguist/test/helper.rb:3:in `require'
	from /home/runner/work/linguist/linguist/test/helper.rb:3:in `<top (required)>'
	from /home/runner/work/linguist/linguist/test/test_blob.rb:1:in `require_relative'
	from /home/runner/work/linguist/linguist/test/test_blob.rb:1:in `<top (required)>'
	from /home/runner/work/linguist/linguist/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `require'
	from /home/runner/work/linguist/linguist/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /home/runner/work/linguist/linguist/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `select'
	from /home/runner/work/linguist/linguist/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
[...]

```

## Checklist:

N/A