### PR TITLE
Add BitBake grammar and missing extensions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1205,6 +1205,9 @@
 [submodule "vendor/grammars/vscode-antlers-language-server"]
 	path = vendor/grammars/vscode-antlers-language-server
 	url = https://github.com/Stillat/vscode-antlers-language-server.git
+[submodule "vendor/grammars/vscode-bitbake"]
+	path = vendor/grammars/vscode-bitbake
+	url = https://github.com/yoctoproject/vscode-bitbake.git
 [submodule "vendor/grammars/vscode-brightscript-language"]
 	path = vendor/grammars/vscode-brightscript-language
 	url = https://github.com/rokucommunity/vscode-brightscript-language.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1081,6 +1081,8 @@ vendor/grammars/vscode-TalonScript:
 - source.talon
 vendor/grammars/vscode-antlers-language-server:
 - text.html.statamic
+vendor/grammars/vscode-bitbake:
+- source.bb
 vendor/grammars/vscode-brightscript-language:
 - source.brs
 vendor/grammars/vscode-cadence:

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -103,7 +103,7 @@ disambiguations:
   - language: BlitzBasic
     pattern: '(<^\s*; |End Function)'
   - language: BitBake
-    pattern: '^\s*(# |include|require)\b'
+    pattern: '^(# |include|require|inherit)\b'
   - language: Clojure
     pattern: '\((def|defn|defmacro|let)\s'
 - extensions: ['.bf']
@@ -371,6 +371,8 @@ disambiguations:
     pattern:
     - '(?i:^\s*\{\$(?:mode|ifdef|undef|define)[ ]+[a-z0-9_]+\})'
     - '^\s*end[.;]\s*$'
+  - language: BitBake
+    pattern: '^inherit(\s+[\w.-]+)+\s*$'
 - extensions: ['.json']
   rules:
   - language: OASv2-json

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -598,7 +598,7 @@ Bison:
 BitBake:
   type: programming
   color: "#00bce4"
-  tm_scope: none
+  tm_scope: source.bb
   extensions:
   - ".bb"
   ace_mode: text

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -601,6 +601,9 @@ BitBake:
   tm_scope: source.bb
   extensions:
   - ".bb"
+  - ".bbappend"
+  - ".bbclass"
+  - ".inc"
   ace_mode: text
   language_id: 32
 Blade:

