### PR TITLE
Add Glimmer JS language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1335,3 +1335,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/vsc-ember-syntax"]
+	path = vendor/grammars/vsc-ember-syntax
+	url = https://github.com/lifeart/vsc-ember-syntax.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1057,6 +1057,11 @@ vendor/grammars/verilog.tmbundle:
 - source.verilog
 vendor/grammars/vhdl:
 - source.vhdl
+vendor/grammars/vsc-ember-syntax:
+- inline.hbs
+- inline.template
+- source.gjs
+- source.gts
 vendor/grammars/vsc-fennel:
 - source.fnl
 vendor/grammars/vscode-TalonScript:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2424,6 +2424,7 @@ Glimmer JS:
   color: "#F5835F"
   tm_scope: source.gjs
   group: JavaScript
+  language_id: 5523150
 Glyph:
   type: programming
   color: "#c1ac7f"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2416,6 +2416,14 @@ Gleam:
   - ".gleam"
   tm_scope: source.gleam
   language_id: 1054258749
+Glimmer JS:
+  type: programming
+  extensions:
+  - ".gjs"
+  ace_mode: javascript
+  color: "#F5835F"
+  tm_scope: source.gjs
+  group: JavaScript
 Glyph:
   type: programming
   color: "#c1ac7f"

--- a/samples/Glimmer JS/class.gjs
+++ b/samples/Glimmer JS/class.gjs
@@ -1,0 +1,48 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import DButton from "discourse/components/d-button";
+import DModal from "discourse/components/d-modal";
+import DModalCancel from "discourse/components/d-modal-cancel";
+import I18n from "I18n";
+import { htmlSafe } from "@ember/template";
+
+const t = I18n.t.bind(I18n);
+
+export default class ModalDiffModal extends Component {
+  <template>
+    <DModal
+      class="composer-ai-helper-modal"
+      @title={{t "discourse_ai.ai_helper.context_menu.changes"}}
+      @closeModal={{@closeModal}}
+    >
+      <:body>
+        {{#if @diff}}
+          {{htmlSafe @diff}}
+        {{else}}
+          <div class="composer-ai-helper-modal__old-value">
+            {{@oldValue}}
+          </div>
+
+          <div class="composer-ai-helper-modal__new-value">
+            {{@newValue}}
+          </div>
+        {{/if}}
+      </:body>
+
+      <:footer>
+        <DButton
+          class="btn-primary confirm"
+          @action={{this.triggerConfirmChanges}}
+          @label="discourse_ai.ai_helper.context_menu.confirm"
+        />
+        <DModalCancel @close={{@closeModal}} />
+      </:footer>
+    </DModal>
+  </template>
+
+  @action
+  triggerConfirmChanges() {
+    this.args.closeModal();
+    this.args.confirm();
+  }
+}

--- a/samples/Glimmer JS/template-only.gjs
+++ b/samples/Glimmer JS/template-only.gjs
@@ -1,0 +1,55 @@
+import { ExternalLink, Link } from '@crowdstrike/ember-oss-docs';
+
+export const Footer = <template>
+  <footer class="bg-mezzanine theme-mezzanine pb-10 sm:pb-20 md:pb-28 pt-6 sm:pt-10 md:pt-20">
+    <div class="max-w-screen-lg mx-auto grid gap-4 md:gap-14">
+      <nav class="p-8 md:p-0 grid sm:flex flex-wrap justify-between">
+        <div class="flex flex-col items-start">
+          <Link @variant="quiet" @href="https://www.crowdstrike.com/why-crowdstrike/">Why CrowdStrike</Link>
+          <Link @variant="quiet" @href="https://www.crowdstrike.com/why-crowdstrike/crowdstrike-customers/">Our Customers</Link>
+        </div>
+        <div class="flex flex-col items-start">
+          <Link @variant="quiet" @href="https://www.crowdstrike.com/about-crowdstrike/">CrowdStrike's Story</Link>
+          <Link @variant="quiet" @href="http://www.crowdstrike.com/news/">CrowdStrike News and Releases</Link>
+        </div>
+        <div class="flex flex-col items-start">
+          <Link @variant="quiet" @href="https://www.crowdstrike.com/blog/category/engineering-and-technology/">CrowdStrike Engineering and Tech Blog CrowdStrike</Link>
+          <Link @variant="quiet" @href="#">CrowdStrike People and Culture</Link>
+          <Link @variant="quiet" @href="https://crowdstrike.wd5.myworkdayjobs.com/crowdstrikecareers">CrowdStrike Open Positions</Link>
+        </div>
+      </nav>
+
+      <div class="p-8 md:p-0 grid gap-4 md:grid-flow-col w-full items-center">
+        <ExternalLink @href="https://crowdstrike.com" class="mt-3 justify-self-start">
+          <img src="/logo_footer.png" alt="Visit crowdstrike.com" />
+        </ExternalLink>
+
+        <div class="md:justify-self-center text-body-and-labels type-xs">
+          <span class="px-2">Copyright &copy; 2023</span>
+          <span>|</span>
+          <ExternalLink @href="https://www.crowdstrike.com/contact-us/">Contact Us</ExternalLink>
+          <span>|</span>
+          <ExternalLink @href="https://www.crowdstrike.com/privacy-notice/">Private</ExternalLink>
+          <span>|</span>
+          <ExternalLink @href="https://www.crowdstrike.com/website-terms-of-use/">Terms of Use</ExternalLink>
+          <span>|</span>
+          <ExternalLink @href="https://www.crowdstrike.com/careers/candidate-privacy-notices/">Candidate Privacy Notices</ExternalLink>
+        </div>
+
+        <div class="md:justify-self-end flex gap-2 items-center">
+          <ExternalLink @href="https://www.youtube.com/user/CrowdStrike">
+            <img src="/youtube.png" alt="Visit the CrowdStrike YouTube channel" />
+          </ExternalLink>
+          <ExternalLink @href="https://www.instagram.com/crowdstrike/?hl=en">
+            <img src="/instagram.png" alt="Visit the CrowdStrike Instagram" />
+          </ExternalLink>
+          <ExternalLink @href="https://www.linkedin.com/company/crowdstrike">
+            <img src="/linkedin.png" alt="Visit the CrowdStrike LinkedIN" />
+          </ExternalLink>
+        </div>
+      </div>
+    </div>
+  </footer>
+</template>
+
+export default Footer;

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -202,6 +202,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Git Config:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **Git Revision List:** [Nixinova/NovaGrammars](https://github.com/Nixinova/NovaGrammars)
 - **Gleam:** [gleam-lang/tree-sitter-gleam](https://github.com/gleam-lang/tree-sitter-gleam) 🐌
+- **Glimmer JS:** [lifeart/vsc-ember-syntax](https://github.com/lifeart/vsc-ember-syntax)
 - **Glyph:** [textmate/tcl.tmbundle](https://github.com/textmate/tcl.tmbundle)
 - **Glyph Bitmap Distribution Format:** [Alhadis/language-fontforge](https://github.com/Alhadis/language-fontforge)
 - **Gnuplot:** [mattfoster/gnuplot-tmbundle](https://github.com/mattfoster/gnuplot-tmbundle)

--- a/vendor/licenses/git_submodule/vsc-ember-syntax.dep.yml
+++ b/vendor/licenses/git_submodule/vsc-ember-syntax.dep.yml
@@ -1,0 +1,24 @@
+---
+name: vsc-ember-syntax
+version: 55ca6981204a1f3934b55057a5a7abbab66a1d8e
+type: git_submodule
+homepage: https://github.com/lifeart/vsc-ember-syntax.git
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: "Copyright (c) 2021 Aleksandr Kanunnikov, and contributors.\n\nAll rights
+    reserved. \n\nMIT License\n\nPermission is hereby granted, free of charge, to
+    any person obtaining a copy of this software and associated documentation files
+    (the \"Software\"), to deal in the Software without restriction, including without
+    limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the Software
+    is furnished to do so, subject to the following conditions:\n\nThe above copyright
+    notice and this permission notice shall be included in all copies or substantial
+    portions of the Software.\n\nTHE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY
+    OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+    SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.\n"
+notices: []


### PR DESCRIPTION
## Description
Adds support for [Glimmer.js](https://glimmerjs.com/) which will be the [component authoring format](https://github.com/ember-template-imports/ember-template-imports) of the [next Edition of Ember.js](https://emberjs.com/editions/polaris/).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  [.gjs search](https://github.com/search?q=%28path%3A*.gjs%29+AND+%28content%3A%3Ctemplate%3E+OR+content%3A%40glimmer+OR+content%3A%40ember%29&type=code) 1.7k files
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
	    - [class.gjs](https://github.com/discourse/discourse-ai/blob/main/assets/javascripts/discourse/components/modal/diff-modal.gjs)
	    - [class.gts](https://github.com/cardstack/cardstack/blob/main/packages/boxel/addon/components/boxel/input/time/usage.gts)
    - Sample license(s):
	    - class.gjs - (https://github.com/discourse/discourse-ai) MIT
	    - template-only.gjs (https://github.com/CrowdStrike/opensource.crowdstrike.com) MIT
  - [x] I have included a syntax highlighting grammar:
	 - https://github.com/lifeart/vsc-ember-syntax – MIT
  - [x] I have added a color
    - Hex value: `#F5835F`
    - Rationale: Logo colour from https://glimmerjs.com/ at time of writing
