### PR TITLE
.vscode/settings.json as filename for jsonc

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3176,6 +3176,7 @@ JSON with Comments:
   - ".jshintrc"
   - ".jslintrc"
   - ".swcrc"
+  - ".vscode/settings.json"
   - api-extractor.json
   - devcontainer.json
   - jsconfig.json


### PR DESCRIPTION
- Visual Studio Code's `.vscode/settings.json` uses `JSON with Comments`, see https://code.visualstudio.com/docs/getstarted/settings#_workspace-settingsjson-location.
- GitHub treats this file as `JSON`. 

## Description
Adds `.vscode/settings.json` as a filename for `JSON with Comments`.

## Checklist:
- [x] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language:
    - Sample source(s):
      - https://github.com/fabiorocha/vscode-settings.json/blob/master/settings.json
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
    - I don't think this applies as the filepath is quite distinct. 