### PR TITLE
Add `jq` interpreters

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8197,6 +8197,13 @@ jq:
   type: programming
   extensions:
   - ".jq"
+  interpreters:
+  - gojq
+  - jaq
+  - jq
+  - jqjq
+  - jqq
+  - query-json
   tm_scope: source.jq
   language_id: 905371884
 kvlang:


### PR DESCRIPTION
## Description
This pull-request adds a list of interpreters for the `jq` language:

- [`gojq`](https://github.com/itchyny/gojq): Pure Go implementation of `jq`
- [`jaq`](https://github.com/01mf02/jaq): Pure Rust implementation of `jq`
- [`jq`](https://github.com/jqlang/jq): The OG `jq`.
- [`jqjq`](https://github.com/wader/jqjq): `jq` implemented in `jq`. Seriously.
- [`jqq`](https://github.com/jcsalterego/jqq): `jq` with REPL support
- [`query-json`](https://github.com/davesnx/query-json): Pure [Reason](https://reasonml.github.io/) implementation of `jq`

**Resolves:** github-linguist/linguist#6660

_(Template removed as it doesn't apply)._