### PR TITLE
Add `.env.sample` as Dotenv filename

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1594,6 +1594,7 @@ Dotenv:
   - ".env.local"
   - ".env.prod"
   - ".env.production"
+  - ".env.sample"
   - ".env.staging"
   - ".env.test"
   - ".env.testing"

--- a/samples/Dotenv/filenames/.env.sample
+++ b/samples/Dotenv/filenames/.env.sample
@@ -1,0 +1,15 @@
+# The database to use when testing against Postgres.
+PG_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/diesel_test
+# The database to use when running the Postgres examples during testing.
+PG_EXAMPLE_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/diesel_example
+
+# The database to use when testing against MySQL.
+MYSQL_DATABASE_URL=mysql://root@127.0.0.1:3306/diesel_test
+# The database to use when running the MySQL examples during testing.
+MYSQL_EXAMPLE_DATABASE_URL=mysql://root@127.0.0.1:3306/diesel_example
+# A database different from the others above used for certain unit tests.
+# TODO: this is magical, explain what it's there for.
+MYSQL_UNIT_TEST_DATABASE_URL=mysql://root@127.0.0.1:3306/diesel_unit_test
+
+# The database to use when testing against SQLite.
+SQLITE_DATABASE_URL=/tmp/diesel_test.sqlite


### PR DESCRIPTION
This adds the `.env.sample` filename for the Dotenv language

## Checklist:
- [x] **I am adding a new ~~extension~~ filename to a language.**
  - [x] The new ~~extension~~ filename is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A%2F%28%5E%7C%5C%2F%29%5C.env%5C.sample%24%2F
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/diesel-rs/diesel/blob/9d8d1ee7ed8ea1ad8759492fb727747c8b34055f/.env.sample
    - Sample license(s):
      - [Apache 2.0](https://github.com/diesel-rs/diesel/blob/9d8d1ee7ed8ea1ad8759492fb727747c8b34055f/LICENSE-APACHE)
      - [MIT](https://github.com/diesel-rs/diesel/blob/9d8d1ee7ed8ea1ad8759492fb727747c8b34055f/LICENSE-MIT)
      - (License is Apache 2.0 *or* MIT according to the project's [`Cargo.toml`](https://github.com/diesel-rs/diesel/blob/9d8d1ee7ed8ea1ad8759492fb727747c8b34055f/diesel/Cargo.toml#L4))
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.