### PR TITLE
Add heuristics for C++ macros

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -835,7 +835,7 @@ named_patterns:
   - '^[ \t]*catch\s*\('
   - '^[ \t]*(class|(using[ \t]+)?namespace)\s+\w+'
   - '^[ \t]*(private|public|protected):$'
-  - '__has_cpp_attribute|__cplusplus'
+  - '__has_cpp_attribute|__cplusplus >'
   - 'std::\w+'
   euphoria:
   - '^\s*namespace\s'

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -835,6 +835,7 @@ named_patterns:
   - '^[ \t]*catch\s*\('
   - '^[ \t]*(class|(using[ \t]+)?namespace)\s+\w+'
   - '^[ \t]*(private|public|protected):$'
+  - '__has_cpp_attribute|__cplusplus'
   - 'std::\w+'
   euphoria:
   - '^\s*namespace\s'

--- a/samples/C++/NoDiscard.h
+++ b/samples/C++/NoDiscard.h
@@ -1,0 +1,24 @@
+//===--- NoDiscard.h ------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_NODISCARD_H
+#define SWIFT_BASIC_NODISCARD_H
+
+#if __cplusplus > 201402l && __has_cpp_attribute(nodiscard)
+#define SWIFT_NODISCARD [[nodiscard]]
+#elif __has_cpp_attribute(clang::warn_unused_result)
+#define SWIFT_NODISCARD [[clang::warn_unused_result]]
+#else
+#define SWIFT_NODISCARD
+#endif
+
+#endif

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -260,7 +260,7 @@ class TestBlob < Minitest::Test
 
   def test_language
     allowed_failures = {
-      "#{samples_path}/C++/rpc.h" => ["C", "C++"],
+      "#{samples_path}/C/rpc.h" => ["C", "C++"],
     }
     Samples.each do |sample|
       blob = sample_blob_memory(sample[:path])

--- a/test/test_classifier.rb
+++ b/test/test_classifier.rb
@@ -46,7 +46,7 @@ class TestClassifier < Minitest::Test
   def test_classify_ambiguous_languages
     # Failures are reasonable in some cases, such as when a file is fully valid in more than one language.
     allowed_failures = {
-      "#{samples_path}/C++/rpc.h" => ["C", "C++"],
+      "#{samples_path}/C/rpc.h" => ["C", "C++"],
     }
 
     # Skip extensions with catch-all rule

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -670,7 +670,7 @@ class TestFileBlob < Minitest::Test
   def test_language
     # Failures are reasonable in some cases, such as when a file is fully valid in more than one language.
     allowed_failures = {
-      "#{samples_path}/C++/rpc.h" => ["C", "C++"],
+      "#{samples_path}/C/rpc.h" => ["C", "C++"],
     }
     Samples.each do |sample|
       blob = sample_blob(sample[:path])


### PR DESCRIPTION
This PR adds a new heuristic for C++ that checks for the preprocessor macros
__has_cpp_attribute and __cplusplus. These are commonly-used macros that check
what version of C++ is supported, and the available attributes.

## Checklist:
- [x] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language:
    - Sample source(s): [NoDiscard.h](https://github.com/apple/swift/blob/f9ec3b1d7e6e4698b73120a548e93adf22b097e8/include/swift/Basic/NoDiscard.h#L4) from Swift project
    - Sample license(s): Apache v2
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.