### PR TITLE
Add support for Java Template Engine

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -557,6 +557,9 @@
 [submodule "vendor/grammars/jflex.tmbundle"]
 	path = vendor/grammars/jflex.tmbundle
 	url = https://github.com/jflex-de/jflex.tmbundle.git
+[submodule "vendor/grammars/jte-template-syntax-highlight"]
+	path = vendor/grammars/jte-template-syntax-highlight
+	url = https://github.com/maj2c/jte-template-syntax-highlight.git
 [submodule "vendor/grammars/kivy-language-grammer"]
 	path = vendor/grammars/kivy-language-grammer
 	url = https://github.com/p0lygun/kivy-language-grammer.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -470,6 +470,8 @@ vendor/grammars/javascript-objective-j.tmbundle:
 - source.js.objj
 vendor/grammars/jflex.tmbundle:
 - source.jflex
+vendor/grammars/jte-template-syntax-highlight:
+- text.html.jte
 vendor/grammars/kivy-language-grammer:
 - source.python.kivy
 vendor/grammars/kusto-sublime:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3301,6 +3301,17 @@ Java Server Pages:
   codemirror_mode: htmlembedded
   codemirror_mime_type: application/x-jsp
   language_id: 182
+Java Template Engine:
+  type: programming
+  color: "#2A6277"
+  group: Java
+  aliases:
+  - jte
+  extensions:
+  - ".jte"
+  ace_mode: text
+  tm_scope: text.html.jte
+  language_id: 599494012
 JavaScript:
   type: programming
   tm_scope: source.js

--- a/samples/Java Template Engine/baseLayout.jte
+++ b/samples/Java Template Engine/baseLayout.jte
@@ -1,0 +1,81 @@
+@import static org.example.common.utils.JteHelper.*
+@import static org.example.global.ExampleConstants.*
+@import gg.jte.Content
+
+@param String pageTitle = null
+@param Content body
+
+!{pageTitle = pageTitle == null ? APP_NAME : pageTitle;}
+
+!{addCssFile("main");}
+!{addScriptFile("layout");}
+
+!{var renderedBody = preRenderContent(body);}
+<!DOCTYPE html>
+<html lang="${getLang()}" data-template="jte">
+<head>
+	<title>${pageTitle}</title>
+
+	<meta charset="utf-8"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+
+	<link rel="icon" href="${assetHelper().path("favicon.ico")}"/>
+	<link rel="stylesheet" href="${assetHelper().path("js/jquery-ui.css")}"/>
+
+	@for(var resource : assetHelper().bundle("globals").getAssets().getCss())
+    <link rel="stylesheet" href="${assetHelper().bundlePath(resource)}"/>
+	@endfor
+
+	<%--	Ensure our css files have precedence over global ones --%>
+	@for(var file : getCssFiles())
+		<link rel="stylesheet" href="${assetHelper().path("css/" + file + ".css")}" />
+	@endfor
+
+	@for(var file : getBundleFiles())
+		@for(var resource : assetHelper().bundle(file).getAssets().getCss())
+			<link rel="stylesheet" href="${assetHelper().bundlePath(resource)}"/>
+		@endfor
+	@endfor
+
+	@for(var style : getInlineStyles())
+		${style}
+	@endfor
+</head>
+<body>
+<script>
+	window.FTC_ENV = ${jsonEncode(ftcEnv())};
+</script>
+@for(var resource : assetHelper().bundle("sentry").getAssets().getJs())
+	<script src="${assetHelper().bundlePath(resource)}" type="module"></script>
+@endfor
+<script src="${assetHelper().path("translations/" + getLang() + ".js")}"></script>
+<script src="${assetHelper().path("js/jquery-1.12.4.js")}"></script>
+<script src="${assetHelper().path("js/jquery-ui.js")}"></script>
+<script src="${assetHelper().path("bootstrap/js/bootstrap.bundle.min.js")}"></script>
+<script src="${assetHelper().path("bootstrap/js/bootstrap-table.min.js")}"></script>
+<script src="${assetHelper().path("js/general.js")}"></script>
+@for(var resource : assetHelper().bundle("globals").getAssets().getJs())
+	<script src="${assetHelper().bundlePath(resource)}" type="module"></script>
+@endfor
+
+$unsafe{renderedBody}
+
+@for(var file : getScriptFiles())
+	<script src="${assetHelper().path("js/" + file + ".js")}"></script>
+@endfor
+@for(var file : getDeferScriptFiles())
+<%-- Defer to ensure it runs *after* globals have loaded --%>
+	<script src="${assetHelper().path("js/" + file + ".js")}" defer></script>
+@endfor
+
+@for(var script : getInlineScripts())
+	${script}
+@endfor
+
+@for(var file : getBundleFiles())
+	@for(var resource : assetHelper().bundle(file).getAssets().getJs())
+		<script src="${assetHelper().bundlePath(resource)}" type="module"></script>
+	@endfor
+@endfor
+</body>
+</html>

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -269,6 +269,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Java:** [tree-sitter/tree-sitter-java](https://github.com/tree-sitter/tree-sitter-java) 🐌
 - **Java Properties:** [textmate/java.tmbundle](https://github.com/textmate/java.tmbundle)
 - **Java Server Pages:** [textmate/java.tmbundle](https://github.com/textmate/java.tmbundle)
+- **Java Template Engine:** [maj2c/jte-template-syntax-highlight](https://github.com/maj2c/jte-template-syntax-highlight)
 - **JavaScript:** [tree-sitter/tree-sitter-javascript](https://github.com/tree-sitter/tree-sitter-javascript) 🐌
 - **JavaScript+ERB:** [atom/language-javascript](https://github.com/atom/language-javascript)
 - **Jest Snapshot:** [jest-community/vscode-jest](https://github.com/jest-community/vscode-jest)

--- a/vendor/licenses/git_submodule/jte-template-syntax-highlight.dep.yml
+++ b/vendor/licenses/git_submodule/jte-template-syntax-highlight.dep.yml
@@ -1,0 +1,200 @@
+---
+name: jte-template-syntax-highlight
+version: 32a99356e875c685496e66a0d47bde6a79f9cad9
+type: git_submodule
+homepage: https://github.com/maj2c/jte-template-syntax-highlight
+license: apache-2.0
+licenses:
+- sources: LICENSE.md
+  text: |2
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+
+       END OF TERMS AND CONDITIONS
+
+       Copyright 2022 Mansour Abou Jaoude
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+notices: []


### PR DESCRIPTION
## Description
This template adds support for [JTE](https://jte.gg/).  I expect this PR to immediate go into "Pending Popularity", but since I already prepared this PR before running the search, I might as well submit it so it is out there and if JTE ever actually gets popular enough it will be ready :)

## Checklist:

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  jte: https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.jte+%28%40param+OR+%40import%29
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - Originally taken from a private repo
    - Sample license:
      - Linguist MIT license (This was originally authored by me, and I hereby license it to linguist under the MIT license)
  - [x] I have included a syntax highlighting grammar: https://github.com/maj2c/jte-template-syntax-highlight
  - [x] I have added a color
    - Hex value: `#2A6277`
    - Rationale: Selected to match other java-related languages (e.g. JSP and Java Properties)
  - [n/a] I have updated the heuristics to distinguish my language from others using the same extension.