### PR TITLE
Add Gradle Kotlin DSL

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2544,6 +2544,15 @@ Gradle:
   tm_scope: source.groovy.gradle
   ace_mode: text
   language_id: 136
+Gradle Kotlin DSL:
+  group: Gradle
+  type: data
+  color: "#02303a"
+  extensions:
+  - ".gradle.kts"
+  ace_mode: text
+  tm_scope: source.kotlin
+  language_id: 432600901
 Grammatical Framework:
   type: programming
   aliases:

--- a/samples/Gradle Kotlin DSL/build.gradle.kts
+++ b/samples/Gradle Kotlin DSL/build.gradle.kts
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+plugins {
+  alias(libs.plugins.nexus.publish)
+  alias(libs.plugins.android.library) apply false
+  alias(libs.plugins.android.application) apply false
+  alias(libs.plugins.download) apply false
+  alias(libs.plugins.kotlin.android) apply false
+}
+
+val reactAndroidProperties = java.util.Properties()
+
+File("$rootDir/packages/react-native/ReactAndroid/gradle.properties").inputStream().use {
+  reactAndroidProperties.load(it)
+}
+
+version =
+    if (project.hasProperty("isNightly") &&
+        (project.property("isNightly") as? String).toBoolean()) {
+      "${reactAndroidProperties.getProperty("VERSION_NAME")}-SNAPSHOT"
+    } else {
+      reactAndroidProperties.getProperty("VERSION_NAME")
+    }
+
+group = "com.facebook.react"
+
+val ndkPath by extra(System.getenv("ANDROID_NDK"))
+val ndkVersion by extra(System.getenv("ANDROID_NDK_VERSION") ?: "25.1.8937393")
+val sonatypeUsername = findProperty("SONATYPE_USERNAME")?.toString()
+val sonatypePassword = findProperty("SONATYPE_PASSWORD")?.toString()
+
+nexusPublishing {
+  repositories {
+    sonatype {
+      username.set(sonatypeUsername)
+      password.set(sonatypePassword)
+    }
+  }
+}
+
+tasks.register("clean", Delete::class.java) {
+  description = "Remove all the build files and intermediate build outputs"
+  dependsOn(gradle.includedBuild("react-native-gradle-plugin").task(":clean"))
+  subprojects.forEach {
+    if (it.project.plugins.hasPlugin("com.android.library") ||
+        it.project.plugins.hasPlugin("com.android.application")) {
+      dependsOn(it.tasks.named("clean"))
+    }
+  }
+  delete(allprojects.map { it.layout.buildDirectory.asFile })
+  delete(rootProject.file("./packages/react-native/ReactAndroid/.cxx"))
+  delete(rootProject.file("./packages/react-native/ReactAndroid/hermes-engine/.cxx"))
+  delete(rootProject.file("./packages/react-native/sdks/download/"))
+  delete(rootProject.file("./packages/react-native/sdks/hermes/"))
+  delete(
+      rootProject.file("./packages/react-native/ReactAndroid/src/main/jni/prebuilt/lib/arm64-v8a/"))
+  delete(
+      rootProject.file(
+          "./packages/react-native/ReactAndroid/src/main/jni/prebuilt/lib/armeabi-v7a/"))
+  delete(rootProject.file("./packages/react-native/ReactAndroid/src/main/jni/prebuilt/lib/x86/"))
+  delete(rootProject.file("./packages/react-native/ReactAndroid/src/main/jni/prebuilt/lib/x86_64/"))
+  delete(rootProject.file("./packages/react-native-codegen/lib"))
+  delete(rootProject.file("./node_modules/@react-native/codegen/lib"))
+  delete(rootProject.file("./packages/rn-tester/android/app/.cxx"))
+}
+
+tasks.register("build") {
+  description = "Build and test all the React Native relevant projects."
+  dependsOn(gradle.includedBuild("react-native-gradle-plugin").task(":build"))
+}
+
+tasks.register("downloadAll") {
+  description = "Download all the depedencies needed locally so they can be cached on CI."
+  dependsOn(gradle.includedBuild("react-native-gradle-plugin").task(":dependencies"))
+  dependsOn(":packages:react-native:ReactAndroid:downloadNdkBuildDependencies")
+  dependsOn(":packages:react-native:ReactAndroid:dependencies")
+  dependsOn(":packages:react-native:ReactAndroid:androidDependencies")
+  dependsOn(":packages:react-native:ReactAndroid:hermes-engine:dependencies")
+  dependsOn(":packages:react-native:ReactAndroid:hermes-engine:androidDependencies")
+  dependsOn(":packages:rn-tester:android:app:dependencies")
+  dependsOn(":packages:rn-tester:android:app:androidDependencies")
+}
+
+tasks.register("publishAllInsideNpmPackage") {
+  description =
+      "Publish all the artifacts to be available inside the NPM package in the `android` folder."
+  // Due to size constraints of NPM, we publish only react-native and hermes-engine inside
+  // the NPM package.
+  dependsOn(":packages:react-native:ReactAndroid:installArchives")
+  dependsOn(":packages:react-native:ReactAndroid:hermes-engine:installArchives")
+}
+
+tasks.register("publishAllToMavenTempLocal") {
+  description = "Publish all the artifacts to be available inside a Maven Local repository on /tmp."
+  dependsOn(":packages:react-native:ReactAndroid:publishAllPublicationsToMavenTempLocalRepository")
+  // We don't publish the external-artifacts to Maven Local as CircleCI is using it via workspace.
+  dependsOn(
+      ":packages:react-native:ReactAndroid:flipper-integration:publishAllPublicationsToMavenTempLocalRepository")
+  dependsOn(
+      ":packages:react-native:ReactAndroid:hermes-engine:publishAllPublicationsToMavenTempLocalRepository")
+}
+
+tasks.register("publishAllToSonatype") {
+  description = "Publish all the artifacts to Sonatype (Maven Central or Snapshot repository)"
+  dependsOn(":packages:react-native:ReactAndroid:publishToSonatype")
+  dependsOn(":packages:react-native:ReactAndroid:external-artifacts:publishToSonatype")
+  dependsOn(":packages:react-native:ReactAndroid:flipper-integration:publishToSonatype")
+  dependsOn(":packages:react-native:ReactAndroid:hermes-engine:publishToSonatype")
+}
+
+if (project.findProperty("react.internal.useHermesNightly")?.toString()?.toBoolean() == true) {
+  logger.warn(
+      """
+      ********************************************************************************
+      INFO: You're using Hermes from nightly as you set
+
+      react.internal.useHermesNightly=true
+
+      in the ./gradle.properties file.
+
+      That's fine for local development, but you should not commit this change.
+      ********************************************************************************
+  """
+          .trimIndent())
+  allprojects {
+    configurations.all {
+      resolutionStrategy.dependencySubstitution {
+        substitute(project(":packages:react-native:ReactAndroid:hermes-engine"))
+            .using(module("com.facebook.react:hermes-android:0.0.0-+"))
+            .because("Users opted to use hermes from nightly")
+      }
+    }
+  }
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -214,6 +214,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Gosu:** [jpcamara/Textmate-Gosu-Bundle](https://github.com/jpcamara/Textmate-Gosu-Bundle)
 - **Grace:** [zmthy/grace-tmbundle](https://github.com/zmthy/grace-tmbundle)
 - **Gradle:** [alkemist/gradle.tmbundle](https://github.com/alkemist/gradle.tmbundle)
+- **Gradle Kotlin DSL:** [nishtahir/language-kotlin](https://github.com/nishtahir/language-kotlin)
 - **Grammatical Framework:** [johnjcamilleri/language-gf](https://github.com/johnjcamilleri/language-gf)
 - **GraphQL:** [graphql/graphiql](https://github.com/graphql/graphiql)
 - **Graphviz (DOT):** [textmate/graphviz.tmbundle](https://github.com/textmate/graphviz.tmbundle)


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
This PR adds Gradle Kotlin DSL as a new language grouped with Gradle.

Closes https://github.com/github-linguist/linguist/issues/6469

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.gradle.kts
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [build.gradle.kts](https://github.com/facebook/react-native/blob/bf955a0352ee29cab0a8197120ee345d6929f8db/build.gradle.kts)
    - Sample license(s): MIT
  - [x] I have included a syntax highlighting grammar: [URL to grammar repo]
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#02303a`
    - Rationale: It's the same colour as used for Gradle
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

/cc mikewacker as author of https://github.com/github-linguist/linguist/issues/6469