--- a/samples/BitBake/cmake.bbclass
+++ b/samples/BitBake/cmake.bbclass
@@ -1,0 +1,233 @@
+#
+# Copyright OpenEmbedded Contributors
+#
+# SPDX-License-Identifier: MIT
+#
+
+# Path to the CMake file to process.
+OECMAKE_SOURCEPATH ??= "${S}"
+
+DEPENDS:prepend = "cmake-native "
+B = "${WORKDIR}/build"
+
+# What CMake generator to use.
+# The supported options are "Unix Makefiles" or "Ninja".
+OECMAKE_GENERATOR ?= "Ninja"
+
+python() {
+    generator = d.getVar("OECMAKE_GENERATOR")
+    if "Unix Makefiles" in generator:
+        args = "-G '" + generator +  "' -DCMAKE_MAKE_PROGRAM=" + d.getVar("MAKE")
+        d.setVar("OECMAKE_GENERATOR_ARGS", args)
+        d.setVarFlag("do_compile", "progress", "percent")
+    elif "Ninja" in generator:
+        args = "-G '" + generator + "' -DCMAKE_MAKE_PROGRAM=ninja"
+        d.appendVar("DEPENDS", " ninja-native")
+        d.setVar("OECMAKE_GENERATOR_ARGS", args)
+        d.setVarFlag("do_compile", "progress", r"outof:^\[(\d+)/(\d+)\]\s+")
+    else:
+        bb.fatal("Unknown CMake Generator %s" % generator)
+}
+OECMAKE_AR ?= "${AR}"
+
+# Compiler flags
+OECMAKE_C_FLAGS ?= "${HOST_CC_ARCH} ${TOOLCHAIN_OPTIONS} ${CFLAGS}"
+OECMAKE_CXX_FLAGS ?= "${HOST_CC_ARCH} ${TOOLCHAIN_OPTIONS} ${CXXFLAGS}"
+OECMAKE_C_FLAGS_RELEASE ?= "-DNDEBUG"
+OECMAKE_CXX_FLAGS_RELEASE ?= "-DNDEBUG"
+OECMAKE_C_LINK_FLAGS ?= "${HOST_CC_ARCH} ${TOOLCHAIN_OPTIONS} ${CPPFLAGS} ${LDFLAGS}"
+OECMAKE_CXX_LINK_FLAGS ?= "${HOST_CC_ARCH} ${TOOLCHAIN_OPTIONS} ${CXXFLAGS} ${LDFLAGS}"
+
+def oecmake_map_compiler(compiler, d):
+    args = d.getVar(compiler).split()
+    if args[0] == "ccache":
+        return args[1], args[0]
+    return args[0], ""
+
+# C/C++ Compiler (without cpu arch/tune arguments)
+OECMAKE_C_COMPILER ?= "${@oecmake_map_compiler('CC', d)[0]}"
+OECMAKE_C_COMPILER_LAUNCHER ?= "${@oecmake_map_compiler('CC', d)[1]}"
+OECMAKE_CXX_COMPILER ?= "${@oecmake_map_compiler('CXX', d)[0]}"
+OECMAKE_CXX_COMPILER_LAUNCHER ?= "${@oecmake_map_compiler('CXX', d)[1]}"
+
+# clear compiler vars for allarch to avoid sig hash difference
+OECMAKE_C_COMPILER:allarch = ""
+OECMAKE_C_COMPILER_LAUNCHER:allarch = ""
+OECMAKE_CXX_COMPILER:allarch = ""
+OECMAKE_CXX_COMPILER_LAUNCHER:allarch = ""
+
+OECMAKE_RPATH ?= ""
+OECMAKE_PERLNATIVE_DIR ??= ""
+OECMAKE_EXTRA_ROOT_PATH ?= ""
+
+OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "ONLY"
+
+EXTRA_OECMAKE:append = " ${PACKAGECONFIG_CONFARGS}"
+
+export CMAKE_BUILD_PARALLEL_LEVEL
+CMAKE_BUILD_PARALLEL_LEVEL:task-compile = "${@oe.utils.parallel_make(d, False)}"
+CMAKE_BUILD_PARALLEL_LEVEL:task-install = "${@oe.utils.parallel_make(d, True)}"
+
+OECMAKE_TARGET_COMPILE ?= "all"
+OECMAKE_TARGET_INSTALL ?= "install"
+
+def map_host_os_to_system_name(host_os):
+    if host_os.startswith('mingw'):
+        return 'Windows'
+    if host_os.startswith('linux'):
+        return 'Linux'
+    return host_os
+
+# CMake expects target architectures in the format of uname(2),
+# which do not always match TARGET_ARCH, so all the necessary
+# conversions should happen here.
+def map_host_arch_to_uname_arch(host_arch):
+    if host_arch == "powerpc":
+        return "ppc"
+    if host_arch == "powerpc64le":
+        return "ppc64le"
+    if host_arch == "powerpc64":
+        return "ppc64"
+    return host_arch
+
+
+cmake_do_generate_toolchain_file() {
+	if [ "${BUILD_SYS}" = "${HOST_SYS}" ]; then
+		cmake_crosscompiling="set( CMAKE_CROSSCOMPILING FALSE )"
+	else
+		cmake_sysroot="set( CMAKE_SYSROOT \"${RECIPE_SYSROOT}\" )"
+	fi
+
+	cat > ${WORKDIR}/toolchain.cmake <<EOF
+# CMake system name must be something like "Linux".
+# This is important for cross-compiling.
+$cmake_crosscompiling
+set( CMAKE_SYSTEM_NAME ${@map_host_os_to_system_name(d.getVar('HOST_OS'))} )
+set( CMAKE_SYSTEM_PROCESSOR ${@map_host_arch_to_uname_arch(d.getVar('HOST_ARCH'))} )
+set( CMAKE_C_COMPILER ${OECMAKE_C_COMPILER} )
+set( CMAKE_CXX_COMPILER ${OECMAKE_CXX_COMPILER} )
+set( CMAKE_C_COMPILER_LAUNCHER ${OECMAKE_C_COMPILER_LAUNCHER} )
+set( CMAKE_CXX_COMPILER_LAUNCHER ${OECMAKE_CXX_COMPILER_LAUNCHER} )
+set( CMAKE_ASM_COMPILER ${OECMAKE_C_COMPILER} )
+find_program( CMAKE_AR ${OECMAKE_AR} DOC "Archiver" REQUIRED )
+
+set( CMAKE_C_FLAGS "${OECMAKE_C_FLAGS}" CACHE STRING "CFLAGS" )
+set( CMAKE_CXX_FLAGS "${OECMAKE_CXX_FLAGS}" CACHE STRING "CXXFLAGS" )
+set( CMAKE_ASM_FLAGS "${OECMAKE_C_FLAGS}" CACHE STRING "ASM FLAGS" )
+set( CMAKE_C_FLAGS_RELEASE "${OECMAKE_C_FLAGS_RELEASE}" CACHE STRING "Additional CFLAGS for release" )
+set( CMAKE_CXX_FLAGS_RELEASE "${OECMAKE_CXX_FLAGS_RELEASE}" CACHE STRING "Additional CXXFLAGS for release" )
+set( CMAKE_ASM_FLAGS_RELEASE "${OECMAKE_C_FLAGS_RELEASE}" CACHE STRING "Additional ASM FLAGS for release" )
+set( CMAKE_C_LINK_FLAGS "${OECMAKE_C_LINK_FLAGS}" CACHE STRING "LDFLAGS" )
+set( CMAKE_CXX_LINK_FLAGS "${OECMAKE_CXX_LINK_FLAGS}" CACHE STRING "LDFLAGS" )
+
+# only search in the paths provided so cmake doesnt pick
+# up libraries and tools from the native build machine
+set( CMAKE_FIND_ROOT_PATH ${STAGING_DIR_HOST} ${STAGING_DIR_NATIVE} ${CROSS_DIR} ${OECMAKE_PERLNATIVE_DIR} ${OECMAKE_EXTRA_ROOT_PATH} ${EXTERNAL_TOOLCHAIN} ${HOSTTOOLS_DIR})
+set( CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY )
+set( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ${OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM} )
+set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )
+set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )
+set( CMAKE_PROGRAM_PATH "/" )
+
+$cmake_sysroot
+
+# Use qt.conf settings
+set( ENV{QT_CONF_PATH} ${WORKDIR}/qt.conf )
+
+# We need to set the rpath to the correct directory as cmake does not provide any
+# directory as rpath by default
+set( CMAKE_INSTALL_RPATH ${OECMAKE_RPATH} )
+
+# Use RPATHs relative to build directory for reproducibility
+set( CMAKE_BUILD_RPATH_USE_ORIGIN ON )
+
+# Use our cmake modules
+list(APPEND CMAKE_MODULE_PATH "${STAGING_DATADIR}/cmake/Modules/")
+
+# add for non /usr/lib libdir, e.g. /usr/lib64
+set( CMAKE_LIBRARY_PATH ${libdir} ${base_libdir})
+
+# add include dir to implicit includes in case it differs from /usr/include
+list(APPEND CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES ${includedir})
+list(APPEND CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES ${includedir})
+
+EOF
+}
+
+addtask generate_toolchain_file after do_patch before do_configure
+
+CONFIGURE_FILES = "CMakeLists.txt *.cmake"
+
+do_configure[cleandirs] = "${@d.getVar('B') if d.getVar('S') != d.getVar('B') else ''}"
+
+OECMAKE_ARGS = "\
+    -DCMAKE_INSTALL_PREFIX:PATH=${prefix} \
+    -DCMAKE_INSTALL_BINDIR:PATH=${@os.path.relpath(d.getVar('bindir'), d.getVar('prefix') + '/')} \
+    -DCMAKE_INSTALL_SBINDIR:PATH=${@os.path.relpath(d.getVar('sbindir'), d.getVar('prefix') + '/')} \
+    -DCMAKE_INSTALL_LIBEXECDIR:PATH=${@os.path.relpath(d.getVar('libexecdir'), d.getVar('prefix') + '/')} \
+    -DCMAKE_INSTALL_SYSCONFDIR:PATH=${sysconfdir} \
+    -DCMAKE_INSTALL_SHAREDSTATEDIR:PATH=${@os.path.relpath(d.getVar('sharedstatedir'), d.  getVar('prefix') + '/')} \
+    -DCMAKE_INSTALL_LOCALSTATEDIR:PATH=${localstatedir} \
+    -DCMAKE_INSTALL_LIBDIR:PATH=${@os.path.relpath(d.getVar('libdir'), d.getVar('prefix') + '/')} \
+    -DCMAKE_INSTALL_INCLUDEDIR:PATH=${@os.path.relpath(d.getVar('includedir'), d.getVar('prefix') + '/')} \
+    -DCMAKE_INSTALL_DATAROOTDIR:PATH=${@os.path.relpath(d.getVar('datadir'), d.getVar('prefix') + '/')} \
+    -DPYTHON_EXECUTABLE:PATH=${PYTHON} \
+    -DPython_EXECUTABLE:PATH=${PYTHON} \
+    -DPython3_EXECUTABLE:PATH=${PYTHON} \
+    -DLIB_SUFFIX=${@d.getVar('baselib').replace('lib', '')} \
+    -DCMAKE_INSTALL_SO_NO_EXE=0 \
+    -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${WORKDIR}/toolchain.cmake \
+    -DCMAKE_NO_SYSTEM_FROM_IMPORTED=1 \
+    -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON \
+    -DFETCHCONTENT_FULLY_DISCONNECTED=ON \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
+"
+
+cmake_do_configure() {
+	if [ "${OECMAKE_BUILDPATH}" ]; then
+		bbnote "cmake.bbclass no longer uses OECMAKE_BUILDPATH.  The default behaviour is now out-of-tree builds with B=WORKDIR/build."
+	fi
+
+	if [ "${S}" = "${B}" ]; then
+		find ${B} -name CMakeFiles -or -name Makefile -or -name cmake_install.cmake -or -name CMakeCache.txt -delete
+	fi
+
+	# Just like autotools cmake can use a site file to cache result that need generated binaries to run
+	if [ -e ${WORKDIR}/site-file.cmake ] ; then
+		oecmake_sitefile="-C ${WORKDIR}/site-file.cmake"
+	else
+		oecmake_sitefile=
+	fi
+
+	cmake \
+	  ${OECMAKE_GENERATOR_ARGS} \
+	  $oecmake_sitefile \
+	  ${OECMAKE_SOURCEPATH} \
+	  ${OECMAKE_ARGS} \
+	  ${EXTRA_OECMAKE} \
+	  -Wno-dev
+}
+
+# To disable verbose cmake logs for a given recipe or globally config metadata e.g. local.conf
+# add following
+#
+# CMAKE_VERBOSE = ""
+#
+
+CMAKE_VERBOSE ??= "VERBOSE=1"
+
+# Then run do_compile again
+cmake_runcmake_build() {
+	bbnote ${DESTDIR:+DESTDIR=${DESTDIR} }${CMAKE_VERBOSE} cmake --build '${B}' "$@" -- ${EXTRA_OECMAKE_BUILD}
+	eval ${DESTDIR:+DESTDIR=${DESTDIR} }${CMAKE_VERBOSE} cmake --build '${B}' "$@" -- ${EXTRA_OECMAKE_BUILD}
+}
+
+cmake_do_compile()  {
+	cmake_runcmake_build --target ${OECMAKE_TARGET_COMPILE}
+}
+
+cmake_do_install() {
+	DESTDIR='${D}' cmake_runcmake_build --target ${OECMAKE_TARGET_INSTALL}
+}
+
+EXPORT_FUNCTIONS do_configure do_compile do_install do_generate_toolchain_file

