### PR TITLE
Add TextGrid data file format

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7125,6 +7125,14 @@ Text:
   tm_scope: none
   ace_mode: text
   language_id: 372
+TextGrid:
+  type: data
+  color: "#c8506d"
+  tm_scope: source.textgrid
+  ace_mode: text
+  extensions:
+  - ".TextGrid"
+  language_id: 965696054
 TextMate Properties:
   type: data
   color: "#df66e4"

--- a/samples/TextGrid/part_of_speech.TextGrid
+++ b/samples/TextGrid/part_of_speech.TextGrid
@@ -1,0 +1,62 @@
+File type = "ooTextFile"
+Object class = "TextGrid"
+
+xmin = 0
+xmax = 9.1
+tiers? <exists>
+size = 1
+item []:
+    item [1]:
+        class = "IntervalTier"
+        name = "TestTier"
+        xmin = 0
+        xmax = 9.1
+        intervals: size = 6
+        intervals [1]:
+            xmin = 0
+            xmax = 3.4
+            text = "a_DT"
+        intervals [2]:
+            xmin = 3.4
+            xmax = 5.2
+            text = "a_DT"
+        intervals [3]:
+            xmin = 5.2
+            xmax = 5.4
+            text = "aal_JJ"
+        intervals [4]:
+            xmin = 5.4
+            xmax = 5.88
+            text = "a_DT"
+        intervals [5]:
+            xmin = 5.88
+            xmax = 6.2
+            text = "uhm_IN"
+        intervals [6]:
+            xmin = 6.2
+            xmax = 7.1
+            text = "aal_JJ"
+        intervals [7]:
+            xmin = 7.1
+            xmax = 8.2
+            text = ""
+        intervals [8]:
+            xmin = 8.2
+            xmax = 8.3
+            text = "aal_JJ"
+        intervals [9]:
+            xmin = 8.3
+            xmax = 8.5
+            text = "some_JJ"
+        intervals [10]:
+            xmin = 8.5
+            xmax = 8.8
+            text = "some_WP$"
+        intervals [11]:
+            xmin = 8.8
+            xmax = 8.9
+            text = "a_DT"
+        intervals [12]:
+            xmin = 8.9
+            xmax = 9.1
+            text = "aal_JJ"

--- a/samples/TextGrid/three_tiers.TextGrid
+++ b/samples/TextGrid/three_tiers.TextGrid
@@ -1,0 +1,62 @@
+File type = "ooTextFile"
+Object class = "TextGrid"
+
+xmin = 0
+xmax = 1
+tiers? <exists>
+size = 3
+item []:
+    item [1]:
+        class = "IntervalTier"
+        name = "First"
+        xmin = 0
+        xmax = 1
+        intervals: size = 3
+        intervals [1]:
+            xmin = 0
+            xmax = 0.06588581304037375
+            text = "One"
+        intervals [2]:
+            xmin = 0.06588581304037375
+            xmax = 0.2342878321396945
+            text = "Two"
+        intervals [3]:
+            xmin = 0.2342878321396945
+            xmax = 1
+            text = "Three"
+    item [2]:
+        class = "IntervalTier"
+        name = "Second"
+        xmin = 0
+        xmax = 1
+        intervals: size = 3
+        intervals [1]:
+            xmin = 0
+            xmax = 0.19395201918177338
+            text = "One"
+        intervals [2]:
+            xmin = 0.19395201918177338
+            xmax = 0.3341189692105493
+            text = "Two"
+        intervals [3]:
+            xmin = 0.3341189692105493
+            xmax = 1
+            text = "Three"
+    item [3]:
+        class = "IntervalTier"
+        name = "Third"
+        xmin = 0
+        xmax = 1
+        intervals: size = 3
+        intervals [1]:
+            xmin = 0
+            xmax = 0.4117654091545475
+            text = "One"
+        intervals [2]:
+            xmin = 0.4117654091545475
+            xmax = 0.5186553134930385
+            text = "Two"
+        intervals [3]:
+            xmin = 0.5186553134930385
+            xmax = 1
+            text = "Three"

--- a/samples/TextGrid/words.TextGrid
+++ b/samples/TextGrid/words.TextGrid
@@ -1,0 +1,46 @@
+File type = "ooTextFile"
+Object class = "TextGrid"
+
+xmin = 0 
+xmax = 7.2 
+tiers? <exists> 
+size = 1 
+item []: 
+    item [1]:
+        class = "IntervalTier" 
+        name = "TestTier" 
+        xmin = 0 
+        xmax = 7.2
+        intervals: size = 6 
+        intervals [1]:
+            xmin = 0 
+            xmax = 3.4 
+            text = "a" 
+        intervals [2]:
+            xmin = 3.4 
+            xmax = 5.2 
+            text = "A" 
+        intervals [3]:
+            xmin = 5.2 
+            xmax = 5.4 
+            text = "aal  " 
+        intervals [4]:
+            xmin = 5.4 
+            xmax = 5.6 
+            text = "" 
+        intervals [5]:
+            xmin = 5.6 
+            xmax = 5.88 
+            text = "aardvark" 
+        intervals [6]:
+            xmin = 5.88 
+            xmax = 6.2 
+            text = "uhm" 
+        intervals [7]:
+            xmin = 6.2 
+            xmax = 7.1 
+            text = "isn't" 
+        intervals [8]:
+            xmin = 7.1 
+            xmax = 7.2 
+            text = "BLEEH"     

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -556,6 +556,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Terra:** [pyk/sublime-terra](https://github.com/pyk/sublime-terra)
 - **Terraform Template:** [hashicorp/syntax](https://github.com/hashicorp/syntax)
 - **Texinfo:** [Alhadis/language-texinfo](https://github.com/Alhadis/language-texinfo)
+- **TextGrid:** [orhunulusahin/praatvscode](https://github.com/orhunulusahin/praatvscode)
 - **TextMate Properties:** [textmate/textmate.tmbundle](https://github.com/textmate/textmate.tmbundle)
 - **Thrift:** [textmate/thrift.tmbundle](https://github.com/textmate/thrift.tmbundle)
 - **Toit:** [toitware/ide-tools](https://github.com/toitware/ide-tools)


### PR DESCRIPTION
## Description
This adds the TextGrid data format with the `.TextGrid` file extension. This is a text-based data format used in linguistic research for aligning text (usually transcriptions) with audio. It has over 100K files checked in on GitHub. The official documentation for it can be found here: https://www.fon.hum.uva.nl/praat/manual/TextGrid_file_formats.html

As the format suggests, there are indeed more types of `ooTextFile`, several dozen in fact, but TextGrids are the only ones that are frequently checked into source control.

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each `.TextGrid`:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.TextGrid
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample license(s):
    - I wrote these myself for unit tests as a part of a Research internship, and am happy to re-licence them under linguist's MIT licence (which I am allowed to do following the terms of the internship).
  - [x] I have included a syntax highlighting grammar:
      - This one was already done by #6620 
  - [x] I have added a color
    - Hex value: `#c8506d`
    - Rationale: Same as Praat, as it is a data format associated with Praat. If it can "inherit" this it might be better, but I cannot find how. Also, it's a data file, so it shouldn't matter too much, as it's not displayed by default.
