### PR TITLE
Add language: `Ohm`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1353,3 +1353,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/vscode-ohm"]
+	path = vendor/grammars/vscode-ohm
+	url = https://github.com/novusnota/vscode-ohm.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1148,6 +1148,8 @@ vendor/grammars/vscode-move-syntax:
 - markdown.move.codeblock
 - mdx.LANGUAGE.codeblock
 - source.move
+vendor/grammars/vscode-ohm:
+- source.ohm
 vendor/grammars/vscode-opa:
 - source.rego
 vendor/grammars/vscode-pddl:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4791,6 +4791,14 @@ Odin:
   tm_scope: source.odin
   ace_mode: text
   language_id: 889244082
+Ohm:
+  type: programming
+  color: "#A469F8"
+  extensions:
+  - ".ohm"
+  ace_mode: text
+  tm_scope: source.ohm
+  language_id: 861148446
 Omgrofl:
   type: programming
   extensions:

--- a/samples/Ohm/ohm-grammar.ohm
+++ b/samples/Ohm/ohm-grammar.ohm
@@ -1,0 +1,123 @@
+Ohm {
+
+  Grammars
+    = Grammar*
+
+  Grammar
+    = ident SuperGrammar? "{" Rule* "}"
+
+  SuperGrammar
+    = "<:" ident
+
+  Rule
+    = ident Formals? ruleDescr? "="  RuleBody  -- define
+    | ident Formals?            ":=" OverrideRuleBody  -- override
+    | ident Formals?            "+=" RuleBody  -- extend
+
+  RuleBody
+    = "|"? NonemptyListOf<TopLevelTerm, "|">
+
+  TopLevelTerm
+    = Seq caseName  -- inline
+    | Seq
+
+  OverrideRuleBody
+    = "|"? NonemptyListOf<OverrideTopLevelTerm, "|">
+
+  OverrideTopLevelTerm
+    = "..."  -- superSplice
+    | TopLevelTerm
+
+  Formals
+    = "<" ListOf<ident, ","> ">"
+
+  Params
+    = "<" ListOf<Seq, ","> ">"
+
+  Alt
+    = NonemptyListOf<Seq, "|">
+
+  Seq
+    = Iter*
+
+  Iter
+    = Pred "*"  -- star
+    | Pred "+"  -- plus
+    | Pred "?"  -- opt
+    | Pred
+
+  Pred
+    = "~" Lex  -- not
+    | "&" Lex  -- lookahead
+    | Lex
+
+  Lex
+    = "#" Base  -- lex
+    | Base
+
+  Base
+    = ident Params? ~(ruleDescr? "=" | ":=" | "+=")  -- application
+    | oneCharTerminal ".." oneCharTerminal           -- range
+    | terminal                                       -- terminal
+    | "(" Alt ")"                                    -- paren
+
+  ruleDescr  (a rule description)
+    = "(" ruleDescrText ")"
+
+  ruleDescrText
+    = (~")" any)*
+
+  caseName
+    = "--" (~"\n" space)* name (~"\n" space)* ("\n" | &"}")
+
+  name  (a name)
+    = nameFirst nameRest*
+
+  nameFirst
+    = "_"
+    | letter
+
+  nameRest
+    = "_"
+    | alnum
+
+  ident  (an identifier)
+    = name
+
+  terminal
+    = "\"" terminalChar* "\""
+
+  oneCharTerminal
+    = "\"" terminalChar "\""
+
+  terminalChar
+    = escapeChar
+      | ~"\\" ~"\"" ~"\n" "\u{0}".."\u{10FFFF}"
+
+  escapeChar  (an escape sequence)
+    = "\\\\"                                     -- backslash
+    | "\\\""                                     -- doubleQuote
+    | "\\\'"                                     -- singleQuote
+    | "\\b"                                      -- backspace
+    | "\\n"                                      -- lineFeed
+    | "\\r"                                      -- carriageReturn
+    | "\\t"                                      -- tab
+    | "\\u{" hexDigit hexDigit? hexDigit? hexDigit? hexDigit? hexDigit? "}"   -- unicodeCodePoint
+    | "\\u" hexDigit hexDigit hexDigit hexDigit  -- unicodeEscape
+    | "\\x" hexDigit hexDigit                    -- hexEscape
+
+  space
+   += comment
+
+  comment
+    = "//" (~"\n" any)* &("\n" | end)  -- singleLine
+    | "/*" (~"*/" any)* "*/"  -- multiLine
+
+  tokens = token*
+
+  token = caseName | comment | ident | operator | punctuation | terminal | any
+
+  operator = "<:" | "=" | ":=" | "+=" | "*" | "+" | "?" | "~" | "&"
+
+  punctuation = "<" | ">" | "," | "--"
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -387,6 +387,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Objective-C++:** [textmate/objective-c.tmbundle](https://github.com/textmate/objective-c.tmbundle)
 - **Objective-J:** [textmate/javascript-objective-j.tmbundle](https://github.com/textmate/javascript-objective-j.tmbundle)
 - **Odin:** [odin-lang/sublime-odin](https://github.com/odin-lang/sublime-odin)
+- **Ohm:** [novusnota/vscode-ohm](https://github.com/novusnota/vscode-ohm)
 - **Opa:** [mads379/opa.tmbundle](https://github.com/mads379/opa.tmbundle)
 - **Opal:** [artifactz/sublime-opal](https://github.com/artifactz/sublime-opal)
 - **Open Policy Agent:** [open-policy-agent/vscode-opa](https://github.com/open-policy-agent/vscode-opa)

--- a/vendor/licenses/git_submodule/vscode-ohm.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-ohm.dep.yml
@@ -1,0 +1,34 @@
+---
+name: vscode-ohm
+version: 5cb92f22187d4e388dfada00698d720c434bbed5
+type: git_submodule
+homepage: https://github.com/novusnota/vscode-ohm.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2024 Novus Nota
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+- sources: README.md
+  text: "[MIT](LICENSE)"
+notices: []
+


### PR DESCRIPTION
Adding an Ohm language for `.ohm` extension. Expected to only occur once per repo.

## Description

Ohm is a parsing toolkit consisting of a library and a domain-specific language. One can use it to parse custom file formats or quickly build parsers, interpreters, and compilers for programming languages.

The Ohm language is based on [parsing expression grammars](http://en.wikipedia.org/wiki/Parsing_expression_grammar) (PEGs), which are a formal way of describing syntax, similar to regular expressions and context-free grammars. The Ohm library provides a JavaScript interface for creating parsers, interpreters, and more from the grammars you write.

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com. As this extension is used for making parsers, and interpreter/compiler frontends, it's expected to occur only once per repository (except for the repositories in `ohmjs` organization):
    - Search results for each extension:
      - [Not forks](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.ohm) (~440 files)
      - [Not forks, excluding ohmjs organization](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.ohm+NOT+user%3Aohmjs) (~380 files)
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - `ohm-grammar.ohm` is adapted from it's version in [ohmjs/ohm](https://github.com/ohmjs/ohm/blob/main/packages/ohm-js/src/ohm-grammar.ohm)
    - Sample license(s):
  - [x] I have included a syntax highlighting grammar: [novusnota/vscode-ohm](https://github.com/novusnota/vscode-ohm)
  - [x] I have added a color
    - Hex value: `#A469F8`
    - Rationale: Most used on the language website, primary color.
  - [ ] ~~I have updated the heuristics to distinguish my language from others using the same extension.~~ No other language has the same extension, so I didn't update heuristics.
