### PR TITLE
Platform agnostic line endings

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -74,7 +74,7 @@ disambiguations:
   - language: Public Key
     pattern: '^(----[- ]BEGIN|ssh-(rsa|dss)) '
   - language: AsciiDoc
-    pattern: '^[=-]+(\s|\n)|\{\{[A-Za-z]'
+    pattern: '^[=-]+[\s\r\n]|\{\{[A-Za-z]'
   - language: AGS Script
     pattern: '^(\/\/.+|((import|export)\s+)?(function|int|float|char)\s+((room|repeatedly|on|game)_)?([A-Za-z]+[A-Za-z_0-9]+)\s*[;\(])'
 - extensions: ['.asm']
@@ -161,7 +161,7 @@ disambiguations:
 - extensions: ['.cmp']
   rules:
   - language: Gerber Image
-    pattern: '^[DGMT][0-9]{2}\*\r?\n'
+    pattern: '^[DGMT][0-9]{2}\*(?:\r?\n|\r)'
 - extensions: ['.cs']
   rules:
   - language: Smalltalk
@@ -278,7 +278,7 @@ disambiguations:
 - extensions: ['.ftl']
   rules:
   - language: FreeMarker
-    pattern: '^(?:<|[a-zA-Z-][a-zA-Z0-9_-]+[ \t]+\w)|\$\{\w+[^\n]*?\}|^[ \t]*(?:<#--.*?-->|<#([a-z]+)(?=\s|>)[^>]*>.*?</#\1>|\[#--.*?--\]|\[#([a-z]+)(?=\s|\])[^\]]*\].*?\[#\2\])'
+    pattern: '^(?:<|[a-zA-Z-][a-zA-Z0-9_-]+[ \t]+\w)|\$\{\w+[^\r\n]*?\}|^[ \t]*(?:<#--.*?-->|<#([a-z]+)(?=\s|>)[^>]*>.*?</#\1>|\[#--.*?--\]|\[#([a-z]+)(?=\s|\])[^\]]*\].*?\[#\2\])'
   - language: Fluent
     pattern: '^-?[a-zA-Z][a-zA-Z0-9_-]* *=|\{\$-?[a-zA-Z][-\w]*(?:\.[a-zA-Z][-\w]*)?\}'
 - extensions: ['.g']
@@ -286,7 +286,7 @@ disambiguations:
   - language: GAP
     pattern: '\s*(Declare|BindGlobal|KeyDependentOperation|Install(Method|GlobalFunction)|SetPackageInfo)'
   - language: G-code
-    pattern: '^[MG][0-9]+\n'
+    pattern: '^[MG][0-9]+(?:\r?\n|\r)'
 - extensions: ['.gd']
   rules:
   - language: GAP
@@ -431,7 +431,7 @@ disambiguations:
   - language: Win32 Message File
     pattern: '(?i)^[ \t]*(?>\/\*\s*)?MessageId=|^\.$'
   - language: M4
-    pattern: '^dnl|^divert\((?:-?\d+)?\)|^\w+\(`[^\n]*?''[),]'
+    pattern: '^dnl|^divert\((?:-?\d+)?\)|^\w+\(`[^\r\n]*?''[),]'
   - language: Monkey C
     pattern: '\b(?:using|module|function|class|var)\s+\w'
 - extensions: ['.md']
@@ -476,7 +476,7 @@ disambiguations:
   - language: XML
     pattern: '^\s*<\?xml\s+version'
   - language: Gerber Image
-    pattern: '^[DGMT][0-9]{2}\*\r?\n'
+    pattern: '^[DGMT][0-9]{2}\*(?:\r?\n|\r)'
   - language: Text
     pattern: 'THE_TITLE'
 - extensions: ['.nl']
@@ -540,7 +540,7 @@ disambiguations:
 - extensions: ['.pod']
   rules:
   - language: Pod 6
-    pattern: '^[\s&&[^\n]]*=(comment|begin pod|begin para|item\d+)'
+    pattern: '^[\s&&[^\r\n]]*=(comment|begin pod|begin para|item\d+)'
   - language: Pod
 - extensions: ['.pp']
   rules:
@@ -579,7 +579,7 @@ disambiguations:
 - extensions: ['.q']
   rules:
   - language: q
-    pattern: '((?i:[A-Z.][\w.]*:\{)|(^|\n)\\(cd?|d|l|p|ts?) )'
+    pattern: '((?i:[A-Z.][\w.]*:\{)|^\\(cd?|d|l|p|ts?) )'
   - language: HiveQL
     pattern: '(?i:SELECT\s+[\w*,]+\s+FROM|(CREATE|ALTER|DROP)\s(DATABASE|SCHEMA|TABLE))'
 - extensions: ['.qs']
@@ -652,7 +652,7 @@ disambiguations:
   - language: Solidity
     pattern: '\bpragma\s+solidity\b|\b(?:abstract\s+)?contract\s+(?!\d)[a-zA-Z0-9$_]+(?:\s+is\s+(?:[a-zA-Z0-9$_][^\{]*?)?)?\s*\{'
   - language: Gerber Image
-    pattern: '^[DGMT][0-9]{2}\*\r?\n'
+    pattern: '^[DGMT][0-9]{2}\*(?:\r?\n|\r)'
 - extensions: ['.sql']
   rules:
    # Postgres
@@ -767,7 +767,7 @@ disambiguations:
 - extensions: ['.url']
   rules:
   - language: INI
-    pattern: '^\[InternetShortcut\](?:\r?\n|\r)(?>[^\s\[][^\n]*(?:\r?\n|\r))*URL='
+    pattern: '^\[InternetShortcut\](?:\r?\n|\r)(?>[^\s\[][^\r\n]*(?:\r?\n|\r))*URL='
 - extensions: ['.v']
   rules:
   - language: Coq


### PR DESCRIPTION
## Description
This PR should make all remaining regex patterns follow our new approach of using platform-agnostic line endings as discussed here: https://github.com/github-linguist/linguist/pull/6417#issuecomment-1559966383

Here are the replacements made:
1. Standalone[^1] `\r?\n` with `(?:\r?\n|\r)` 
2. Standalone[^1] `\n` with `(?:\r?\n|\r)`
3. `(\s|\n)` with  `[\s\r\n]`
4. `[^\n]` with `[^\r\n]`

I also replaced `(^|\n)` with just `^` since matching with the previous line ending or not doesn't affect the outcome.

[^1]: In the sense that they are not part of a character set.

_(Checklist removed as it doesn't apply)._