### PR TITLE
Add Lingo language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1374,3 +1374,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/vscode-lingo-director"]
+	path = vendor/grammars/vscode-lingo-director
+	url = https://github.com/markhughes/vscode-lingo-director.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1281,6 +1281,9 @@
 [submodule "vendor/grammars/vscode-lean4"]
 	path = vendor/grammars/vscode-lean4
 	url = https://github.com/leanprover/vscode-lean4.git
+[submodule "vendor/grammars/vscode-lingo-director"]
+	path = vendor/grammars/vscode-lingo-director
+	url = https://github.com/markhughes/vscode-lingo-director.git
 [submodule "vendor/grammars/vscode-monkey-c"]
 	path = vendor/grammars/vscode-monkey-c
 	url = https://github.com/ghisguth/vscode-monkey-c
@@ -1374,6 +1377,3 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
-[submodule "vendor/grammars/vscode-lingo-director"]
-	path = vendor/grammars/vscode-lingo-director
-	url = https://github.com/markhughes/vscode-lingo-director.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1156,6 +1156,8 @@ vendor/grammars/vscode-lean4:
 - markdown.lean4.codeblock
 - source.lean4
 - source.lean4.markdown
+vendor/grammars/vscode-lingo-director:
+- source.lingo
 vendor/grammars/vscode-monkey-c:
 - source.mc
 vendor/grammars/vscode-motoko:

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -404,6 +404,8 @@ disambiguations:
     pattern: '^import [A-Z]'
 - extensions: ['.ls']
   rules:
+  - language: Lingo
+    pattern: '^(on\s\w+\sme|^on\s\w+)$|#comment:\s'
   - language: LoomScript
     pattern: '^\s*package\s*[\w\.\/\*\s]*\s*\{'
   - language: LiveScript

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -405,7 +405,7 @@ disambiguations:
 - extensions: ['.ls']
   rules:
   - language: Lingo
-    pattern: '^(on\s\w+\sme|^on\s\w+)$|#comment:\s'
+    pattern: '^on\s\w+([\s\S]*?)\nend$'
   - language: LoomScript
     pattern: '^\s*package\s*[\w\.\/\*\s]*\s*\{'
   - language: LiveScript

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3796,6 +3796,14 @@ Limbo:
   tm_scope: none
   ace_mode: text
   language_id: 201
+Lingo:
+  type: programming
+  color: "#974413"
+  extensions:
+  - ".ls"
+  tm_scope: source.lingo
+  ace_mode: text
+  language_id: 79715894
 Linker Script:
   type: data
   extensions:

--- a/samples/Lingo/AutoDismisser.ls
+++ b/samples/Lingo/AutoDismisser.ls
@@ -1,0 +1,42 @@
+global msgXtra
+
+on clickWindowButton windowRef, buttonNum
+  set WM_LBUTTONDOWN = 513
+  set WM_LBUTTONUP = 514
+  
+  set buttonRefs = baChildWindowList(windowRef, "Button", "", False)
+  if buttonNum <= the count of buttonRefs then
+    set buttonRef = buttonRefs.getAt(buttonNum)
+    msgXtra.send_msg(buttonRef, WM_LBUTTONDOWN, 0, 0)
+    msgXtra.send_msg(buttonRef, WM_LBUTTONUP, 0, 0)
+    return True
+  end if
+  return False
+end
+
+on findDialog windowTitle, exactMatch
+  set dialogClass = "#32770"
+  set dialogRefs = baWindowList(dialogClass, windowTitle, exactMatch)
+  if the count of dialogRefs > 0 then return dialogRefs.getAt(1)
+  return 0
+end
+
+on dismissDialog windowTitle, exactMatch, buttonIndex
+  set dialogRef = findDialog(windowTitle, exactMatch)
+  if dialogRef then return clickWindowButton(dialogRef, buttonIndex)
+end
+
+on dismissPopupDialogs
+  dismissDialog("Director Player Error", True, 1)
+  dismissDialog("Where is" && QUOTE, False, 2)
+end
+
+on prepareMovie
+  if the commandLine = EMPTY then
+    alert "This is a tool used by Cast Ripper. It should not be run directly."
+    halt()
+  else
+    set the title of the window = the commandLine
+  end if
+  set msgXtra = new xtra("msg")
+end

