### PR TITLE
Add tmux.conf and .tmux.conf as shell filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6503,6 +6503,7 @@ Shell:
   - ".kshrc"
   - ".login"
   - ".profile"
+  - ".tmux.conf"
   - ".zlogin"
   - ".zlogout"
   - ".zprofile"
@@ -6520,6 +6521,7 @@ Shell:
   - login
   - man
   - profile
+  - tmux.conf
   - zlogin
   - zlogout
   - zprofile

--- a/samples/Shell/filenames/.tmux.conf
+++ b/samples/Shell/filenames/.tmux.conf
@@ -1,0 +1,99 @@
+# ==========================
+# ===  General settings  ===
+# ==========================
+#
+# Some of these borrowed from https://github.com/samoshkin/tmux-config/blob/master/tmux/tmux.conf
+#
+# Good book: https://leanpub.com/the-tao-of-tmux/read
+
+# utf8 is on
+set -g utf8 on
+set -g status-utf8 on
+
+# address vim mode switching delay (http://superuser.com/a/252717/65504)
+set -s escape-time 0
+
+# Force lotsa colours
+set -g default-terminal "screen-256color"
+
+# Start index of window/pane with 1, because we're humans, not computers
+set -g base-index 1
+setw -g pane-base-index 1
+
+# split panes using | and - cos it's waay more logical than % and "
+unbind '"'
+unbind %
+bind | split-window -h
+bind - split-window -v
+
+# reload config file (change file location to your the tmux.conf you want to use)
+bind r source-file ~/.tmux.conf
+
+# don't rename windows automatically
+set-option -g allow-rename off
+
+# Enable mouse support
+# < 2.1
+#set -g mode-mouse on
+# 2.1 onwards
+#set -g mouse on
+
+# =====================================
+# ===           Theme               ===
+# =====================================
+
+# Feel free to NOT use this variables at all (remove, rename)
+# this are named colors, just for convenience
+color_orange="colour166" # 208, 166
+color_purple="colour134" # 135, 134
+color_green="colour076" # 070
+color_blue="colour39"
+color_yellow="colour220"
+color_red="colour160"
+color_black="colour232"
+color_white="white" # 015
+
+# This is a theme CONTRACT, you are required to define variables below
+# Change values, but not remove/rename variables itself
+color_dark="$color_black"
+color_light="$color_white"
+color_session_text="$color_blue"
+color_status_text="colour245"
+color_main="$color_orange"
+color_secondary="$color_purple"
+color_level_ok="$color_green"
+color_level_warn="$color_yellow"
+color_level_stress="$color_red"
+color_window_off_indicator="colour088"
+color_window_off_status_bg="colour238"
+color_window_off_status_current_bg="colour254"
+
+# =====================================
+# ===    Appearance and status bar  ===
+# ======================================
+
+set -g mode-style "fg=default,bg=$color_main"
+
+# command line style
+set -g message-style "fg=$color_main,bg=$color_dark"
+
+# status line style
+set -g status-style "fg=$color_status_text,bg=$color_dark"
+
+# window segments in status line
+set -g window-status-separator ""
+
+# setw -g window-status-style "fg=$color_status_text,bg=$color_dark"
+setw -g window-status-format " #I:#W "
+setw -g window-status-current-style "fg=$color_light,bold,bg=$color_main"
+setw -g window-status-current-format "#[fg=$color_dark,bg=$color_main] #I:#W #[fg=$color_main,bg=$color_dark]#[default]"
+
+# outline for active pane
+setw -g pane-active-border-style "fg=$color_main"
+
+# The left hand side of the status bar
+set -g status-left "#[fg=$color_session_text] #S #[default]"
+
+# The right hand side of the status bar
+set -g status-right-length 100
+set -g status-right "#[fg=$color_orange,bold] #h #[default]#[fg=$color_blue] %d-%b-%y %H:%M %Z"

--- a/samples/Shell/filenames/.tmux.conf
+++ b/samples/Shell/filenames/.tmux.conf
@@ -1,3 +1,6 @@
+# Source: https://github.com/lildude/dotfiles/blob/main/chezmoi/dot_config/tmux/tmux.conf
+# Licensed under MIT (https://github.com/lildude/dotfiles/blob/main/LICENSE)
+
 # ==========================
 # ===  General settings  ===
 # ==========================

