### PR TITLE
Replace Common Lisp grammar source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -383,6 +383,9 @@
 [submodule "vendor/grammars/cmake.tmbundle"]
 	path = vendor/grammars/cmake.tmbundle
 	url = https://github.com/textmate/cmake.tmbundle
+[submodule "vendor/grammars/common-lisp-tmlanguage"]
+	path = vendor/grammars/common-lisp-tmlanguage
+	url = https://github.com/qingpeng9802/common-lisp-tmlanguage.git
 [submodule "vendor/grammars/conllu-linguist-grammar"]
 	path = vendor/grammars/conllu-linguist-grammar
 	url = https://github.com/odanoburu/conllu-linguist-grammar

--- a/grammars.yml
+++ b/grammars.yml
@@ -313,6 +313,9 @@ vendor/grammars/clarity.tmbundle:
 vendor/grammars/cmake.tmbundle:
 - source.cache.cmake
 - source.cmake
+vendor/grammars/common-lisp-tmlanguage:
+- markdown.commonlisp.codeblock
+- source.commonlisp
 vendor/grammars/conllu-linguist-grammar:
 - text.conllu
 vendor/grammars/cool-tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1211,7 +1211,7 @@ ColdFusion CFC:
   language_id: 65
 Common Lisp:
   type: programming
-  tm_scope: source.lisp
+  tm_scope: source.commonlisp
   color: "#3fb68b"
   aliases:
   - lisp

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -108,7 +108,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **CoffeeScript:** [atom/language-coffee-script](https://github.com/atom/language-coffee-script)
 - **ColdFusion:** [SublimeText/ColdFusion](https://github.com/SublimeText/ColdFusion)
 - **ColdFusion CFC:** [SublimeText/ColdFusion](https://github.com/SublimeText/ColdFusion)
-- **Common Lisp:** [textmate/lisp.tmbundle](https://github.com/textmate/lisp.tmbundle)
+- **Common Lisp:** [qingpeng9802/common-lisp-tmlanguage](https://github.com/qingpeng9802/common-lisp-tmlanguage)
 - **Common Workflow Language:** [manabuishii/language-cwl](https://github.com/manabuishii/language-cwl)
 - **Component Pascal:** [textmate/pascal.tmbundle](https://github.com/textmate/pascal.tmbundle)
 - **Cool:** [anunayk/cool-tmbundle](https://github.com/anunayk/cool-tmbundle)

--- a/vendor/licenses/git_submodule/common-lisp-tmlanguage.dep.yml
+++ b/vendor/licenses/git_submodule/common-lisp-tmlanguage.dep.yml
@@ -1,0 +1,31 @@
+---
+name: common-lisp-tmlanguage
+version: 4cb85fe1b7f1854ec24644bd9894516a51362357
+type: git_submodule
+homepage: https://github.com/qingpeng9802/common-lisp-tmlanguage.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |-
+    MIT License
+
+    Copyright (c) 2020 Qingpeng Li
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

Things may be a bit more complicated than usual. This PR would like to replace the old grammar of Common Lisp with my grammar.

Common Lisp and other lisp dialects are currently using `source.lisp` as the scope. My grammar is strictly follow Common Lisp standard so it is not a good idea to use my grammar on other lisp dialects. Thus, the new grammar (`source.commonlisp`) is added for Common Lisp only, but the old grammar (`source.lisp`) is kept for other lisp dialects.

The grammar is originally from my repo [vscode-common-lisp](https://github.com/qingpeng9802/vscode-common-lisp).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **I am changing the source of a syntax highlighting grammar**
  - Old: https://github.com/textmate/lisp.tmbundle
  - New: https://github.com/qingpeng9802/common-lisp-tmlanguage