### PR TITLE
Add `.bicepparam` to list of Bicep file extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -573,6 +573,7 @@ Bicep:
   color: "#519aba"
   extensions:
   - ".bicep"
+  - ".bicepparam"
   tm_scope: source.bicep
   ace_mode: text
   language_id: 321200902

--- a/samples/Bicep/params.bicepparam
+++ b/samples/Bicep/params.bicepparam
@@ -1,0 +1,36 @@
+/*
+This is a
+multiline comment!
+*/
+
+// This is a single line comment
+
+// using keyword for specifying a Bicep file
+using './params_main.bicep'
+
+// parameter assignment to literals
+param myString = 'hello world!!'
+param myInt = 42
+param myBool = true
+
+// parameter assignment to objects
+param password = 'strongPassword'
+param secretObject = {
+  name : 'vm2'
+  location : 'westus'
+}
+param storageSku = 'Standard_LRS'
+param storageName = 'myStorage'
+param someArray = [
+  'a'
+  'b'
+  'c'
+  'd'
+]
+param emptyMetadata = 'empty!'
+param description = 'descriptive description'
+param description2 = 'also descriptive'
+param additionalMetadata = 'more metadata'
+param someParameter = 'three'
+param stringLiteral = 'abc'
+param decoratedString = 'Apple'

--- a/samples/Bicep/params.bicepparam
+++ b/samples/Bicep/params.bicepparam
@@ -1,36 +1,25 @@
-/*
-This is a
-multiline comment!
-*/
+using 'br/public:ai/cognitiveservices:1.1.1'
 
-// This is a single line comment
+var suffix = 'ac9h8d'
 
-// using keyword for specifying a Bicep file
-using './params_main.bicep'
-
-// parameter assignment to literals
-param myString = 'hello world!!'
-param myInt = 42
-param myBool = true
-
-// parameter assignment to objects
-param password = 'strongPassword'
-param secretObject = {
-  name : 'vm2'
-  location : 'westus'
-}
-param storageSku = 'Standard_LRS'
-param storageName = 'myStorage'
-param someArray = [
-  'a'
-  'b'
-  'c'
-  'd'
+param skuName = 'S0'
+param kind = 'OpenAI'
+param name = 'openai-${suffix}'
+param location = 'westus2'
+param deployments = [
+  {
+    name: 'model-deployment-${suffix}'
+    sku: {
+      name: 'Standard'
+      capacity: 120
+    }
+    properties: {
+      model: {
+        format: 'OpenAI'
+        name: 'text-davinci-002'
+        version: 1
+      }
+      raiPolicyName: 'Microsoft.Default'
+    }
+  }
 ]
-param emptyMetadata = 'empty!'
-param description = 'descriptive description'
-param description2 = 'also descriptive'
-param additionalMetadata = 'more metadata'
-param someParameter = 'three'
-param stringLiteral = 'abc'
-param decoratedString = 'Apple'


### PR DESCRIPTION
Add `.bicepparam` to list of Bicep file extensions

## Description
We added the `.bicepparam` file extension to the Bicep language some time back, and have been keeping our textmate grammar updated with changes for it. It would be great to have GitHub highlighting enabled for it.

## Checklist:
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.bicepparam
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/Azure/bicep/blob/main/src/monarch/test/baselines/params.bicepparam
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.