### PR TITLE
Fix TextMate Scope for '.ice' Files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6613,7 +6613,7 @@ Slash:
 Slice:
   type: programming
   color: "#003fa2"
-  tm_scope: source.slice
+  tm_scope: source.ice
   ace_mode: text
   extensions:
   - ".ice"


### PR DESCRIPTION
Hello! I'm the maintainer of the Slice language!

A few months ago, we released a new 'edition' of our language's syntax, so there are now 2 separate syntaxes for Slice.
By convention, the original syntax uses (and has always used) `.ice` file suffixes. The new syntax uses `.slice` file suffixes.
Due to the difference in syntax, each uses it's own highlighter. You can see them here:
https://github.com/zeroc-ice/vscode-slice/tree/main/syntaxes
Note that this is already the grammar repo used by Linguist:
https://github.com/github-linguist/linguist/blob/fd10bee20ed5f8c3709577f009cab788ebed41f7/vendor/README.md?plain=1#L517

As part of this change, we modified the TM scope associated with `.ice` files from `source.slice` to `source.ice`
(so we could use the `source.slice` TM scope for the new syntax).
This change took place here: https://github.com/zeroc-ice/vscode-slice/commit/ab6bf2d2a50ab1bd4ee7fd4a69783af7c0c052a8

I acknowledge this is probably a fairly unorthodox thing to do, so any guidance on what's the best way to proceed would be appreciated! But, as the absolute least, I opened this PR because the highlighting for `.ice` files is currently broken, as they're pulling in the TM scope for the new syntax.

## Checklist:
- [x] **I am changing the source of a syntax highlighting grammar**
  - The grammar repo is still https://github.com/zeroc-ice/vscode-slice/blob/main/syntaxes/ice.tmLanguage.json
This isn't changed by this PR.
