### PR TITLE
Fix VBA heuristic for Access Option Compare statement

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -887,7 +887,7 @@ named_patterns:
   - '^[ ]*#If Win64\b'
   - '^[ ]*(?:Dim|Const) [0-9a-zA-Z_]*[ ]*As Long(?:Ptr|Long)\b'
   # Top module declarations unique to VBA
-  - '^[ ]*Option (?:Private Module|Compare Database)\b'
+  - '^[ ]*Option (?:Private Module|Compare (?:Database|Text))\b'
   # General VBA libraries and objects
   - '(?: |\()(?:Access|Excel|Outlook|PowerPoint|Visio|Word|VBIDE)\.\w'
   - '\b(?:(?:Active)?VBProjects?|VBComponents?|Application\.(?:VBE|ScreenUpdating))\b'

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -887,7 +887,7 @@ named_patterns:
   - '^[ ]*#If Win64\b'
   - '^[ ]*(?:Dim|Const) [0-9a-zA-Z_]*[ ]*As Long(?:Ptr|Long)\b'
   # Top module declarations unique to VBA
-  - '^[ ]*Option (?:Private Module|Compare (?:Database|Text))\b'
+  - '^[ ]*Option (?:Private Module|Compare (?:Database|Text|Binary))\b'
   # General VBA libraries and objects
   - '(?: |\()(?:Access|Excel|Outlook|PowerPoint|Visio|Word|VBIDE)\.\w'
   - '\b(?:(?:Active)?VBProjects?|VBComponents?|Application\.(?:VBE|ScreenUpdating))\b'

--- a/samples/VBA/AccUnitLoaderConfigProcedures.bas
+++ b/samples/VBA/AccUnitLoaderConfigProcedures.bas
@@ -1,0 +1,114 @@
+Attribute VB_Name = "AccUnitLoaderConfigProcedures"
+Option Explicit
+Option Compare Text
+
+Public Sub AddAccUnitTlbReference()
+   RemoveAccUnitTlbReference
+   CurrentVbProject.References.AddFromFile CurrentAccUnitConfiguration.AccUnitDllPath & "\AccessCodeLib.AccUnit.tlb"
+End Sub
+
+Public Sub RemoveAccUnitTlbReference()
+
+   Dim ref As Reference
+   Dim RefName As String
+   
+   With CurrentVbProject
+      For Each ref In .References
+On Error Resume Next
+         RefName = ref.Name
+         If Err.Number <> 0 Then
+            Err.Clear
+            RefName = vbNullString
+         End If
+On Error GoTo 0
+         If RefName = "AccUnit" Then
+            .References.Remove ref
+            Exit Sub
+         End If
+      Next
+   End With
+   
+End Sub
+
+Public Sub InsertFactoryModule()
+
+   Dim Configurator As AccUnit.Configurator
+   
+   With New AccUnitLoaderFactory
+      Set Configurator = .Configurator
+   End With
+   
+   Configurator.InsertAccUnitLoaderFactoryModule AccUnitTlbReferenceExists, True, CurrentVbProject, Application
+   Set Configurator = Nothing
+   
+On Error Resume Next
+'   Application.RunCommand acCmdCompileAndSaveAllModules
+
+End Sub
+
+Private Function AccUnitTlbReferenceExists() As Boolean
+
+   Dim ref As Reference
+   Dim RefName As String
+   
+   For Each ref In CurrentVbProject.References
+On Error Resume Next
+      RefName = ref.Name
+      If Err.Number <> 0 Then
+         Err.Clear
+         RefName = vbNullString
+      End If
+On Error GoTo 0
+      If RefName = "AccUnit" Then
+         AccUnitTlbReferenceExists = True
+         Exit Function
+      End If
+   Next
+   
+End Function
+
+Public Sub ImportTestClasses()
+
+   Dim Configurator As AccUnit.Configurator
+   
+   With New AccUnitLoaderFactory
+      Set Configurator = .Configurator
+   End With
+   
+   Configurator.InsertAccUnitLoaderFactoryModule AccUnitTlbReferenceExists, False, CurrentVbProject, Application
+   Configurator.ImportTestClasses
+   Set Configurator = Nothing
+   
+On Error Resume Next
+'   Application.RunCommand acCmdCompileAndSaveAllModules
+   
+End Sub
+
+Public Sub ExportTestClasses()
+
+   Dim Configurator As AccUnit.Configurator
+   
+   With New AccUnitLoaderFactory
+      Set Configurator = .Configurator
+   End With
+   
+   Configurator.ExportTestClasses
+   Set Configurator = Nothing
+   
+End Sub
+
+Public Sub RemoveTestEnvironment(ByVal RemoveTestModules As Boolean)
+
+   Dim Configurator As AccUnit.Configurator
+   
+   With New AccUnitLoaderFactory
+      Set Configurator = .Configurator
+   End With
+   
+   Configurator.RemoveTestEnvironment RemoveTestModules, , CurrentVbProject
+   Set Configurator = Nothing
+   
+On Error Resume Next
+'   Application.RunCommand acCmdCompileAndSaveAllModules
+
+End Sub


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
This PR fixes an existing heuristic for VBA. It now allows all specifications of the [Option Compare statement](https://learn.microsoft.com/en-us/office/vba/language/reference/user-interface-help/option-compare-statement). A sample for the `Option Compare Text` case was provided.

## Checklist:
- [x] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language:
    - Sample source(s):
      - https://github.com/AccessCodeLib/AccUnit/blob/aca5ccf6f8a30849110bff790708a9c744bc47ab/excel-add-in/source/AccUnitLoaderConfigProcedures.bas
    - Sample license(s): [GNU General Public License v3.0](https://github.com/AccessCodeLib/AccUnit/blob/main/LICENSE)
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.

