### PR TITLE
Add `pikchr` as an alias of Pic

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5136,6 +5136,8 @@ Pic:
   extensions:
   - ".pic"
   - ".chem"
+  aliases:
+  - pikchr
   ace_mode: text
   codemirror_mode: troff
   codemirror_mime_type: text/troff


### PR DESCRIPTION
[Pikchr](https://pikchr.org/) is a web-centric implementation of the [Pic](https://en.wikipedia.org/wiki/PIC_(markup_language)) programming language, designed to work with markdown code-blocks instead of Roff documents:

~~~markdown
```pikchr
arrow right 200% "Markdown" "Source"
box rad 10px "Markdown" "Formatter" "(markdown.c)" fit
arrow right 200% "HTML+SVG" "Output"
arrow <-> down 70% from last box.s
box same "Pikchr" "Formatter" "(pikchr.c)" fit
```
~~~

This pull-request simply adds `pikchr` as an alias of Pic so that such code-blocks receive syntax highlighting on GitHub.

_(Checklist removed as it doesn't apply)_