### PR TITLE
Add support for Pkl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -737,6 +737,9 @@
 [submodule "vendor/grammars/language-pcb"]
 	path = vendor/grammars/language-pcb
 	url = https://github.com/Alhadis/language-pcb
+[submodule "vendor/grammars/language-pkl"]
+	path = vendor/grammars/language-pkl
+	url = https://github.com/nishtahir/language-pkl.git
 [submodule "vendor/grammars/language-povray"]
 	path = vendor/grammars/language-povray
 	url = https://github.com/c-lipka/language-povray
@@ -1353,3 +1356,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/language-pkl"]
+	path = vendor/grammars/language-pkl
+	url = https://github.com/nishtahir/language-pkl.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -702,6 +702,8 @@ vendor/grammars/language-pcb:
 - source.pcb.board
 - source.pcb.schematic
 - source.pcb.sexp
+vendor/grammars/language-pkl:
+- source.pkl
 vendor/grammars/language-povray:
 - source.pov-ray sdl
 vendor/grammars/language-property-list:

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -516,6 +516,11 @@ disambiguations:
     pattern: '<\?hh'
   - language: PHP
     pattern: '<\?[^h]'
+- extensions: ['.pkl']
+  rules:
+  - language: Pkl
+    pattern: 'new|class|function|import|module|(\w+\s*({|=))'
+  - language: Pickle
 - extensions: ['.pl']
   rules:
   - language: Prolog

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5240,6 +5240,16 @@ Pike:
   tm_scope: source.pike
   ace_mode: text
   language_id: 287
+Pkl:
+  type: programming
+  color: "#6b9543"
+  extensions:
+  - ".pkl"
+  interpreters:
+  - pkl
+  tm_scope: source.pkl
+  ace_mode: text
+  language_id: 502403550
 PlantUML:
   type: data
   color: "#fbbd16"

--- a/samples/Pkl/app-config.pkl
+++ b/samples/Pkl/app-config.pkl
@@ -1,0 +1,38 @@
+// ===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ===----------------------------------------------------------------------===//
+// This sample is taken from https://github.com/apple/pkl-go-examples and showcases
+// the use of PKL for configuration of a Go app, see the original repository for
+// more information
+
+/// Application configuration for the Pkl Go Example application.
+///
+/// See generated sources in the gen/ directory.
+@go.Package { name = "github.com/apple/pkl-go-examples/gen/appconfig" }
+module org.pkl.golang.example.AppConfig
+
+import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.5.0#/go.pkl"
+import "RedisConfig.pkl"
+
+typealias Port = UInt16(this > 0)
+
+/// The host to listen on
+host: String = "127.0.0.1"
+
+/// The application port to listen on
+port: Port = 5051
+
+/// Redis settings for this application
+redis: RedisConfig

