### PR TITLE
Added more verilog/systemverilog extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6851,9 +6851,7 @@ SystemVerilog:
   extensions:
   - ".sv"
   - ".svh"
-  - ".svi"
   - ".svp"
-  - ".vlib"
   tm_scope: source.systemverilog
   ace_mode: verilog
   codemirror_mode: verilog
@@ -7348,16 +7346,12 @@ Verilog:
   color: "#b2b7f8"
   extensions:
   - ".v"
-  - ".v95"
-  - ".v95p"
-  - ".vcfg"
   - ".veo"
   - ".verilog"
   - ".vh"
-  - ".vlg"
+  - ".vlib"
   - ".vlt"
   - ".vp"
-  - ".vs"
   - ".vt"
   tm_scope: source.verilog
   ace_mode: verilog

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6851,7 +6851,9 @@ SystemVerilog:
   extensions:
   - ".sv"
   - ".svh"
-  - ".vh"
+  - ".svi"
+  - ".svp"
+  - ".vlib"
   tm_scope: source.systemverilog
   ace_mode: verilog
   codemirror_mode: verilog
@@ -7346,7 +7348,17 @@ Verilog:
   color: "#b2b7f8"
   extensions:
   - ".v"
+  - ".v95"
+  - ".v95p"
+  - ".vcfg"
   - ".veo"
+  - ".verilog"
+  - ".vh"
+  - ".vlg"
+  - ".vlt"
+  - ".vp"
+  - ".vs"
+  - ".vt"
   tm_scope: source.verilog
   ace_mode: verilog
   codemirror_mode: verilog


### PR DESCRIPTION

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:

- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.svp+module
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.verilog+module
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.vlib+module
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.vlt+%60verilator_config
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.vp+module
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.vt+module+initial
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/StanfordAHA/garnet/blob/4800891aa59b0047fc347854ef69953f218ca4dd/global_controller/rtl/genesis/tap.svp
      - https://github.com/VerticalResearchGroup/miaow/blob/143929c4163edfd559be4086aa9895cd80cee465/src/verilog/tb/simd/vector_alu_tb.verilog
      - https://github.com/nvdla/hw/blob/8e06b1b9d85aab65b40d43d08eec5ea4681ff715/vmod/vlibs/RANDFUNC.vlib
      - https://github.com/openhwgroup/cva6/blob/4641acf9d2a58e3f14561575526145d45a59c57c/verilator_config.vlt
      - https://github.com/VerticalResearchGroup/miaow/blob/143929c4163edfd559be4086aa9895cd80cee465/src/verilog/rtl/wavepool/wavepool.vp
      - https://github.com/HeLiangHIT/polyphase_filter_prj/blob/c6f7e4c0ad2db8f16bf7b38fc3b2d1db99b34fb1/VERILOG/simulation/modelsim/wave_add.vt
    - Sample license(s):
      - [StanfordAHA/garnet: BSD 3-Clause "New" or "Revised" License](https://github.com/StanfordAHA/garnet/blob/master/LICENSE)
      - [VerticalResearchGroup/miaow: BSD 3-Clause "New" or "Revised" License](https://github.com/VerticalResearchGroup/miaow/blob/master/COPYING)
      - [nvdla/hw: NVIDIA Open NVDLA License](https://github.com/nvdla/hw/blob/nvdlav1/LICENSE)
      - [openhwgroup/cva6: SOLDERPAD HARDWARE LICENSE](https://github.com/openhwgroup/cva6/blob/master/LICENSE)
      - [VerticalResearchGroup/miaow: BSD 3-Clause "New" or "Revised" License](https://github.com/VerticalResearchGroup/miaow/blob/master/COPYING)
      - [HeLiangHIT/polyphase_filter_prj: MIT License](https://github.com/HeLiangHIT/polyphase_filter_prj/blob/master/LICENSE)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [x] **I am fixing a misclassified language**
  - `.vh` was mistakenly put under SystemVerilog although it belongs under Verilog. This has now been corrected
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
  