--- a/samples/Lingo/Progress.ls
+++ b/samples/Lingo/Progress.ls
@@ -1,0 +1,43 @@
+global numTasks, finishedTasks, numSteps, finishedSteps
+
+on setTasks num
+  set ongoingTask = numTasks > 0
+  set numTasks = num + ongoingTask
+  set finishedTasks = 0
+end
+
+on removeTasks num
+  set numTasks = max(numTasks - num, 1)
+end
+
+on finishTask
+  if finishedTasks < numTasks then
+    set finishedTasks = finishedTasks + 1
+    setSteps(0)
+  end if
+end
+
+on setSteps num
+  set numSteps = num
+  set finishedSteps = 0
+end
+
+on finishStep
+  if finishedSteps < numSteps then set finishedSteps = finishedSteps + 1
+end
+
+on getProgress
+  set taskProgress = float(finishedSteps) / max(numSteps, 1)
+  return (finishedTasks + taskProgress) / max(numTasks, 1)
+end
+
+on resetProgress
+  set numTasks = 0
+  set finishedTasks = 0
+  set numSteps = 0
+  set finishedSteps = 0
+end
+
+on logProgress
+  logMsg(finishedTasks && "/" && numTasks && "tasks," && finishedSteps && "/" && numSteps && "steps")
+end

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -605,6 +605,7 @@ class TestHeuristics < Minitest::Test
 
   def test_ls_by_heuristics
     assert_heuristics({
+      "Lingo" => all_fixtures("Lingo", "*.ls"),
       "LiveScript" => all_fixtures("LiveScript", "*.ls"),
       "LoomScript" => all_fixtures("LoomScript", "*.ls")
     })

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -310,6 +310,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Lex:** [Alhadis/language-grammars](https://github.com/Alhadis/language-grammars)
 - **LigoLANG:** [pewulfman/Ligo-grammar](https://github.com/pewulfman/Ligo-grammar)
 - **LilyPond:** [nwhetsell/linter-lilypond](https://github.com/nwhetsell/linter-lilypond)
+- **Lingo:** [markhughes/vscode-lingo-director](https://github.com/markhughes/vscode-lingo-director)
 - **Liquid:** [Shopify/liquid-tm-grammar](https://github.com/Shopify/liquid-tm-grammar)
 - **Literate CoffeeScript:** [atom/language-coffee-script](https://github.com/atom/language-coffee-script)
 - **Literate Haskell:** [atom-haskell/language-haskell](https://github.com/atom-haskell/language-haskell)

--- a/vendor/licenses/git_submodule/vscode-lingo-director.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-lingo-director.dep.yml
@@ -1,0 +1,20 @@
+---
+name: vscode-lingo-director
+version: 36b18aa3b8da8f1e240738f833fd24ec90fd878f
+type: git_submodule
+homepage: https://github.com/markhughes/vscode-lingo-director.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright 2023 Mark Hughes
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: This project is licensed under the MIT License. See the [LICENSE](./LICENSE)
+    file for details.
+notices: []


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

Adds support for the [Lingo](https://en.wikipedia.org/wiki/Lingo_(programming_language)) programming language, created for [Adobe Director](https://en.wikipedia.org/wiki/Adobe_Director).

Note that [excluding the biggest contributing organisation](https://github.com/search?type=code&q=NOT+org%3AQuackster+NOT+is%3Afork+path%3A*.ls+%2F%5Eon%5Cs%5Cw%2B%28%5B%5Cs%5CS%5D*%3F%29%5Cnend%24%2F&p=4), Lingo likely does not currently meet popularity requirements. 

## Checklist:
- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.ls+%2F%5Eon%5Cs%5Cw%2B%28%5B%5Cs%5CS%5D*%3F%29%5Cnend%24%2F+NOT+user%3AQuackster
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [AutoDismisser.ls](https://github.com/n0samu/DirectorCastRipper/blob/main/AutoDismisser.ls)
      - [Progress.ls](https://github.com/n0samu/DirectorCastRipper/blob/main/Progress.ls)
    - Sample license(s): [MIT](https://github.com/n0samu/DirectorCastRipper/blob/main/LICENSE)
  - [x] I have included a syntax highlighting grammar: https://github.com/markhughes/vscode-lingo-director
  - [x] I have added a color
    - Hex value: `#974413`
    - Rationale: Calculated as "average colour" in [Adobe Director's logo](https://en.wikipedia.org/wiki/Adobe_Director#/media/File:Adobe_Di.svg).
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.