--- a/samples/Pkl/frontend.pkl
+++ b/samples/Pkl/frontend.pkl
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+// This sample is taken from https://github.com/apple/pkl-k8s-examples and showcases
+// the use of PKL to generate YAML manifests for K8s, see the original repository for
+// additional information
+
+import "@k8s/K8sResource.pkl"
+import "@k8s/api/apps/v1/Deployment.pkl"
+import "@k8s/api/core/v1/Service.pkl"
+
+resources: Listing<K8sResource> = new {
+  new Service {
+    metadata {
+      name = "frontend"
+      labels {
+        ["app"] = "guestbook"
+        ["tier"] = "frontend"
+      }
+    }
+    spec {
+      type = "NodePort"
+      ports {
+        new {
+          port = 80
+        }
+      }
+      selector {
+        ["app"] = "guestbook"
+        ["tier"] = "frontend"
+      }
+    }
+  }
+
+  new Deployment {
+    metadata {
+      name = "frontend"
+    }
+    spec {
+      selector {
+        matchLabels {
+          ["app"] = "guestbook"
+          ["tier"] = "frontend"
+        }
+      }
+      replicas = 3
+      template {
+        metadata {
+          labels {
+            ["app"] = "guestbook"
+            ["tier"] = "frontend"
+          }
+        }
+        spec {
+          containers {
+            new {
+              name = "php-redis"
+              image = "gcr.io/google-samples/gb-frontend:v4"
+              resources {
+                requests {
+                  ["cpu"] = "100m"
+                  ["memory"] = "100Mi"
+                }
+              }
+              env {
+                new {
+                  name = "GET_HOSTS_FROM"
+                  value = "dns"
+                }
+              }
+              ports {
+                new {
+                  containerPort = 80
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+output {
+  value = resources
+  renderer = (K8sResource.output.renderer as YamlRenderer) {
+    isStream = true
+  }
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -418,6 +418,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **PicoLisp:** [textmate/lisp.tmbundle](https://github.com/textmate/lisp.tmbundle)
 - **PigLatin:** [goblindegook/sublime-text-pig-latin](https://github.com/goblindegook/sublime-text-pig-latin)
 - **Pike:** [hww3/pike-textmate](https://github.com/hww3/pike-textmate)
+- **Pkl:** [nishtahir/language-pkl](https://github.com/nishtahir/language-pkl)
 - **PlantUML:** [qjebbs/vscode-plantuml](https://github.com/qjebbs/vscode-plantuml)
 - **Pod 6:** [perl6/atom-language-perl6](https://github.com/perl6/atom-language-perl6)
 - **PogoScript:** [featurist/PogoScript.tmbundle](https://github.com/featurist/PogoScript.tmbundle)

--- a/vendor/licenses/git_submodule/language-pkl.dep.yml
+++ b/vendor/licenses/git_submodule/language-pkl.dep.yml
@@ -1,0 +1,217 @@
+---
+name: language-pkl
+version: 05b5903cc34fcfcd94c481fe109cc8235c96251a
+type: git_submodule
+homepage: https://github.com/nishtahir/language-pkl.git
+license: other
+licenses:
+- sources: LICENSE
+  text: |2+
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+
+       END OF TERMS AND CONDITIONS
+
+       APPENDIX: How to apply the Apache License to your work.
+
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "{}"
+          replaced with your own identifying information. (Don't include
+          the brackets!)  The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+
+       Copyright 2024 Nish Tahir
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+notices:
+- sources: NOTICE
+  text: "NOTICE file corresponding to the section 4 d of the Apache License, Version
+    2.0\n\nThis product includes software developed as part of: \npkl-vscode (https://github.com/apple/pkl-vscode).\n\nAll
+    other copyright for project nishtahir/language-pkl are held by Nish Tahir."
+...


### PR DESCRIPTION
Adds support for the new [Pkl](https://pkl-lang.org/index.html) configuration language from Apple.

## Description

Credit to:
- @darvld and myself from the Elide team for assembling the tests + linguist changes
- @nishtahir for the textmate grammar
- @pixelcmtd for the feature request issue at #6705 

Fixes and closes #6705 
Fixes and closes apple/pkl#155

### Changelog

- feat: language support for Apple Pkl with textmate bundle
- feat: heuristics to distinguish with Python Pickle
- test: tests/samples for Apple Pkl configuration language

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am adding a new extension to a language.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.pkl
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  [Here](https://github.com/search?type=repositories&q=NOT+is%3Afork+path%3A*.pkl+KEYWORDS), but it is hard to distinguish Pkl sources from Pickle (Python) data
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - Samples from the official [`apple/pkl-go-examples`](https://github.com/apple/pkl-go-examples)
    - Sample license(s): [Apache 2.0](https://github.com/apple/pkl-go-examples?tab=Apache-2.0-1-ov-file#readme)
  - [x] I have included a syntax highlighting grammar: [Grammar here](https://github.com/nishtahir/language-pkl)
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#6b9543`
    - Rationale: Main color (outer gear green) used in the [Pkl project icon](https://github.com/apple/pkl/pull/212)
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  - Old: [URL to grammar repo]
  - New: [URL to grammar repo]

- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

- [ ] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [URL to public discussion]
    - [Optional: URL to official branding guidelines for the language]
