### PR TITLE
Remove unnecessary alias for R

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5632,7 +5632,6 @@ R:
   type: programming
   color: "#198CE7"
   aliases:
-  - R
   - Rscript
   - splus
   extensions:


### PR DESCRIPTION
`R` was added as an alias of `R` 10 years ago in #783. I'm not sure what the problem it fixed back then was but it seems to be unnecessary now in 2024.