### PR TITLE
Make max tree size configurable and throw when hit

### DIFF
--- a/lib/linguist/repository.rb
+++ b/lib/linguist/repository.rb
@@ -129,10 +129,9 @@ module Linguist
     end
 
     protected
-    MAX_TREE_SIZE = 100_000
 
-    def compute_stats(old_commit_oid, cache = nil)
-      return {} if current_tree.count_recursive(MAX_TREE_SIZE) >= MAX_TREE_SIZE
+    def compute_stats(old_commit_oid, cache = nil, max_tree_size = 100_000)
+      return {} if current_tree.count_recursive(max_tree_size) >= max_tree_size
 
       old_tree = old_commit_oid && Rugged::Commit.lookup(repository, old_commit_oid).tree
       read_index


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
The size of repositories we consider for analysis is currently hardcoded to 100k objects and returns an empty result without any reasoning.

This PR makes it configurable and throws an exception when this is hit.

This will need changes on the GitHub side of things to accommodate this change before this can be merged and deployed.

- Closes https://github.com/github-linguist/linguist/issues/6550

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.