--- a/samples/BitBake/qtbase_%.bbappend
+++ b/samples/BitBake/qtbase_%.bbappend
@@ -1,0 +1,19 @@
+PACKAGECONFIG_GL:rpi = "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'gl', \
+                        bb.utils.contains('DISTRO_FEATURES',     'opengl', 'eglfs gles2', \
+                                                                       '', d), d)}"
+PACKAGECONFIG_GL:append:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', ' kms', '', d)}"
+PACKAGECONFIG_GL:append:rpi = " gbm"
+PACKAGECONFIG_FONTS:rpi = "fontconfig"
+PACKAGECONFIG:append:rpi = " libinput examples tslib xkbcommon"
+PACKAGECONFIG:remove:rpi = "tests"
+
+OE_QTBASE_EGLFS_DEVICE_INTEGRATION:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', 'eglfs_brcm', d)}"
+
+do_configure:prepend:rpi() {
+    # Add the appropriate EGLFS_DEVICE_INTEGRATION
+    if [ "${@d.getVar('OE_QTBASE_EGLFS_DEVICE_INTEGRATION')}" != "" ]; then
+        echo "EGLFS_DEVICE_INTEGRATION = ${OE_QTBASE_EGLFS_DEVICE_INTEGRATION}" >> ${S}/mkspecs/oe-device-extra.pri
+    fi
+}
+RDEPENDS:${PN}:append:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' userland', d)}"
+DEPENDS:append:rpi = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', ' userland', d)}"

