### PR TITLE
add `HappyX` language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1308,6 +1308,9 @@
 [submodule "vendor/grammars/wgsl-analyzer"]
 	path = vendor/grammars/wgsl-analyzer
 	url = https://github.com/wgsl-analyzer/wgsl-analyzer.git
+[submodule "vendor/grammars/hpx-vs-code"]
+	path = vendor/grammars/hpx-vs-code
+	url = https://github.com/HapticX/hpx-vs-code.git
 [submodule "vendor/grammars/witcherscript-grammar"]
 	path = vendor/grammars/witcherscript-grammar
 	url = https://github.com/ADawesomeguy/witcherscript-grammar.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1182,6 +1182,8 @@ vendor/grammars/vscode_cobol:
 - source.utreport
 vendor/grammars/vscode_mikrotik_routeros_script:
 - source.rsc
+vendor/grammars/hpx-vs-code:
+- source.hpx
 vendor/grammars/vue-syntax-highlight:
 - text.html.vue
 vendor/grammars/wdl-sublime-syntax-highlighter:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2775,6 +2775,14 @@ Haml:
   codemirror_mode: haml
   codemirror_mime_type: text/x-haml
   language_id: 154
+HappyX:
+  type: markup
+  color: "#EF7575"
+  extensions:
+  - ".hpx"
+  tm_scope: source.hpx
+  ace_mode: html
+  language_id: 391
 Handlebars:
   type: markup
   color: "#f7931e"

--- a/samples/HappyX/basic.hpx
+++ b/samples/HappyX/basic.hpx
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <h2 class="scoped-class">Hello, world!</h2>
+  </div>
+</template>
+
+<script>
+echo "Hello from Nim programming language"
+
+props:
+  additionalContext: string = ""
+
+proc doSomething*() =
+  echo "you can call it with self.doSomething()"
+</script>
+
+<style>
+  .scoped-class {
+    background: red;  
+  }
+</style>


### PR DESCRIPTION
Add `.hpx` files syntax highlight support.

## Description
HappyX is a web framework, that provides `.hpx` files to write components

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new language.**
  - [x] I have included a real-world usage sample for all extensions added in this PR
  - [x] I have included a syntax highlighting grammar: https://github.com/HapticX/hpx-vs-code
  - [x] I have added a color
    - Hex value: `#EF7575`
    - Rationale: HappyX brand color
