### PR TITLE
Add `.code-workspace` to `JSON with Comments`

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3155,6 +3155,7 @@ JSON with Comments:
   extensions:
   - ".jsonc"
   - ".code-snippets"
+  - ".code-workspace"
   - ".sublime-build"
   - ".sublime-commands"
   - ".sublime-completions"

--- a/samples/JSON with Comments/plyr.code-workspace
+++ b/samples/JSON with Comments/plyr.code-workspace
@@ -1,0 +1,39 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "search.exclude": {
+      "**/node_modules": true,
+      "**/dist": true
+    },
+
+    // Linting
+    "stylelint.enable": true,
+    "stylelint.validate": ["css", "scss"],
+    "css.validate": false,
+    "less.validate": false,
+    "scss.validate": false,
+    "javascript.validate.enable": false,
+
+    // Formatting
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true,
+    "editor.formatOnSave": true,
+
+    // Trim on save
+    "files.trimTrailingWhitespace": true,
+
+    // Special file associations
+    "files.associations": {
+      ".eslintrc": "jsonc"
+    },
+
+    "editor.codeActionsOnSave": {
+      "source.fixAll": true
+    }
+  }
+}


### PR DESCRIPTION
Add extension `.code-workspace` to the language `JSON with Comments`.
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
[Workspaces in Visual Studio Code](https://code.visualstudio.com/docs/editor/workspaces)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.code-workspace
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - <https://github.com/sampotts/plyr/blob/cbd1596af4673a954051e0bfffdde7558dd24293/plyr.code-workspace>
    - Sample license(s):
      - MIT