--- a/samples/Shell/filenames/tmux.conf
+++ b/samples/Shell/filenames/tmux.conf
@@ -1,0 +1,99 @@
+# ==========================
+# ===  General settings  ===
+# ==========================
+#
+# Some of these borrowed from https://github.com/samoshkin/tmux-config/blob/master/tmux/tmux.conf
+#
+# Good book: https://leanpub.com/the-tao-of-tmux/read
+
+# utf8 is on
+set -g utf8 on
+set -g status-utf8 on
+
+# address vim mode switching delay (http://superuser.com/a/252717/65504)
+set -s escape-time 0
+
+# Force lotsa colours
+set -g default-terminal "screen-256color"
+
+# Start index of window/pane with 1, because we're humans, not computers
+set -g base-index 1
+setw -g pane-base-index 1
+
+# split panes using | and - cos it's waay more logical than % and "
+unbind '"'
+unbind %
+bind | split-window -h
+bind - split-window -v
+
+# reload config file (change file location to your the tmux.conf you want to use)
+bind r source-file ~/.tmux.conf
+
+# don't rename windows automatically
+set-option -g allow-rename off
+
+# Enable mouse support
+# < 2.1
+#set -g mode-mouse on
+# 2.1 onwards
+#set -g mouse on
+
+# =====================================
+# ===           Theme               ===
+# =====================================
+
+# Feel free to NOT use this variables at all (remove, rename)
+# this are named colors, just for convenience
+color_orange="colour166" # 208, 166
+color_purple="colour134" # 135, 134
+color_green="colour076" # 070
+color_blue="colour39"
+color_yellow="colour220"
+color_red="colour160"
+color_black="colour232"
+color_white="white" # 015
+
+# This is a theme CONTRACT, you are required to define variables below
+# Change values, but not remove/rename variables itself
+color_dark="$color_black"
+color_light="$color_white"
+color_session_text="$color_blue"
+color_status_text="colour245"
+color_main="$color_orange"
+color_secondary="$color_purple"
+color_level_ok="$color_green"
+color_level_warn="$color_yellow"
+color_level_stress="$color_red"
+color_window_off_indicator="colour088"
+color_window_off_status_bg="colour238"
+color_window_off_status_current_bg="colour254"
+
+# =====================================
+# ===    Appearance and status bar  ===
+# ======================================
+
+set -g mode-style "fg=default,bg=$color_main"
+
+# command line style
+set -g message-style "fg=$color_main,bg=$color_dark"
+
+# status line style
+set -g status-style "fg=$color_status_text,bg=$color_dark"
+
+# window segments in status line
+set -g window-status-separator ""
+
+# setw -g window-status-style "fg=$color_status_text,bg=$color_dark"
+setw -g window-status-format " #I:#W "
+setw -g window-status-current-style "fg=$color_light,bold,bg=$color_main"
+setw -g window-status-current-format "#[fg=$color_dark,bg=$color_main] #I:#W #[fg=$color_main,bg=$color_dark]#[default]"
+
+# outline for active pane
+setw -g pane-active-border-style "fg=$color_main"
+
+# The left hand side of the status bar
+set -g status-left "#[fg=$color_session_text] #S #[default]"
+
+# The right hand side of the status bar
+set -g status-right-length 100
+set -g status-right "#[fg=$color_orange,bold] #h #[default]#[fg=$color_blue] %d-%b-%y %H:%M %Z"

--- a/samples/Shell/filenames/tmux.conf
+++ b/samples/Shell/filenames/tmux.conf
@@ -1,3 +1,6 @@
+# Source: https://github.com/lildude/dotfiles/blob/main/chezmoi/dot_config/tmux/tmux.conf
+# Licensed under MIT (https://github.com/lildude/dotfiles/blob/main/LICENSE)
+
 # ==========================
 # ===  General settings  ===
 # ==========================


### PR DESCRIPTION
Add `tmux.conf` and `.tmux.conf` as filenames for shell. There was already the extension `.tmux` but the default config filenames were missing.
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
classify `tmux.conf` and `.tmux.conf` as shell too, so we can get the sweet syntax highlighting

## Checklist:
- [X] **I am adding a new ~extension~ filename to a language.**
  - [X] The new ~extension~ filename is used in hundreds of repositories on GitHub.com
    - Search results for each ~extension~ filename: 
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.tmux.conf+bind
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*tmux.conf+bind
  - [X] I have included a real-world usage sample for all ~extensions~ filenames added in this PR:
    - Sample source(s):
      - https://github.com/lildude/dotfiles/blob/main/chezmoi/dot_config/tmux/tmux.conf :wink: 
    - Sample license(s):
      - https://github.com/lildude/dotfiles/blob/main/LICENSE
  - [X] I have included a change to the heuristics to distinguish my language from others using the same extension. (Not applicable, the filename shouldn't be universally used for anything else afaik)