--- a/samples/BitBake/tclibc-newlib.inc
+++ b/samples/BitBake/tclibc-newlib.inc
@@ -1,0 +1,47 @@
+#
+# Newlib configuration
+#
+
+LIBCEXTENSION = "-newlib"
+LIBCOVERRIDE = ":libc-newlib"
+
+PREFERRED_PROVIDER_virtual/libc ?= "newlib"
+PREFERRED_PROVIDER_virtual/libiconv ?= "newlib"
+PREFERRED_PROVIDER_virtual/libintl ?= "newlib"
+PREFERRED_PROVIDER_virtual/nativesdk-libintl ?= "nativesdk-glibc"
+PREFERRED_PROVIDER_virtual/nativesdk-libiconv ?= "nativesdk-glibc"
+
+DISTRO_FEATURES_BACKFILL_CONSIDERED += "ldconfig"
+
+#USE_NLS ?= "no"
+
+IMAGE_LINGUAS = ""
+
+LIBC_DEPENDENCIES = "\
+    newlib-dbg \
+    newlib-dev \
+    libgloss \
+    libgloss-dev \
+    libgloss-dbg \
+    libgcc-dev \
+    libgcc-dbg \
+    libstdc++-dev \
+    libstdc++-staticdev \
+    "
+
+ASSUME_PROVIDED += "virtual/crypt"
+
+# Its useful to be able to extend newlib, but we dont provide a native variant of libgloss
+NEWLIB_EXTENDED ?=  "libgloss libgcc"
+BASE_DEFAULT_DEPS:append:class-target = " ${NEWLIB_EXTENDED}"
+
+TARGET_OS = "elf"
+TARGET_OS:arm = "eabi"
+
+TOOLCHAIN_HOST_TASK ?= "packagegroup-cross-canadian-${MACHINE} nativesdk-qemu nativesdk-sdk-provides-dummy"
+TOOLCHAIN_TARGET_TASK ?= "${LIBC_DEPENDENCIES}"
+TOOLCHAIN_NEED_CONFIGSITE_CACHE:remove = "zlib ncurses"
+
+# disable pie security flags by default
+SECURITY_CFLAGS:libc-newlib = "${SECURITY_NOPIE_CFLAGS}"
+SECURITY_LDFLAGS:libc-newlib = ""

