### PR TITLE
Add language definition for Uxntal.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1187,6 +1187,9 @@
 [submodule "vendor/grammars/typst-grammar"]
 	path = vendor/grammars/typst-grammar
 	url = https://github.com/michidk/typst-grammar.git
+[submodule "vendor/grammars/uxntal-vscode"]
+	path = vendor/grammars/uxntal-vscode
+	url = https://github.com/bellinitte/uxntal-vscode.git
 [submodule "vendor/grammars/verilog.tmbundle"]
 	path = vendor/grammars/verilog.tmbundle
 	url = https://github.com/textmate/verilog.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -1064,6 +1064,8 @@ vendor/grammars/turtle.tmbundle:
 - source.turtle
 vendor/grammars/typst-grammar:
 - source.typst
+vendor/grammars/uxntal-vscode:
+- source.tal
 vendor/grammars/verilog.tmbundle:
 - source.verilog
 vendor/grammars/vhdl:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7300,6 +7300,16 @@ UrWeb:
   tm_scope: source.ur
   ace_mode: text
   language_id: 383
+UxnTal:
+  type: programming
+  color: "#8dff9c"
+  aliases:
+  - uxn
+  - tal
+  extensions:
+  - ".tal"
+  tm_scope: source.tal
+  ace_mode: "text"
 V:
   type: programming
   color: "#4f87c4"

