### PR TITLE
Harden heuristics against `Regexp::TimeoutError` errors

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -30,6 +30,8 @@ module Linguist
       end
 
       [] # No heuristics matched
+    rescue Regexp::TimeoutError
+      [] # Return nothing if we have a bad regexp which leads to a timeout enforced by Regexp.timeout in Ruby 3.2 or later
     end
 
     # Public: Get all heuristic definitions

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -686,7 +686,7 @@ disambiguations:
 - extensions: ['.stl']
   rules:
   - language: STL
-    pattern: '\A\s*solid[\s\S]*^endsolid(?:$|\s)'
+    pattern: '\A\s*solid(?:$|\s)[\s\S]*^endsolid(?:$|\s)'
 - extensions: ['.sw']
   rules:
   - language: Sway

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -686,7 +686,7 @@ disambiguations:
 - extensions: ['.stl']
   rules:
   - language: STL
-    pattern: '\A\s*solid(?=$|\s)(?:.|[\r\n])*?^endsolid(?:$|\s)'
+    pattern: '\A\s*solid[\s\S]*endsolid(?:$|\s)'
 - extensions: ['.sw']
   rules:
   - language: Sway

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -686,7 +686,7 @@ disambiguations:
 - extensions: ['.stl']
   rules:
   - language: STL
-    pattern: '\A\s*solid[\s\S]*endsolid(?:$|\s)'
+    pattern: '\A\s*solid[\s\S]*^endsolid(?:$|\s)'
 - extensions: ['.sw']
   rules:
   - language: Sway

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -34,6 +34,11 @@ class TestHeuristics < Minitest::Test
     assert_equal [], Heuristics.call(file_blob("Markdown/symlink.md"), [Language["Markdown"]])
   end
 
+  def test_no_match_if_regexp_timeout
+    Regexp.any_instance.stubs(:match).raises(Regexp::TimeoutError)
+    assert_equal [], Heuristics.call(file_blob("#{fixtures_path}/Generic/stl/STL/cube1.stl"), [Language["STL"]])
+  end
+
   # alt_name is a file name that will be used instead of the file name of the
   # original sample. This is used to force a sample to go through a specific
   # heuristic even if its extension doesn't match.

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -35,6 +35,8 @@ class TestHeuristics < Minitest::Test
   end
 
   def test_no_match_if_regexp_timeout
+    skip("This test requires Ruby 3.2.0 or later") if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.2.0')
+
     Regexp.any_instance.stubs(:match).raises(Regexp::TimeoutError)
     assert_equal [], Heuristics.call(file_blob("#{fixtures_path}/Generic/stl/STL/cube1.stl"), [Language["STL"]])
   end


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

Ruby 3.2 allows you to set a process global `Regexp.timeout = <time>` to limit the impact of poorly written regexes and prevent ReDoS attacks. GitHub is now enforcing a timeout which has revealed...  

a) we're not playing nicely and rescuing the `Regexp::TimeoutError` errors so GitHub may sometime respond with a 500 error or not render a file at all
b) https://github.com/github-linguist/linguist/pull/6417 introduced a [regex which suffers from catastrophic backtracking](https://github.com/github-linguist/linguist/pull/6417#pullrequestreview-1580134908) which ultimately causes the `Regexp::TimeoutError` errors. This was missed as the issue only comes to light when analysing largish files.

This PR addresses both by rescuing the `Regexp::TimeoutError` exceptions when analysing using the heuristics strategy - we return an empty result as misidentifcation is better than a 500 error -  and replaces the bad regex that brought this to light.

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.