--- a/samples/BitBake/xorg-driver-common.inc
+++ b/samples/BitBake/xorg-driver-common.inc
@@ -1,0 +1,44 @@
+SUMMARY = "X driver"
+HOMEPAGE = "http://www.x.org"
+BUGTRACKER = "https://bugs.freedesktop.org"
+SECTION = "x11/drivers"
+LICENSE = "MIT"
+
+PE = "2"
+
+DEPENDS = "virtual/xserver xorgproto util-macros"
+
+XORG_DRIVER_COMPRESSOR ?= ".tar.bz2"
+SRC_URI = "${XORG_MIRROR}/individual/driver/${BPN}-${PV}${XORG_DRIVER_COMPRESSOR}"
+
+FILES:${PN} += " ${libdir}/xorg/modules/drivers/*.so"
+
+XORGBUILDCLASS ??= "autotools"
+inherit ${XORGBUILDCLASS} pkgconfig features_check
+
+# depends on virtual/xserver
+REQUIRED_DISTRO_FEATURES = "x11"
+
+# FIXME: We don't want to include the libtool archives (*.la) from modules
+# directory, as they serve no useful purpose. Upstream should fix Makefile.am
+do_install:append() {
+	find ${D}${libdir}/xorg/modules -regex ".*\.la$" | xargs rm -f --
+}
+
+# Function to add the relevant ABI dependency to drivers, which should be called
+# from a PACKAGEFUNC.
+def _add_xorg_abi_depends(d, name):
+    # Map of ABI names exposed in the dependencies to pkg-config variables
+    abis = {
+      "video": "abi_videodrv",
+      "input": "abi_xinput"
+    }
+
+    output = os.popen("pkg-config xorg-server --variable=%s" % abis[name]).read()
+    mlprefix = d.getVar('MLPREFIX') or ''
+    abi = "%sxorg-abi-%s-%s" % (mlprefix, name, output.split(".")[0])
+
+    pn = d.getVar("PN")
+    d.appendVar('RDEPENDS:' + pn, ' ' + abi)
+
+SECURITY_LDFLAGS = "${SECURITY_X_LDFLAGS}"

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -57,6 +57,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Bicep:** [azure/bicep](https://github.com/azure/bicep)
 - **Bikeshed:** [tabatkins/bikeshed](https://github.com/tabatkins/bikeshed)
 - **Bison:** [Alhadis/language-grammars](https://github.com/Alhadis/language-grammars)
+- **BitBake:** [yoctoproject/vscode-bitbake](https://github.com/yoctoproject/vscode-bitbake)
 - **Blade:** [jawee/language-blade](https://github.com/jawee/language-blade)
 - **BlitzBasic:** [textmate/blitzmax.tmbundle](https://github.com/textmate/blitzmax.tmbundle)
 - **BlitzMax:** [textmate/blitzmax.tmbundle](https://github.com/textmate/blitzmax.tmbundle)

--- a/vendor/licenses/git_submodule/vscode-bitbake.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-bitbake.dep.yml
@@ -1,0 +1,26 @@
+---
+name: vscode-bitbake
+version: aa82827bfc25cbb08da262b75162981f0ca3773e
+type: git_submodule
+homepage: https://github.com/yoctoproject/vscode-bitbake.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: "MIT License\n\nCopyright (c) 2023 Savoir-faire Linux. \n\nPermission is hereby
+    granted, free of charge, to any person obtaining a copy\nof this software and
+    associated documentation files (the \"Software\"), to deal\nin the Software without
+    restriction, including without limitation the rights\nto use, copy, modify, merge,
+    publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit
+    persons to whom the Software is\nfurnished to do so, subject to the following
+    conditions:\n\nThe above copyright notice and this permission notice shall be
+    included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE
+    IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING
+    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR
+    PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS
+    BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF
+    CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE
+    OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.\n\nThe syntax settings used in
+    this project are forked from \n\nhttps://github.com/mholo65/vscode-bitbake\n\nOriginal
+    work Copyright (c) 2016 Richard Leitner\nModified work Copyright (c) 2017 Martin
+    Björkström\nModified work Copyright (c) 2018 Eugen Wiens\n"
+notices: []


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

The BitBake language is a metadata language created for the Yocto project. Support in linguist was added in 2014 (PR #1129), but at the time only to solve conflicts with BlitzBasic. Only the `.bb` extension was implemented without any grammar.

The Yocto project now has an [official VSCode extension](https://github.com/yoctoproject/vscode-bitbake) which includes a TextMate grammar. This PR adds the BitBake grammar from this repository (MIT License).

This PR also adds the following file extensions for the BitBake language:
 - `.bbappend`
 - `.bbclass`
 - ~`.conf`~
 - `.inc`

The two first extensions are pretty unique so no heuristics was needed. ~For `.conf`, I added it to `generic.yml` because a lot of Linux configuration files are using it (and are not BitBake). I tried to make heuristics that match BitBake specific assignments (e.g., `A += ...`) which are usually not present in generic conf files.~ Concerning `.inc`, there are many languages having this extension so making the heuristics was tricky. The current heuristics is a bit too restrictive (that's why I have added two `.inc` sample files), but still matches the majority (~ 95%) of BitBake `.inc` files in my experiments.

Finally, I fixed the `.bb` heuristics to reduce BlitzBasic misclassification. In my experiments, the error rate was less than 1%.

I made may experiments using the following repositories:
 - https://github.com/openembedded/openembedded-core
 - https://github.com/openembedded/meta-openembedded
 - https://github.com/agherzan/meta-raspberrypi

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.bbappend
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.bbclass
      - ~https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.conf+MACHINEOVERRIDES~
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.inc+SRC_URI
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/agherzan/meta-raspberrypi/blob/master/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%25.bbappend
      - https://github.com/openembedded/openembedded-core/blob/master/meta/classes-recipe/cmake.bbclass
      - ~https://github.com/agherzan/meta-raspberrypi/blob/master/conf/machine/raspberrypi4-64.conf~
      - https://github.com/openembedded/openembedded-core/blob/master/meta/conf/distro/include/tclibc-newlib.inc
      - https://github.com/openembedded/openembedded-core/blob/master/meta/recipes-graphics/xorg-driver/xorg-driver-common.inc
    - Sample license(s): MIT
      - https://github.com/openembedded/openembedded-core/blob/master/LICENSE.MIT
      - https://github.com/agherzan/meta-raspberrypi/blob/master/COPYING.MIT

  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [x] **I am changing the source of a syntax highlighting grammar**
  - Old: None
  - New: https://github.com/yoctoproject/vscode-bitbake (MIT License)

