### PR TITLE
Add SARIF as JSON alias

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3155,6 +3155,7 @@ JSON:
   aliases:
   - geojson
   - jsonl
+  - sarif
   - topojson
   extensions:
   - ".json"
@@ -3168,6 +3169,7 @@ JSON:
   - ".JSON-tmLanguage"
   - ".jsonl"
   - ".mcmeta"
+  - ".sarif"
   - ".tfstate"
   - ".tfstate.backup"
   - ".topojson"

--- a/samples/JSON/code-scanning.sarif
+++ b/samples/JSON/code-scanning.sarif
@@ -1,0 +1,250 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Tool Name",
+          "semanticVersion": "2.0.0",
+          "rules": [
+            {
+              "id": "3f292041e51d22005ce48f39df3585d44ce1b0ad",
+              "name": "js/unused-local-variable",
+              "shortDescription": {
+                "text": "Unused variable, import, function or class"
+              },
+              "fullDescription": {
+                "text": "Unused variables, imports, functions or classes may be a symptom of a bug and should be examined carefully."
+              },
+              "defaultConfiguration": {
+                "level": "note"
+              },
+              "properties": {
+                "tags": [
+                  "maintainability"
+                ],
+                "precision": "very-high"
+              }
+            },
+            {
+              "id": "d5b664aefd5ca4b21b52fdc1d744d7d6ab6886d0",
+              "name": "js/inconsistent-use-of-new",
+              "shortDescription": {
+                "text": "Inconsistent use of 'new'"
+              },
+              "fullDescription": {
+                "text": "If a function is intended to be a constructor, it should always be invoked with 'new'. Otherwise, it should always be invoked as a normal function, that is, without 'new'."
+              },
+              "properties": {
+                "tags": [
+                  "reliability",
+                  "correctness",
+                  "language-features"
+                ],
+                "precision": "very-high"
+              }
+            },
+            {
+              "id": "R01"
+            }
+          ]
+        }
+      },
+      "automationDetails": {
+        "id": "my-category/"
+      },
+      "results": [
+        {
+          "ruleId": "3f292041e51d22005ce48f39df3585d44ce1b0ad",
+          "ruleIndex": 0,
+          "message": {
+            "text": "Unused variable foo."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "main.js",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startLine": 2,
+                  "startColumn": 7,
+                  "endColumn": 10
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "39fa2ee980eb94b0:1",
+            "primaryLocationStartColumnFingerprint": "4"
+          }
+        },
+        {
+          "ruleId": "d5b664aefd5ca4b21b52fdc1d744d7d6ab6886d0",
+          "ruleIndex": 1,
+          "message": {
+            "text": "Function resolvingPromise is sometimes invoked as a constructor (for example [here](1)), and sometimes as a normal function (for example [here](2))."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/promises.js",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "5061c3315a741b7d:1",
+            "primaryLocationStartColumnFingerprint": "7"
+          },
+          "relatedLocations": [
+            {
+              "id": 1,
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/ParseObject.js",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startLine": 2281,
+                  "startColumn": 33,
+                  "endColumn": 55
+                }
+              },
+              "message": {
+                "text": "here"
+              }
+            },
+            {
+              "id": 2,
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/LiveQueryClient.js",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startLine": 166
+                }
+              },
+              "message": {
+                "text": "here"
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "R01",
+          "message": {
+            "text": "Specifying both [ruleIndex](1) and [ruleID](2) might lead to inconsistencies."
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "full.sarif",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startLine": 54,
+                  "startColumn": 10,
+                  "endLine": 55,
+                  "endColumn": 25
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "id": 1,
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "full.sarif"
+                },
+                "region": {
+                  "startLine": 81,
+                  "startColumn": 10,
+                  "endColumn": 18
+                }
+              },
+              "message": {
+                "text": "here"
+              }
+            },
+            {
+              "id": 2,
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "full.sarif"
+                },
+                "region": {
+                  "startLine": 82,
+                  "startColumn": 10,
+                  "endColumn": 21
+                }
+              },
+              "message": {
+                "text": "here"
+              }
+            }
+          ],
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "physicalLocation": {
+                          "region": {
+                            "startLine": 11,
+                            "endLine": 29,
+                            "startColumn": 10,
+                            "endColumn": 18
+                          },
+                          "artifactLocation": {
+                            "uriBaseId": "%SRCROOT%",
+                            "uri": "full.sarif"
+                          }
+                        },
+                        "message": {
+                          "text": "Rule has index 0"
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "physicalLocation": {
+                          "region": {
+                            "endColumn": 47,
+                            "startColumn": 12,
+                            "startLine": 12
+                          },
+                          "artifactLocation": {
+                            "uriBaseId": "%SRCROOT%",
+                            "uri": "full.sarif"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "ABC:2"
+          }
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}


### PR DESCRIPTION
SARIF files are currently rendered as plain-text on GitHub. This PR improves that experience by introducing an alias to JSON.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.sarif+level
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#example-showing-all-supported-sarif-properties
    - Sample license: https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#c-acceptable-use
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