--- a/samples/Uxntal/mandelbrot.tal
+++ b/samples/Uxntal/mandelbrot.tal
@@ -1,0 +1,124 @@
+( mandelbrot.tal )
+( )
+( by alderwick and d_m )
+
+%WIDTH { #02a0 }
+%HEIGHT { #0200 }
+%XMIN { #de69 } ( -8601 )
+%XMAX { #0b33 } ( 2867 )
+%YMIN { #ecc7 } ( -4915 )
+%YMAX { #1333 } ( 4915 )
+
+|00 @System &vector $2 &wst $1 &rst $1 &eaddr $2 &ecode $1 &pad $1 &r $2 &g $2 &b $2 &debug $1 &halt $1
+|20 @Screen &vector $2 &width $2 &height $2 &auto $1 &pad $1 &x $2 &y $2 &addr $2 &pixel $1 &sprite $1
+
+|0100 ( -> )
+
+	( theme )
+	#0f0f .System/r DEO2
+	#0ff0 .System/g DEO2
+	#00ff .System/b DEO2
+
+	( size )
+	WIDTH  .Screen/width  DEO2
+	HEIGHT .Screen/height DEO2
+
+	( run )
+	draw-mandel
+	BRK
+
+( draw the mandelbrot set using 4.12 fixed point numbers )
+@draw-mandel ( -> )
+	XMAX XMIN SUB2 WIDTH DIV2 ,&dx STR2  ( ; &dx<-{xmax-min}/width )
+	YMAX YMIN SUB2 HEIGHT DIV2 ,&dy STR2 ( ; &dy<-{ymax-ymin}/height )
+	[ LIT2 01 -Screen/auto ] DEO         ( ; auto<-1 )
+	LIT2r 8000                           ( [8000] )
+	YMAX YMIN                            ( ymax* ymin* [8000] )
+	&yloop                               ( ymax* y* [8000] )
+		XMAX XMIN                        ( ymax* y* xmax* xmin* [8000] )
+		&xloop                           ( ymax* y* xmax* x* [8000] )
+			ROT2k evaluate               ( ymax* y* xmax* x* xmax* count^ [8000] )
+			.Screen/pixel DEO POP2       ( ymax* y* xmax* x* [8000] )
+			[ LIT2 &dx $2 ] ADD2         ( ymax* y* xmax* x+dx* [8000] )
+			OVR2 STH2kr ADD2             ( ymax* y* xmax* x+dx* 8000+xmax* [8000] )
+			OVR2 STH2kr ADD2             ( ymax* y* xmax* x+dx* 8000+xmax* 8000+x+dx* [8000] )
+			GTH2 ?&xloop                 ( ymax* y* xmax* x+dx* [8000] )
+		POP2 POP2                        ( ymax* y* [8000] )
+		#0000 .Screen/x DEO2             ( ymax* y* [8000] ; sc/x<-0 )
+		.Screen/y DEI2k                  ( ymax* y* d^ sy* [8000] )
+		INC2 ROT DEO2                    ( ymax* y* [8000] ; sc/y<-sy+1 )
+		[ LIT2 &dy $2 ] ADD2             ( ymax* y+dy* [8000] )
+		OVR2 STH2kr ADD2                 ( ymax* y+dy* 8000+ymax* [8000] )
+		OVR2 STH2kr ADD2                 ( ymax* y+dy* 8000+ymax* 8000+y+dy* [8000] )
+		GTH2 ?&yloop                     ( ymax* y+dy* [8000] )
+	POP2 POP2 POP2r JMP2r                ( )
+
+@evaluate ( x* y* -> count^ )
+	#0000 DUP2 ,&x1 STR2         ( x* y* ; x1<-0 )
+		  DUP2 ,&y1 STR2         ( x* y* ; y1<-0 )
+		  DUP2 ,&x2 STR2         ( x* y* ; x2<-0 )
+			   ,&y2 STR2         ( x* y* ; y2<-0 )
+	LIT2r 2000                   ( x* y* [20 00] )
+	&loop                        ( x* y* [20 n^] )
+		[ LIT2 &x1 $2 ]          ( x* y* x1* [20 n^] )
+		[ LIT2 &y1 $2 ]          ( x* y* x1* y1* [20 n^] )
+		smul2 DUP2 ADD2          ( x* y* 2x1y1* [20 n^] )
+		OVR2 ADD2 ,&y1 STR2      ( x* y* [20 n^] ; y1<-2x1y1+y* )
+		SWP2 [ LIT2 &x2 $2 ]     ( y* x* x2* [20 n^] )
+		[ LIT2 &y2 $2 ] SUB2     ( y* x* x2-y2* [20 n^] )
+		OVR2 ADD2 ,&x1 STR2 SWP2 ( x* y* [20 n^] ; x1<-x2-y2+x* )
+		,&x1 LDR2 square         ( x* y* x1^2* [20 n^] )
+		DUP2 ,&x2 STR2           ( x* y* x1^2* [20 n^] ; x2<-x1^2* )
+		,&y1 LDR2 square         ( x* y* x1^2* y1^2* [20 n^] )
+		DUP2 ,&y2 STR2           ( x* y* x1^2* y1^2* [20 n^] ; y2<-y1^2* )
+		ADD2 #4000 GTH2 ?&end    ( x* y* [20 n^] )
+		INCr GTHkr STHr ?&loop   ( x* y* [20 n+1*] )
+	&end                         ( x* y* [20 count^] )
+	POP2 POP2 NIPr STHr JMP2r    ( count^ )
+
+( multiply two signed 4.12 fixed point numbers )
+@smul2 ( a* b* -> ab* )
+	LIT2r 0001 DUP2 #8000 LTH2 ?&bpos negate SWPr ( a* |b|* [sign*] )
+	&bpos SWP2 DUP2 #8000 LTH2 ?&apos negate SWPr ( |b|* |a|* [sign*] )
+	&apos smul2-pos STHr ?&abpos negate           ( ab* [scrap^] )
+	&abpos POPr JMP2r                             ( ab* )
+
+( multiply two non-negative fixed point numbers )
+( )
+( a * b = {a0/16 + a1/4096} * {b0/16 + b1/4096} )
+(       = a0b0/256 + a1b0/65536 + a0b1/65536 + a1b1/16777216 )
+(       = x + y + z + 0 ; the last term is too small to represent, i.e. zero )
+( )
+( x = a0b0 << 4 )
+( y = a1b0 >> 4 )
+( z = a0b1 >> 4 )
+@smul2-pos ( a* b* -> ab* )
+	aerate ROT2 aerate           ( b0* b1* a0* a1* )
+	STH2 ROT2k                   ( b0* b1* a0* b1* a0* b0* [a1*] )
+	STH2 MUL2r                   ( b0* b1* a0* b1* a0* [a1b0*] )
+	MUL2 STH2 ADD2r              ( b0* b1* a0* [a1b0+a0b1*] )
+	NIP2 MUL2 #07ff min #40 SFT2 ( a0b0* [y+z*] )
+	STH2r #04 SFT2 ADD2          ( x* [y+z*] )
+	#7fff !min                   ( ab* )
+
+( equivalent to DUP2 smul2 but faster )
+@square ( a* -> aa* )
+	DUP2 #8000 LTH2 ?&pos negate &pos
+
+( >> )
+
+( equivalent to DUP2 smul2-pos but faster )
+@square-pos ( a* -> aa* )
+	aerate                       ( 00 ahi^ 00 alo^ )
+	OVR2 MUL2 #03 SFT2 SWP2      ( yz* ahi* )
+	DUP2 MUL2 #07ff min #40 SFT2 ( x* yz* )
+	ADD2 #7fff !min              ( aa* )
+
+( convert each byte of a a short into a short )
+@aerate ( x* -> 00 xhi^ 00 xlo^ ) SWP #0000 ROT SWP2 SWP JMP2r
+
+( negate a fixed point number. doesn't work for #8000 )
+@negate ( x* -> -x* ) DUP2k EOR2 SWP2 SUB2 JMP2r
+
+( return the minimum of two non-negative numbers. )
+@min ( x* y* ) GTH2k [ JMP SWP2 ] NIP2 JMP2r

--- a/samples/Uxntal/piano.tal
+++ b/samples/Uxntal/piano.tal
@@ -1,0 +1,560 @@
+( Piano:
+	Play notes with the keyboard or the controller )
+
+|00 @System &vector $2 &wst $1 &rst $1 &pad $4 &r $2 &g $2 &b $2 &debug $1 &halt $1
+|10 @Console &vector $2 &read $1 &pad $5 &write $1 &error $1
+|20 @Screen &vector $2 &width $2 &height $2 &auto $1 &pad $1 &x $2 &y $2 &addr $2 &pixel $1 &sprite $1
+|30 @Audio0 &vector $2 &position $2 &output $1 &pad $3 &adsr $2 &length $2 &addr $2 &volume $1 &pitch $1
+|40 @Audio1 &vector $2 &position $2 &output $1 &pad $3 &adsr $2 &length $2 &addr $2 &volume $1 &pitch $1
+|80 @Controller &vector $2 &button $1 &key $1
+|90 @Mouse &vector $2 &x $2 &y $2 &state $1 &pad $3 &modx $2 &mody $2
+
+|0000
+
+	@octave $1
+	@center &x $2 &y $2
+	@adsr-view &x1 $2 &y1 $2 &x2 $2 &y2 $2
+	@wave-view &x1 $2 &y1 $2 &x2 $2 &y2 $2
+	@octave-view &x1 $2 &y1 $2 &x2 $2 &y2 $2
+
+|0100 ( -> )
+
+	( theme )
+	#0fe3 .System/r DEO2
+	#0fc3 .System/g DEO2
+	#0f23 .System/b DEO2
+	( resize )
+	#0180 .Screen/width DEO2
+	#00e0 .Screen/height DEO2
+	( find center )
+	.Screen/width DEI2 #01 SFT2
+		DUP2 .center/x STZ2
+		#0080 SUB2
+		DUP2 .octave-view/x1 STZ2
+			#0050 ADD2 .octave-view/x2 STZ2
+	.Screen/height DEI2 #01 SFT2 #0010 ADD2
+		DUP2 .center/y STZ2
+		#0010 ADD2
+		DUP2 .octave-view/y1 STZ2
+			#0018 ADD2 .octave-view/y2 STZ2
+	( place adsr )
+	.center/x LDZ2 #0020 SUB2 .adsr-view/x1 STZ2
+	.center/y LDZ2 #0010 ADD2 .adsr-view/y1 STZ2
+	.adsr-view/x1 LDZ2 #00a0 ADD2 .adsr-view/x2 STZ2
+	.adsr-view/y1 LDZ2 #0018 ADD2 .adsr-view/y2 STZ2
+	( place waveform )
+	.center/x LDZ2 #0080 SUB2 .wave-view/x1 STZ2
+	.center/y LDZ2 #0040 SUB2 .wave-view/y1 STZ2
+	.wave-view/x1 LDZ2 #0100 ADD2 .wave-view/x2 STZ2
+	.wave-view/y1 LDZ2 #0040 ADD2 .wave-view/y2 STZ2
+	( setup synth )
+	#041c set-env
+	#dd set-vol
+	;sin-pcm .Audio0/addr DEO2
+	;sin-pcm .Audio1/addr DEO2
+	#0100
+		DUP2 .Audio0/length DEO2
+		.Audio1/length DEO2
+	( inital drawing )
+	draw-octave
+	draw-adsr
+	draw-wave
+	( unlock )
+	;on-frame .Screen/vector DEO2
+	;on-control .Controller/vector DEO2
+	;on-mouse .Mouse/vector DEO2
+	;on-message .Console/vector DEO2
+
+BRK
+
+(
+@|vectors )
+
+@on-frame ( -> )
+
+	.Mouse/state DEI ?&skip-sft
+	[ LIT2 00 &soft $1 ] EQUk ?&no-soft
+		soften
+		DUP #01 SUB ,&soft STR
+		&no-soft
+	POP2
+	&skip-sft
+
+	[ LIT &last $1 ] .Audio0/output DEI NEQk ?&changed
+		POP2 BRK
+		&changed
+	,&last STR POP
+
+	( redraw )
+	[ LIT2 00 -Screen/auto ] DEO
+	.adsr-view/y2 LDZ2 #0020 SUB2 .Screen/y DEO2
+	#1000
+	&loop
+		.adsr-view/x2 LDZ2 #003a SUB2 .Screen/x DEO2
+		( left )
+		#10 OVR SUB
+		#00 .Audio0/output DEI
+		#00 .Audio0/volume DEI #04 SFT 
+			MUL2 #08 SFT2 NIP LTH .Screen/pixel DEO
+		.Screen/x DEI2k INC2 INC2 ROT DEO2
+		( right )
+		#10 OVR SUB
+		#00 .Audio0/output DEI
+		#00 .Audio0/volume DEI #0f AND 
+			MUL2 #08 SFT2 NIP LTH .Screen/pixel DEO
+		.Screen/y DEI2k INC2 INC2 ROT DEO2
+		INC GTHk ?&loop
+	POP2
+
+BRK
+
+@on-control ( -> )
+
+	.Controller/key DEI
+	( octave )
+	[ LIT "a ] NEQk NIP ?&no-c #30 .octave LDZ #0c MUL ADD play &no-c
+	[ LIT "w ] NEQk NIP ?&no-c# #31 .octave LDZ #0c MUL ADD play &no-c#
+	[ LIT "s ] NEQk NIP ?&no-d #32 .octave LDZ #0c MUL ADD play &no-d
+	[ LIT "e ] NEQk NIP ?&no-d# #33 .octave LDZ #0c MUL ADD play &no-d#
+	[ LIT "d ] NEQk NIP ?&no-e #34 .octave LDZ #0c MUL ADD play &no-e
+	[ LIT "f ] NEQk NIP ?&no-f #35 .octave LDZ #0c MUL ADD play &no-f
+	[ LIT "t ] NEQk NIP ?&no-f# #36 .octave LDZ #0c MUL ADD play &no-f#
+	[ LIT "g ] NEQk NIP ?&no-g #37 .octave LDZ #0c MUL ADD play &no-g
+	[ LIT "y ] NEQk NIP ?&no-g# #38 .octave LDZ #0c MUL ADD play &no-g#
+	[ LIT "h ] NEQk NIP ?&no-a #39 .octave LDZ #0c MUL ADD play &no-a
+	[ LIT "u ] NEQk NIP ?&no-a# #3a .octave LDZ #0c MUL ADD play &no-a#
+	[ LIT "j ] NEQk NIP ?&no-b #3b .octave LDZ #0c MUL ADD play &no-b
+	[ LIT "k ] NEQk NIP ?&no-c2 #3c .octave LDZ #0c MUL ADD play &no-c2
+	( controls )
+	[ LIT "z ] NEQk NIP ?&no-dec .octave LDZk #01 SUB SWP STZ &no-dec
+	[ LIT "x ] NEQk NIP ?&no-inc .octave LDZk INC SWP STZ &no-inc
+	[ #1b ] NEQk NIP ?&no-esc #010f DEO &no-esc
+	POP
+
+	( release )
+	#00 .Controller/key DEO
+
+	.Controller/button DEI
+	[ #11 ] NEQk NIP ?&cu #3c play &cu
+	[ #21 ] NEQk NIP ?&cd #3d play &cd
+	[ #41 ] NEQk NIP ?&cl #3e play &cl
+	[ #81 ] NEQk NIP ?&cr #3f play &cr
+	[ #12 ] NEQk NIP ?&au #40 play &au
+	[ #22 ] NEQk NIP ?&ad #41 play &ad
+	[ #42 ] NEQk NIP ?&al #42 play &al
+	[ #82 ] NEQk NIP ?&ar #43 play &ar
+	[ #14 ] NEQk NIP ?&su #44 play &su
+	[ #24 ] NEQk NIP ?&sd #45 play &sd
+	[ #44 ] NEQk NIP ?&sl #46 play &sl
+	[ #84 ] NEQk NIP ?&sr #47 play &sr
+	POP
+
+	draw-octave
+
+BRK
+
+@on-message ( -> )
+
+	.Console/read DEI play
+	draw-octave
+
+BRK
+
+@on-mouse ( -> )
+
+	#00 .Mouse/state DEI NEQ #41 ADD ;cursor-icn update-cursor
+
+	.Mouse/state DEI ?on-mouse-touch
+
+BRK
+
+@on-mouse-touch ( -> )
+
+	.Mouse/x DEI2 .Mouse/y DEI2 .wave-view within-rect
+		?on-touch-wave-view
+	.Mouse/x DEI2 .Mouse/y DEI2 .adsr-view within-rect
+		?on-touch-knobs-view
+	.Mouse/x DEI2 .Mouse/y DEI2 .octave-view within-rect
+		?on-touch-octave-view
+
+BRK
+
+@on-touch-wave-view ( -> )
+
+	.Mouse/state DEI #01 GTH ?&paint
+	.Mouse/x DEI2 .wave-view/x1 LDZ2 SUB2
+		( min ) #0010 GTH2k [ JMP SWP2 POP2 ] set-length
+
+BRK
+
+&paint ( -> )
+
+	.Mouse/y DEI2 .wave-view/y1 LDZ2 SUB2 #20 SFT2 NIP
+	.Mouse/x DEI2 .wave-view/x1 LDZ2 SUB2 ;sin-pcm ADD2 STA
+	draw-wave
+	#10 ;on-frame/soft STA
+
+BRK
+
+@on-touch-octave-view ( -> )
+
+	.Mouse/x DEI2 .octave-view/x1 LDZ2 SUB2 #03 SFT2 NIP #09 NEQ ?&no-mod
+		.Mouse/y DEI2 .octave-view/y1 LDZ2 SUB2 #03 SFT2 NIP
+		[ #00 ] NEQk NIP ?&no-incr
+			.octave LDZ #03 EQU ?&no-incr
+			.octave LDZ INC .octave STZ &no-incr
+		[ #02 ] NEQk NIP ?&no-decr
+			.octave LDZ #ff EQU ?&no-decr
+			.octave LDZ #01 SUB .octave STZ &no-decr
+		POP
+		( release ) #00 .Mouse/state DEO
+		draw-octave
+		BRK
+	&no-mod
+
+	.Mouse/x DEI2 .octave-view/x1 LDZ2 SUB2 #03 SFT2 NIP #06 GTH ?&no-key
+		.Mouse/x DEI2 .octave-view/x1 LDZ2 SUB2 #03 SFT2 ;notes-lut ADD2 LDA .octave LDZ #0c MUL ADD play
+		( release ) #00 .Mouse/state DEO
+		draw-octave
+	&no-key
+
+BRK
+
+@on-touch-knobs-view ( -> )
+
+	.Mouse/x DEI2 .adsr-view/x1 LDZ2 SUB2 #03 SFT2 NIP #03 DIV
+	.Mouse/y DEI2 .adsr-view/y1 LDZ2 SUB2 NIP
+	OVR #04 LTH ?on-touch-adsr
+	OVR #04 GTH ?on-touch-vol
+	POP2
+
+BRK
+
+@on-touch-adsr ( knob value -> )
+
+	STH2
+	( mask ) #ffff #000f #03 OVRr STHr SUB #60 SFT SFT2 EOR2
+		.Audio0/adsr DEI2 AND2
+	( value ) #000f STHr OVR LTHk [ JMP SWP POP ] SUB
+	( shift ) #03 STHr SUB #60 SFT SFT2 ORA2
+	set-env
+
+BRK
+
+@on-touch-vol ( knob value -> )
+
+	SWP #03 SUB INC INC SWP STH2
+	( mask ) #0f OVRr STHr #60 SFT SFT
+		.Audio0/volume DEI AND
+	( value ) #0f STHr OVR LTHk [ JMP SWP POP ] SUB
+	( shift ) #01 STHr SUB #60 SFT SFT ORA
+	set-vol
+
+BRK
+
+(
+@|core )
+
+@play ( pitch -- )
+
+	DUP #0c DIVk MUL SUB ;draw-octave/last STA
+	DUP .Audio0/pitch DEO
+		#0c SUB .Audio1/pitch DEO
+
+JMP2r
+
+@set-length ( length* -- )
+
+	DUP2 .Audio0/length DEO2
+		.Audio1/length DEO2
+
+!draw-wave
+
+@set-vol ( vol -- )
+
+	DUP .Audio0/volume DEO
+		.Audio1/volume DEO
+
+!draw-adsr
+
+@set-env ( adsr* -- )
+
+	DUP2 .Audio0/adsr DEO2
+		.Audio1/adsr DEO2
+
+!draw-adsr
+
+@soften ( -- )
+
+	#0100 #0000
+	&l
+		DUP2 ;sin-pcm ADD2 get-average SWP2 STA POP
+		INC2 GTH2k ?&l
+	POP2 POP2
+	draw-wave
+
+JMP2r
+
+@get-average ( addr* -- addr* average* )
+
+	[ LIT2r 0000 ]
+	DUP2 #0001 SUB2 DUP2 #0002 ADD2 SWP2
+	&l
+		LDAk LITr 00 STH ADD2r
+		INC2 GTH2k ?&l
+	POP2 POP2
+	LDAk #00 SWP DUP2 DUP2 STH2r
+	#01 SFT2 ADD2 ADD2 ADD2 #02 SFT2
+
+JMP2r
+
+(
+@|drawing )
+
+@update-cursor ( color addr* -- )
+
+	[ LIT2 00 -Screen/auto ] DEO
+	.Screen/addr DEO2
+	#40 draw-cursor
+	.Mouse/x DEI2 ,draw-cursor/x STR2
+	.Mouse/y DEI2 ,draw-cursor/y STR2
+
+@draw-cursor ( color -- )
+
+	[ LIT2 &x $2 ] .Screen/x DEO2
+	[ LIT2 &y $2 ] .Screen/y DEO2
+	.Screen/sprite DEO
+
+JMP2r
+
+@draw-octave ( -- )
+
+	( arrows )
+	[ LIT2 02 -Screen/auto ] DEO
+	.octave-view/x1 LDZ2 #0048 ADD2 .Screen/x DEO2
+	.octave-view/y1 LDZ2 .Screen/y DEO2
+	;arrow-icns .Screen/addr DEO2
+	[ LIT2 01 -Screen/sprite ] DEO
+	;font-hex .octave LDZ #03 ADD #00 SWP #30 SFT2 ADD2 .Screen/addr DEO2
+	[ LIT2 02 -Screen/sprite ] DEO
+	;arrow-icns/down .Screen/addr DEO2
+	[ LIT2 01 -Screen/sprite ] DEO
+	( octave )
+	.octave-view/x1 LDZ2 .Screen/x DEO2
+	.octave-view/y1 LDZ2 .Screen/y DEO2
+	[ LIT2 06 -Screen/auto ] DEO
+	[ LITr &last ff ]
+	;keys-left-icns STHkr #00 EQU INC draw-key
+	;keys-middle-icns STHkr #02 EQU INC draw-key
+	;keys-right-icns STHkr #04 EQU INC draw-key
+	;keys-left-icns STHkr #05 EQU INC draw-key
+	;keys-middle-icns STHkr #07 EQU INC draw-key
+	;keys-middle-icns STHkr #09 EQU INC draw-key
+	;keys-right-icns STHr #0b EQU INC
+
+( >> )
+
+@draw-key ( addr* color -- )
+
+	STH
+	.Screen/addr DEO2
+	.Screen/y DEI2
+	STHr .Screen/sprite DEOk DEOk DEO
+	.Screen/x DEI2k #0008 ADD2 ROT DEO2
+	.Screen/y DEO2
+
+JMP2r
+
+@draw-adsr ( -- )
+
+	( adsr )
+	.adsr-view/x1 LDZ2 .adsr-view/y1 LDZ2
+		.Audio0/adsr DEI #04 SFT draw-knob
+	.adsr-view/x1 LDZ2 #0018 ADD2 .adsr-view/y1 LDZ2
+		.Audio0/adsr DEI #0f AND draw-knob
+	.adsr-view/x1 LDZ2 #0030 ADD2 .adsr-view/y1 LDZ2
+		.Audio0/adsr INC DEI #04 SFT draw-knob
+	.adsr-view/x1 LDZ2 #0048 ADD2 .adsr-view/y1 LDZ2
+		.Audio0/adsr INC DEI #0f AND draw-knob
+	( volume )
+	.adsr-view/x2 LDZ2 #0028 SUB2 .adsr-view/y1 LDZ2
+		.Audio0/volume DEI #04 SFT draw-knob
+	.adsr-view/x2 LDZ2 #0010 SUB2 .adsr-view/y1 LDZ2
+		.Audio0/volume DEI #0f AND
+
+!draw-knob
+
+@draw-wave ( -- )
+
+	( background )
+	.wave-view/x1 LDZ2 .Screen/x DEO2
+	.wave-view/y1 LDZ2 .Screen/y DEO2
+	;fill-icn .Screen/addr DEO2
+	[ LIT2 75 -Screen/auto ] DEO
+	#e0 &lbg
+		;dotted-icn .Screen/addr DEO2
+		[ LIT2 0c -Screen/sprite ] DEO
+		INC DUP ?&lbg
+	POP
+	.wave-view/x1 LDZ2 .Screen/x DEO2
+	( waveform )
+	[ LIT2 01 -Screen/auto ] DEO
+	;sin-pcm/end ;sin-pcm
+	&loop
+		DUP2 ;sin-pcm SUB2 .Audio0/length DEI2 DIV2k MUL2 SUB2 ;sin-pcm ADD2 LDA
+		#00 SWP #02 SFT2 .wave-view/y1 LDZ2 ADD2 .Screen/y DEO2
+		( draw ) DUP2 ;sin-pcm SUB2 NIP .Audio0/length DEI2 NIP #01 SUB GTH INC .Screen/pixel DEO
+		INC2 GTH2k ?&loop
+	POP2 POP2
+	( length line )
+	.wave-view/x1 LDZ2 .Audio0/length DEI2 #0001 SUB2 ADD2 .Screen/x DEO2
+	.wave-view/y1 LDZ2 .Screen/y DEO2
+	;line-icn .Screen/addr DEO2
+	[ LIT2 71 -Screen/auto ] DEO
+	[ LIT2 05 -Screen/sprite ] DEO
+	( range )
+	[ LIT2 01 -Screen/auto ] DEO
+	.wave-view/x1 LDZ2 .Screen/x DEO2
+	.wave-view/y1 LDZ2 #0018 SUB2 .Screen/y DEO2
+	.Audio0/length DEI2
+
+!draw-short
+
+@draw-knob ( x* y* value -- )
+
+	STH
+	OVR2 OVR2 .Screen/y DEO2 .Screen/x DEO2
+	( circle )
+	;knob-icns .Screen/addr DEO2
+	[ LIT2 16 -Screen/auto ] DEO
+	[ LIT2 01 -Screen/sprite ] DEOk DEO
+	( value )
+	#0010 ADD2 .Screen/y DEO2
+	#0004 ADD2 .Screen/x DEO2
+	;font-hex #00 STHkr #30 SFT ADD2 .Screen/addr DEO2
+	[ LIT2 00 -Screen/auto ] DEO
+	[ LIT2 01 -Screen/sprite ] DEO
+	( marker )
+	.Screen/x DEI2 #0004 SUB2 #0000 STHkr ;knob-offsetx ADD2 LDA ADD2 .Screen/x DEO2
+	.Screen/y DEI2 #0010 SUB2 #0000 STHr ;knob-offsety ADD2 LDA ADD2 .Screen/y DEO2
+	;knob-icns/index .Screen/addr DEO2
+	[ LIT2 05 -Screen/sprite ] DEO
+
+JMP2r
+
+@draw-short ( short* -- )
+
+	SWP draw-byte
+
+@draw-byte ( byte -- )
+
+	DUP #04 SFT draw-hex #0f AND
+
+@draw-hex ( char -- )
+
+	#00 SWP #30 SFT2 ;font-hex ADD2 .Screen/addr DEO2
+	[ LIT2 02 -Screen/sprite ] DEO
+
+JMP2r
+
+@within-rect ( x* y* rect -- flag )
+
+	STH
+	( y < rect.y1 ) DUP2 STHkr INC INC LDZ2 LTH2 ?&skip
+	( y > rect.y2 ) DUP2 STHkr #06 ADD LDZ2 GTH2 ?&skip
+	SWP2
+	( x < rect.x1 ) DUP2 STHkr LDZ2 LTH2 ?&skip
+	( x > rect.x2 ) DUP2 STHkr #04 ADD LDZ2 GTH2 ?&skip
+	POP2 POP2 POPr
+	#01
+JMP2r
+	&skip
+	POP2 POP2 POPr
+	#00
+
+JMP2r
+
+@phex ( short* -- ) SWP phex/b &b DUP #04 SFT phex/c &c #0f AND DUP #09 GTH #27 MUL ADD #30 ADD #18 DEO JMP2r
+
+(
+@|assets )
+
+@notes-lut [
+	30 32 34 35 37 39 3b 3c ]
+
+@dotted-icn [
+	0000 0000 0000 0000
+	0000 0000 0000 0000
+	0000 0000 0000 0000
+	0000 0000 0000 0000
+	aa00 0000 0000 0000
+	0000 0000 0000 0000
+	0000 0000 0000 0000
+	0000 0000 0000 0000 ]
+@line-icn [
+	8080 8080 8080 8080
+	]
+@fill-icn [
+	ffff ffff ffff ffff ]
+@cursor-icn [
+	80c0 e0f0 f8e0 1000 ]
+@arrow-icns [
+	0010 387c fe10 1000
+&down
+	0010 1010 fe7c 3810 ]
+@keys-left-icns [
+	7c7c 7c7c 7c7c 7c7c
+	7c7c 7c7c 7c7c 7e7f
+	7f7f 7f7f 7f7f 3e00 ]
+@keys-middle-icns [
+	1c1c 1c1c 1c1c 1c1c
+	1c1c 1c1c 1c1c 3e7f
+	7f7f 7f7f 7f7f 3e00 ]
+@keys-right-icns [
+	1f1f 1f1f 1f1f 1f1f
+	1f1f 1f1f 1f1f 3f7f
+	7f7f 7f7f 7f7f 3e00 ]
+@knob-icns [
+	0003 0c10 2020 4040
+	00c0 3008 0404 0202
+	4040 2020 100c 0300
+	0202 0404 0830 c000
+	&index
+	0000 183c 3c18 0000 ]
+@knob-offsetx [
+	01 00 00 00 00 01 02 03
+	05 06 07 08 08 08 08 07 ]
+@knob-offsety [
+	07 06 05 03 02 01 00 00
+	00 00 01 02 03 05 06 07 ]
+@font-hex [
+	007c 8282 8282 827c 0030 1010 1010 1010
+	007c 8202 7c80 80fe 007c 8202 1c02 827c
+	000c 1424 4484 fe04 00fe 8080 7c02 827c
+	007c 8280 fc82 827c 007c 8202 1e02 0202
+	007c 8282 7c82 827c 007c 8282 7e02 827c
+	007c 8202 7e82 827e 00fc 8282 fc82 82fc
+	007c 8280 8080 827c 00fc 8282 8282 82fc
+	007c 8280 f080 827c 007c 8280 f080 8080 ]
+
+( pad ) [ 8080 8080 ]
+@sin-pcm [
+	8083 8689 8c8f 9295 989b 9ea1 a4a7 aaad
+	b0b3 b6b9 bbbe c1c3 c6c9 cbce d0d2 d5d7
+	d9db dee0 e2e4 e6e7 e9eb ecee f0f1 f2f4
+	f5f6 f7f8 f9fa fbfb fcfd fdfe fefe fefe
+	fffe fefe fefe fdfd fcfb fbfa f9f8 f7f6
+	f5f4 f2f1 f0ee eceb e9e7 e6e4 e2e0 dedb
+	d9d7 d5d2 d0ce cbc9 c6c3 c1be bbb9 b6b3
+	b0ad aaa7 a4a1 9e9b 9895 928f 8c89 8683
+	807d 7a77 7471 6e6b 6865 625f 5c59 5653
+	504d 4a47 4542 3f3d 3a37 3532 302e 2b29
+	2725 2220 1e1c 1a19 1715 1412 100f 0e0c
+	0b0a 0908 0706 0505 0403 0302 0202 0202
+	0102 0202 0202 0303 0405 0506 0708 090a
+	0b0c 0e0f 1012 1415 1719 1a1c 1e20 2225
+	2729 2b2e 3032 3537 3a3d 3f42 4547 4a4d
+	5053 5659 5c5f 6265 686b 6e71 7477 7a7d ]
+	&end
+( pad ) [ 8080 8080 ]
+

--- a/vendor/licenses/git_submodule/uxntal-vscode.dep.yml
+++ b/vendor/licenses/git_submodule/uxntal-vscode.dep.yml
@@ -1,0 +1,36 @@
+---
+name: uxntal-vscode
+version: 81112c2d78a0206182866a6157cab37ebde58cf1
+type: git_submodule
+homepage: https://github.com/bellinitte/uxntal-vscode.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2021 Karol Belina
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+- sources: README.md
+  text: |-
+    This software is licensed under the MIT license.
+
+    See the [LICENSE](LICENSE) file for more details.
+notices: []


### PR DESCRIPTION
Add language definition for Uxntal.

## Description

[Uxntal](https://wiki.xxiivv.com/site/uxntal.html) is an assembly language for the [Varvara](https://wiki.xxiivv.com/site/varvara.html) virtual machine.

Uxntal assmebly is compiled into ROMs. Emulators to run these ROMs exist for a [wide variety of hardware](https://github.com/hundredrabbits/awesome-uxn#emulators).

Using various search terms I get the following picture of Uxntal's popularity:

 - Searching for "uxn" I find [268 repos](https://github.com/search?q=uxn&type=repositories)
 - Searching for "varvara" I find [208 repos](https://github.com/search?q=varvara&type=repositories)
 - Searching for "*.tal" files I find [1k files](https://github.com/search?q=path%3A*.tal&type=code)

Given that most projects consist of 1-3 .tal files I believe this meets the criteria for inclusion. Uxn has also been [written about in the press](https://www.theverge.com/22935074/hundred-rabbits-uxn-roms-preservation).

The samples are MIT-licensed programs taken from the main project:

 - [mandelbrot.tal](https://git.sr.ht/~rabbits/uxn/tree/main/item/projects/examples/demos/mandelbrot.tal)
 - [piano.tal](https://git.sr.ht/~rabbits/uxn/tree/main/item/projects/software/piano.tal)

## Checklist:

- [X] **I am adding a new extension to a language.**
  - [X] The new extension is used in hundreds of repositories on GitHub.com
    - I described the methodolgy I 
  - [X] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
       - [mandelbrot.tal](https://git.sr.ht/~rabbits/uxn/tree/main/item/projects/examples/demos/mandelbrot.tal)
       - [piano.tal](https://git.sr.ht/~rabbits/uxn/tree/main/item/projects/software/piano.tal)
    - Sample license(s):
           - MIT
           - MIT
  - [X] I have included a syntax highlighting grammar: https://github.com/bellinitte/uxntal-vscode
  - [X] I have added a color
    - Hex value: `#8dff9c`
    - Rationale: This green seems to match that used on Uxn pages, e.g. https://wiki.xxiivv.com/site/varvara.html