### PR TITLE
Address CodeQL security alerts

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -301,7 +301,7 @@ module Linguist
 
       # Type 1 and Type 42 fonts converted to PostScript are stored as hex-encoded byte streams; these
       # streams are always preceded the `eexec` operator (if Type 1), or the `/sfnts` key (if Type 42).
-      return true if data =~ /(\n|\r\n|\r)\s*(?:currentfile eexec\s+|\/sfnts\s+\[\1<)\h{8,}\1/
+      return true if data =~ /^\s*(?:currentfile eexec\s+|\/sfnts\s+\[\s<)/
 
       # We analyze the "%%Creator:" comment, which contains the author/generator
       # of the file. If there is one, it should be in one of the first few lines.
@@ -693,8 +693,8 @@ module Linguist
     def generated_gimp?
       return false unless ['.c', '.h'].include? extname
       return false unless lines.count > 0
-      return lines[0].match(/\/\* GIMP [a-zA-Z0-9\- ]+ C\-Source image dump \(.+?\.c\) \*\//) ||
-             lines[0].match(/\/\*  GIMP header image file format \([a-zA-Z0-9\- ]+\)\: .+?\.h  \*\//)
+      return lines[0].match(/^\/\* GIMP [a-zA-Z0-9\- ]+ C\-Source image dump \(.+?\.c\) \*\//) ||
+             lines[0].match(/^\/\*  GIMP header image file format \([a-zA-Z0-9\- ]+\)\: .+?\.h  \*\//)
     end
 
     # Internal: Is this a generated Microsoft Visual Studio 6.0 build file?
@@ -795,7 +795,7 @@ module Linguist
       return false unless lines.count >= 5
       lines[0].match?(/^# typed:/) &&
       lines[2].include?("DO NOT EDIT MANUALLY") &&
-      lines[4].match?(/^# Please.*run.*`.*tapioca/)
+      lines[4].match?(/^# Please (run|instead update this file by running) `bin\/tapioca/)
     end
 
     # Internal: Is this an HTML coverage report?

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -28,7 +28,7 @@ class TestGenerated < Minitest::Test
       Generated.generated?(blob, lambda { raise DataLoadedError.new })
     end
     expected = !negate
-    actual = Generated.generated?(blob, lambda { IO.read(blob) })
+    actual = Generated.generated?(blob, lambda { File.read(blob) })
     assert(expected == !!actual, error_message(blob, negate))
   end
 

--- a/test/test_pedantic.rb
+++ b/test/test_pedantic.rb
@@ -46,13 +46,13 @@ class TestPedantic < Minitest::Test
 
   def test_heuristics_tests_are_sorted
     file = File.expand_path("../test_heuristics.rb", __FILE__)
-    tests = open(file).each.grep(/^ *def test_[0-9a-z_]+_by_heuristics/)
+    tests = File.open(file).each.grep(/^ *def test_[0-9a-z_]+_by_heuristics/)
     assert_sorted tests
   end
 
   def test_heuristics_tests_are_exhaustive
     file = File.expand_path("../test_heuristics.rb", __FILE__)
-    tests = open(file).each.grep(/^ *def test_[0-9a-z_]+_by_heuristics/)
+    tests = File.open(file).each.grep(/^ *def test_[0-9a-z_]+_by_heuristics/)
     tests = tests.map { |s| s.match(/test_(.*)_by_heuristic/).captures[0] }
 
     extensions = HEURISTICS['disambiguations'].map { |r| r['extensions'] }


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

CodeQL has been enabled on this repo and the analysis has revealed two issues repeated a few times that this PR addresses:

1. Polynomial regular expression used on uncontrolled data
2. Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value
