### PR TITLE
Add SQLx query files as generated

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -837,7 +837,7 @@ module Linguist
     #
     # Returns true or false.
     def generated_sqlx_query?
-      !!name.match(/^.*\.sqlx\/query-.+\.json$/)
+      !!name.match(/(?:^|.*\/)\.sqlx\/query-.+\.json$/)
     end
   end
 end

--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -829,7 +829,7 @@ module Linguist
 
     # Internal: Is this a generated SQLx query file?
     #
-    # SQLx is a Rust SQL library which generates `**/.sqlx/queries-*.json` files
+    # SQLx is a Rust SQL library which generates `**/.sqlx/query-*.json` files
     # in offline mode (enabled by default).
     #
     # These are used to be able to compile a project without requiring
@@ -837,7 +837,7 @@ module Linguist
     #
     # Returns true or false.
     def generated_sqlx_query?
-      !!name.match(/^.*\.sqlx\/queries-.+\.json$/)
+      !!name.match(/^.*\.sqlx\/query-.+\.json$/)
     end
   end
 end

--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -107,7 +107,8 @@ module Linguist
       generated_haxe? ||
       generated_jooq? ||
       generated_pascal_tlb? ||
-      generated_sorbet_rbi?
+      generated_sorbet_rbi? ||
+      generated_sqlx_query?
     end
 
     # Internal: Is the blob an Xcode file?
@@ -824,6 +825,19 @@ module Linguist
         val = match[1].gsub(/\A["']|["']\Z/, '')
         [key, val]
       end.select { |x| x.length == 2 }.to_h
+    end
+
+    # Internal: Is this a generated SQLx query file?
+    #
+    # SQLx is a Rust SQL library which generates `**/.sqlx/queries-*.json` files
+    # in offline mode (enabled by default).
+    #
+    # These are used to be able to compile a project without requiring
+    # the development database to be online.
+    #
+    # Returns true or false.
+    def generated_sqlx_query?
+      !!name.match(/^.*\.sqlx\/queries-.+\.json$/)
     end
   end
 end

--- a/test/fixtures/Rust/.sqlx/query-2b8b1aae3740a05cb7179be9c7d5af30e8362c3cba0b07bc18fa32ff1a2232cc.json
+++ b/test/fixtures/Rust/.sqlx/query-2b8b1aae3740a05cb7179be9c7d5af30e8362c3cba0b07bc18fa32ff1a2232cc.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT releases.files\n            FROM releases\n            INNER JOIN crates ON crates.id = releases.crate_id\n            WHERE crates.name = $1 AND releases.version = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "files",
+        "type_info": "Json"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "2b8b1aae3740a05cb7179be9c7d5af30e8362c3cba0b07bc18fa32ff1a2232cc"
+}

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -249,6 +249,9 @@ class TestBlob < Minitest::Test
     assert sample_blob_memory("Ruby/rails@7.0.3.1.rbi").generated?
     assert sample_blob_memory("Ruby/rendering.rbi").generated?
     assert sample_blob_memory("Ruby/actionmailer.rbi").generated?
+
+    # SQLx query files
+    assert fixture_blob_memory("Rust/.sqlx/query-2b8b1aae3740a05cb7179be9c7d5af30e8362c3cba0b07bc18fa32ff1a2232cc.json").generated?
   end
 
   def test_vendored


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
Mark `**/.sqlx/query-*.json` files as generated and added a test for it.

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
[SQLx is a Rust SQL library](https://github.com/launchbadge/sqlx) (11.4k stars) which generates `**/.sqlx/query-*.json` files in offline mode (enabled by default).
These are used to be able to compile a project without requiring the development database to be online.

I would like Github to automatically hide these files from diffs, since it could generate lots of files and it's a bit annoying to hide them manually one by one in each PR.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=path%3A**%2F.sqlx%2Fquery-*.json+NOT+is%3Afork
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/rust-lang/docs.rs/blob/master/.sqlx/query-2b8b1aae3740a05cb7179be9c7d5af30e8362c3cba0b07bc18fa32ff1a2232cc.json
    - Sample license(s): MIT
  - [ ] ~~I have included a change to the heuristics to distinguish my language from others using the same extension.~~