### PR TITLE
Remove redundancy in `AsciiDoc`'s regex pattern

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -74,7 +74,7 @@ disambiguations:
   - language: Public Key
     pattern: '^(----[- ]BEGIN|ssh-(rsa|dss)) '
   - language: AsciiDoc
-    pattern: '^[=-]+[\s\r\n]|\{\{[A-Za-z]'
+    pattern: '^[=-]+\s|\{\{[A-Za-z]'
   - language: AGS Script
     pattern: '^(\/\/.+|((import|export)\s+)?(function|int|float|char)\s+((room|repeatedly|on|game)_)?([A-Za-z]+[A-Za-z_0-9]+)\s*[;\(])'
 - extensions: ['.asm']


### PR DESCRIPTION
Fixes the warning introduced in https://github.com/github-linguist/linguist/pull/6530#issuecomment-1709892152
Credit for the suggestion: @Alhadis 

_(Checklist removed as it doesn't apply)._
