### PR TITLE
Fix group name casing: prolog -> Prolog

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1661,7 +1661,7 @@ ECL:
 ECLiPSe:
   type: programming
   color: "#001d9d"
-  group: prolog
+  group: Prolog
   extensions:
   - ".ecl"
   tm_scope: source.prolog.eclipse


### PR DESCRIPTION
## Description

There is a typo in a group name. The corresponding key name is `Prolog`.
https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml#L5362

## Checklist:

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

I don't know if this point applies ^.