### PR TITLE
Update F# language color according to the language icon

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1903,7 +1903,7 @@ Euphoria:
   language_id: 880693982
 F#:
   type: programming
-  color: "#b845fc"
+  color: "#348cbb"
   aliases:
   - fsharp
   extensions:


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

The F# icon color is mostly blue (https://en.wikipedia.org/wiki/F_Sharp_(programming_language)): 

![image](https://github.com/github-linguist/linguist/assets/50725287/f2db5413-25cc-4ddd-893a-392ea5b8db2b)

But the language color on GitHub is pink/purple:

![image](https://github.com/github-linguist/linguist/assets/50725287/28f699b6-77f0-4e4c-838b-449e7d84fcb5)

I'm sending this PR to better align the icon color with the GitHub language color.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [x] I have obtained agreement from the wider language community on this color change.
    - URL to public discussion: https://github.com/dotnet/fsharp/discussions/16563
    - Optional: URL to official branding guidelines for the language: https://en.wikipedia.org/wiki/F_Sharp_(programming_language)
