### PR TITLE
Add Glimmer TS language

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -320,6 +320,12 @@ disambiguations:
   rules:
   - language: GSC
     named_pattern: gsc
+- extensions: ['.gts']
+  rules:
+  - language: Gerber Image
+    pattern: '^G0.'
+  - language: Glimmer TS
+    negative_pattern: '^G0.'
 - extensions: ['.h']
   rules:
   - language: Objective-C

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2443,6 +2443,7 @@ Glimmer TS:
   color: "#3178c6"
   tm_scope: source.gts
   group: TypeScript
+  language_id: 95110458
 Glyph:
   type: programming
   color: "#c1ac7f"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2435,6 +2435,14 @@ Glimmer JS:
   tm_scope: source.gjs
   group: JavaScript
   language_id: 5523150
+Glimmer TS:
+  type: programming
+  extensions:
+  - ".gts"
+  ace_mode: typescript
+  color: "#3178c6"
+  tm_scope: source.gts
+  group: TypeScript
 Glyph:
   type: programming
   color: "#c1ac7f"

--- a/samples/Glimmer TS/class.gts
+++ b/samples/Glimmer TS/class.gts
@@ -1,0 +1,58 @@
+import Component from '@glimmer/component';
+import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+import BoxelInputTime, { Time } from './index';
+import { tracked } from '@glimmer/tracking';
+import { cssVariable, CSSVariableInfo } from 'ember-freestyle/decorators/css-variable';
+import { fn } from '@ember/helper';
+import { action } from '@ember/object';
+
+export default class BoxelInputTimeUsage extends Component {
+  cssClassName = 'boxel-input-time';
+
+  @cssVariable declare boxelInputTimeBackgroundColor: CSSVariableInfo; // TODO: replace or remove
+  @tracked value = new Date(2022,2,3,13,45);
+  @tracked minValue = new Date(2022,2,3,11,0);
+  @tracked minuteInterval = 5;
+  @action timeChanged(val: Time) {
+    this.value = val as Date; //TODO: casting???
+  }
+  <template>
+    <FreestyleUsage @name="Input::Time">
+      <:description>
+        A succint version of a time picker.
+      </:description>
+      <:example>
+        <BoxelInputTime
+          @value={{this.value}}
+          @minValue={{this.minValue}}
+          @minuteInterval={{this.minuteInterval}}
+          @onChange={{this.timeChanged}}
+        />
+      </:example>
+      <:api as |Args|>
+        <Args.Object
+          @name="value"
+          @description="The current value (undefined or conforming to a Time interface that is a subset of JavaScript's Date API"
+          @value={{this.value}}
+          @onInput={{fn (mut this.value)}}
+        />
+        <Args.Object
+          @name="minValue"
+          @description="The times before this value will disabled"
+          @value={{this.minValue}}
+        />
+        <Args.Number
+          @name="minuteInterval"
+          @description="The interval at which to show minute options"
+          @defaultValue={{5}}
+          @value={{this.minuteInterval}}
+          @onInput={{fn (mut this.minuteInterval)}}
+        />
+        <Args.Action
+          @name="onChange"
+          @description="Called when the user changed the time"
+        />
+      </:api>
+    </FreestyleUsage>
+  </template>
+}

--- a/samples/Glimmer TS/template-only.gts
+++ b/samples/Glimmer TS/template-only.gts
@@ -1,0 +1,48 @@
+import { LinkTo } from '@ember/routing';
+import { TOC } from '@ember/component/template-only';
+import Resource from 'ember-crate/models/resource';
+import HeroIcon from 'ember-heroicons/components/hero-icon';
+
+const formatDate = (date: Date) => {
+  const options: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', year: 'numeric' };
+  return new Intl.DateTimeFormat('en-US', options).format(new Date(date));
+};
+
+export const ResourceCard: TOC<{ Args: { resource: Resource } }> = <template>
+  <LinkTo
+    @route='resources.resource'
+    @model={{@resource.slug}}
+    class='block max-w-sm rounded-lg border border-gray-200 bg-white drop-shadow-sm hover:bg-slate-50'
+  >
+    <div class='p-3 md:p-4'>
+      <div class='flex gap-2'>
+        <h5
+          class='text-l mb-2 h-[3em] font-medium tracking-tight text-gray-900 line-clamp-2 xl:text-xl tracking-tight'
+        >{{@resource.title}}</h5>
+        {{#if @resource.isFeatured}}
+          <HeroIcon
+            @icon='star'
+            @type='solid'
+            class='mt-2 h-4 w-4 shrink-0 text-yellow-400'
+          />
+        {{/if}}
+      </div>
+
+      <div
+        class='flex flex-col justify-between gap-2 lg:flex-row lg:items-center'
+      >
+        <div class='flex items-center text-sm text-slate-700'>
+          <HeroIcon @icon='clock' @type='outline' class='mr-2 h-4 w-4' />
+          <span>{{formatDate @resource.publishDate}}</span>
+        </div>
+        <div
+          class='w-fit grow-0 rounded bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-800'
+        >
+          {{@resource.type}}
+        </div>
+      </div>
+    </div>
+  </LinkTo>
+</template>;
+
+export default ResourceCard;

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -510,6 +510,13 @@ class TestHeuristics < Minitest::Test
     })
   end
 
