### PR TITLE
Switch Ruby VS Code extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,8 +17,8 @@
     "vscode": {
       "extensions": [
         "EditorConfig.EditorConfig",
-        "rebornix.Ruby",
-        "redhat.vscode-yaml"
+        "redhat.vscode-yaml",
+        "Shopify.ruby-lsp"
       ]
     }
   },


### PR DESCRIPTION
The `rebornix.Ruby` extension is deprecated in favor of `Shopify.ruby-lsp`.