+  def test_gts_by_heuristics
+    assert_heuristics({
+      "Gerber Image" => all_fixtures("Gerber Image", "*.gts"),
+      "Glimmer TS" => all_fixtures("Glimmer TS", "*.gts"),
+    })
+  end
+
   def test_h_by_heuristics
     assert_heuristics({
       "Objective-C" => all_fixtures("Objective-C", "*.h"),

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -204,6 +204,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Git Revision List:** [Nixinova/NovaGrammars](https://github.com/Nixinova/NovaGrammars)
 - **Gleam:** [gleam-lang/tree-sitter-gleam](https://github.com/gleam-lang/tree-sitter-gleam) 🐌
 - **Glimmer JS:** [lifeart/vsc-ember-syntax](https://github.com/lifeart/vsc-ember-syntax)
+- **Glimmer TS:** [lifeart/vsc-ember-syntax](https://github.com/lifeart/vsc-ember-syntax)
 - **Glyph:** [textmate/tcl.tmbundle](https://github.com/textmate/tcl.tmbundle)
 - **Glyph Bitmap Distribution Format:** [Alhadis/language-fontforge](https://github.com/Alhadis/language-fontforge)
 - **Gnuplot:** [mattfoster/gnuplot-tmbundle](https://github.com/mattfoster/gnuplot-tmbundle)

--- a/vendor/licenses/git_submodule/vsc-ember-syntax.dep.yml
+++ b/vendor/licenses/git_submodule/vsc-ember-syntax.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: vsc-ember-syntax
-version: e45d89e771bf0aba9cc4a85e7c3835878d3054e9
+version: e92ccb2776c37a538eee5eee09c444cff799c59a
 type: git_submodule
 homepage: https://github.com/lifeart/vsc-ember-syntax.git
 license: mit

--- a/vendor/licenses/git_submodule/vsc-ember-syntax.dep.yml
+++ b/vendor/licenses/git_submodule/vsc-ember-syntax.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: vsc-ember-syntax
-version: 3921656e616580b9036b60a06abc1aa4fb436d64
+version: cbb8f92f6f7fdb918146c39f94c6d7c8dca005f3
 type: git_submodule
 homepage: https://github.com/lifeart/vsc-ember-syntax.git
 license: mit

--- a/vendor/licenses/git_submodule/vsc-ember-syntax.dep.yml
+++ b/vendor/licenses/git_submodule/vsc-ember-syntax.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: vsc-ember-syntax
-version: cbb8f92f6f7fdb918146c39f94c6d7c8dca005f3
+version: e45d89e771bf0aba9cc4a85e7c3835878d3054e9
 type: git_submodule
 homepage: https://github.com/lifeart/vsc-ember-syntax.git
 license: mit


### PR DESCRIPTION
## Description
Adds support for TypeScript-flavoured [Glimmer.js](https://glimmerjs.com/) which will be the [component authoring format](https://github.com/ember-template-imports/ember-template-imports) of the [next Edition of Ember.js](https://emberjs.com/editions/polaris/).

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - [.gts search](https://github.com/search?q=%28path%3A*.gts%29+AND+%28content%3A%3Ctemplate%3E+OR+content%3A%40glimmer+OR+content%3A%40ember%29+NOT+is%3Afork&type=code) 2k files excluding forks
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
	    - [class.gts](https://github.com/cardstack/cardstack/blob/main/packages/boxel/addon/components/boxel/input/time/usage.gts)
	    - [template-only.gts](https://github.com/EmberCrate/website/blob/main/app/components/resource-card.gts)
    - Sample license(s):
	    - class.gts -(https://github.com/cardstack/cardstack) MIT
	    - template-only.gjs (https://github.com/CrowdStrike/opensource.crowdstrike.com) MIT
  - [x] I have added a color
    - Hex value: `#3178c6`
    - Rationale: TypeScript colour which is also used by TypeScript and TSX
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.