### PR TITLE
Fix: 105 typos

### DIFF
--- a/samples/C/rf_io.c
+++ b/samples/C/rf_io.c
@@ -884,7 +884,7 @@ int32_t rfFgetc_UTF16BE(FILE* f,uint32_t *c,char cp)
     char swapE=false;
     uint16_t v1,v2;
     // check if we need to be swapping
-    if(rfUTILS_Endianess() == RF_LITTLE_ENDIAN)
+    if(rfUTILS_Endianness() == RF_LITTLE_ENDIAN)
             swapE = true;
     // read the first 2 bytes
     if(fread(&v1,2,1,f) != 1)
@@ -893,7 +893,7 @@ int32_t rfFgetc_UTF16BE(FILE* f,uint32_t *c,char cp)
         else
             return RE_FILE_EOF;
     }
-    if(swapE)// swap endianess if needed
+    if(swapE)// swap endianness if needed
         rfUTILS_SwapEndianUS(&v1);
     /* If the value is in the surrogate area */
     if(RF_HEXGE_US(v1,0xD800) && RF_HEXLE_US(v1,0xDFFF))
@@ -913,7 +913,7 @@ int32_t rfFgetc_UTF16BE(FILE* f,uint32_t *c,char cp)
                 return RE_FILE_EOF;
             }
         }
-        if(swapE)// swap endianess if needed
+        if(swapE)// swap endianness if needed
             rfUTILS_SwapEndianUS(&v2);
         if(RF_HEXL_US(v2,0xDC00) || RF_HEXG_US(v2,0xDFFF))
         {
@@ -943,7 +943,7 @@ int32_t rfFgetc_UTF16LE(FILE* f,uint32_t *c,char cp)
     char swapE=false;
     uint16_t v1,v2;
     // check if we need to be swapping
-    if(rfUTILS_Endianess() == RF_BIG_ENDIAN)
+    if(rfUTILS_Endianness() == RF_BIG_ENDIAN)
             swapE = true;
     // read the first 2 bytes
     if(fread(&v1,2,1,f) != 1)
@@ -952,7 +952,7 @@ int32_t rfFgetc_UTF16LE(FILE* f,uint32_t *c,char cp)
         else
             return RE_FILE_EOF;
     }
-    if(swapE)// swap endianess if needed
+    if(swapE)// swap endianness if needed
         rfUTILS_SwapEndianUS(&v1);
     /* If the value is in the surrogate area */
     if(RF_HEXGE_US(v1,0xD800) && RF_HEXLE_US(v1,0xDFFF))
@@ -972,7 +972,7 @@ int32_t rfFgetc_UTF16LE(FILE* f,uint32_t *c,char cp)
                 return RE_FILE_EOF;
             }
         }
-        if(swapE)// swap endianess if needed
+        if(swapE)// swap endianness if needed
             rfUTILS_SwapEndianUS(&v2);
         if(RF_HEXL_US(v2,0xDC00) || RF_HEXG_US(v2,0xDFFF))
         {
@@ -1007,7 +1007,7 @@ int32_t rfFgetc_UTF32LE(FILE* f,uint32_t *c)
             return RE_FILE_EOF;
     }
     // check if we need to be swapping
-    if(rfUTILS_Endianess() == RF_BIG_ENDIAN)
+    if(rfUTILS_Endianness() == RF_BIG_ENDIAN)
             rfUTILS_SwapEndianUI(c);
     return RF_SUCCESS;
 }
@@ -1022,7 +1022,7 @@ int32_t rfFgetc_UTF32BE(FILE* f,uint32_t *c)
             return RE_FILE_EOF;
     }
     // check if we need to be swapping
-    if(rfUTILS_Endianess() == RF_LITTLE_ENDIAN)
+    if(rfUTILS_Endianness() == RF_LITTLE_ENDIAN)
             rfUTILS_SwapEndianUI(c);
     return RF_SUCCESS;
 }
@@ -1044,7 +1044,7 @@ int32_t rfFback_UTF32BE(FILE* f,uint32_t *c)
         i_FSEEK_CHECK("Going backwards in a Big Endian UTF-32 file stream")
     }
     // check if we need to be swapping
-    if(rfUTILS_Endianess() == RF_LITTLE_ENDIAN)
+    if(rfUTILS_Endianness() == RF_LITTLE_ENDIAN)
             rfUTILS_SwapEndianUI(c);
     return RF_SUCCESS;
 }
@@ -1065,7 +1065,7 @@ int32_t rfFback_UTF32LE(FILE* f,uint32_t *c)
         i_FSEEK_CHECK("Going backwards in a Big Endian UTF-32 file stream")
     }
     // check if we need to be swapping
-    if(rfUTILS_Endianess() == RF_BIG_ENDIAN)
+    if(rfUTILS_Endianness() == RF_BIG_ENDIAN)
             rfUTILS_SwapEndianUI(c);
     return RF_SUCCESS;
 }
@@ -1075,7 +1075,7 @@ int32_t rfFback_UTF16BE(FILE* f,uint32_t *c)
     char swapE=false;
     uint16_t v1,v2;
     // check if we need to be swapping
-    if(rfUTILS_Endianess() == RF_LITTLE_ENDIAN)
+    if(rfUTILS_Endianness() == RF_LITTLE_ENDIAN)
             swapE = true;
     // go back and read the last 2 bytes
     if(fseek(f,-2,SEEK_CUR) != 0)
@@ -1090,7 +1090,7 @@ int32_t rfFback_UTF16BE(FILE* f,uint32_t *c)
     {
         i_FSEEK_CHECK("Going backwards in a Big Endian UTF-16 file stream")
     }
-    if(swapE)// swap endianess if needed
+    if(swapE)// swap endianness if needed
         rfUTILS_SwapEndianUS(&v1);
     /* If the word is a surrogate pair */
     if(RF_HEXGE_US(v1,0xDC00) && RF_HEXLE_US(v1,0xDFFF))
@@ -1108,7 +1108,7 @@ int32_t rfFback_UTF16BE(FILE* f,uint32_t *c)
         {
             i_FSEEK_CHECK("Going backwards in a Big Endian UTF-16 file stream")
         }
-        if(swapE)// swap endianess if needed
+        if(swapE)// swap endianness if needed
             rfUTILS_SwapEndianUS(&v2);
         if(RF_HEXL_US(v2,0xD800) || RF_HEXG_US(v2,0xDBFF))
         {
@@ -1142,7 +1142,7 @@ int32_t rfFback_UTF16LE(FILE* f,uint32_t *c)
     char swapE=false;
     uint16_t v1,v2;
     // check if we need to be swapping
-    if(rfUTILS_Endianess() == RF_BIG_ENDIAN)
+    if(rfUTILS_Endianness() == RF_BIG_ENDIAN)
             swapE = true;
     // go back and read the last 2 bytes
     if(fseek(f,-2,SEEK_CUR) != 0)
@@ -1157,7 +1157,7 @@ int32_t rfFback_UTF16LE(FILE* f,uint32_t *c)
     {
         i_FSEEK_CHECK("Going backwards in a Big Endian UTF-16 file stream")
     }
-    if(swapE)// swap endianess if needed
+    if(swapE)// swap endianness if needed
         rfUTILS_SwapEndianUS(&v1);
     /* If the word is a surrogate pair */
     if(RF_HEXGE_US(v1,0xDC00) && RF_HEXLE_US(v1,0xDFFF))
@@ -1175,7 +1175,7 @@ int32_t rfFback_UTF16LE(FILE* f,uint32_t *c)
         {
             i_FSEEK_CHECK("Going backwards in a Big Endian UTF-16 file stream")
         }
-        if(swapE)// swap endianess if needed
+        if(swapE)// swap endianness if needed
             rfUTILS_SwapEndianUS(&v2);
         if(RF_HEXL_US(v2,0xD800) || RF_HEXG_US(v2,0xDBFF))
         {

--- a/samples/C/rf_io.h
+++ b/samples/C/rf_io.h
@@ -187,7 +187,7 @@ i_DECLIMEX_ int32_t rfFReadLine_UTF32LE(FILE* f,char** utf8,uint32_t* byteLength
 // Since the function null terminates the buffer the given @c buff needs to be of at least
 // @c num+7 size to cater for the worst case.
 //
-// The final bytestream stored inside @c buff is in the endianess of the system.
+// The final bytestream stored inside @c buff is in the endianness of the system.
 //
 // If right after the last character read comes the EOF, the function
 // shall detect so and assign @c true to @c eof.
@@ -226,7 +226,7 @@ i_DECLIMEX_ int32_t rfFgets_UTF32BE(char* buff,uint32_t num,FILE* f,char* eof);
 // Since the function null terminates the buffer the given @c buff needs to be of at least
 // @c num+7 size to cater for the worst case.
 //
-// The final bytestream stored inside @c buff is in the endianess of the system.
+// The final bytestream stored inside @c buff is in the endianness of the system.
 //
 // If right after the last character read comes the EOF, the function
 // shall detect so and assign @c true to @c eof.
@@ -266,7 +266,7 @@ i_DECLIMEX_ int32_t rfFgets_UTF32LE(char* buff,uint32_t num,FILE* f,char* eof);
 // Since the function null terminates the buffer the given @c buff needs to be of at least
 // @c num+5 size to cater for the worst case.
 //
-// The final bytestream stored inside @c buff is in the endianess of the system.
+// The final bytestream stored inside @c buff is in the endianness of the system.
 //
 // If right after the last character read comes the EOF, the function
 // shall detect so and assign @c true to @c eof.
@@ -305,7 +305,7 @@ i_DECLIMEX_ int32_t rfFgets_UTF16BE(char* buff,uint32_t num,FILE* f,char* eof);
 // Since the function null terminates the buffer the given @c buff needs to be of at least
 // @c num+5 size to cater for the worst case.
 //
-// The final bytestream stored inside @c buff is in the endianess of the system.
+// The final bytestream stored inside @c buff is in the endianness of the system.
 //
 // If right after the last character read comes the EOF, the function
 // shall detect so and assign @c true to @c eof.

--- a/samples/C/rfc_string.c
+++ b/samples/C/rfc_string.c
@@ -119,7 +119,7 @@ RF_String* i_rfString_CreateLocal1(const char* s,...)
     RF_MALLOC(codepoints,i)
 #endif
 #if (RF_OPTION_SOURCE_ENCODING  ==  RF_UTF16_LE)// decode the UTF16
-    if(rfUTILS_Endianess() == RF_LITTLE_ENDIAN)
+    if(rfUTILS_Endianness() == RF_LITTLE_ENDIAN)
         if(rfUTF16_Decode(buff,&characterLength,codepoints) == false)
             goto cleanup;
     else
@@ -127,7 +127,7 @@ RF_String* i_rfString_CreateLocal1(const char* s,...)
             goto cleanup;
 
 #elif RF_OPTION_SOURCE_ENCODING == RF_UTF16_BE// decode the UTF16
-    if(rfUTILS_Endianess() == RF_LITTLE_ENDIAN)
+    if(rfUTILS_Endianness() == RF_LITTLE_ENDIAN)
         if(rfUTF16_Decode_swap(buff,&characterLength,codepoints) == false)
             goto cleanup;
     else
@@ -135,7 +135,7 @@ RF_String* i_rfString_CreateLocal1(const char* s,...)
             goto cleanup;
 #elif RF_OPTION_SOURCE_ENCODING == RF_UTF32_LE// copy the UTF32 into the codepoint
     memcpy(codepoints,buff,i);
-    if(rfUTILS_Endianess != RF_LITTLE_ENDIAN)
+    if(rfUTILS_Endianness != RF_LITTLE_ENDIAN)
     {
         for(j=0;j<i;j+=4)
         {
@@ -144,7 +144,7 @@ RF_String* i_rfString_CreateLocal1(const char* s,...)
     }
 #elif RF_OPTION_SOURCE_ENCODING == RF_UTF32_BE// copy the UTF32 into the codepoint
     memcpy(codepoints,buff,i);
-    if(rfUTILS_Endianess !RF_BIG_ENDIAN RF_LITTLE_ENDIAN)
+    if(rfUTILS_Endianness !RF_BIG_ENDIAN RF_LITTLE_ENDIAN)
     {
         for(j=0;j<i;j+=4)
         {
@@ -240,7 +240,7 @@ RF_String* i_NVrfString_CreateLocal(const char* s)
     RF_MALLOC(codepoints,i)
 #endif
 #if (RF_OPTION_SOURCE_ENCODING  ==  RF_UTF16_LE)// decode the UTF16
-    if(rfUTILS_Endianess() == RF_LITTLE_ENDIAN)
+    if(rfUTILS_Endianness() == RF_LITTLE_ENDIAN)
         if(rfUTF16_Decode(s,&characterLength,codepoints) == false)
             goto cleanup;
     else
@@ -248,7 +248,7 @@ RF_String* i_NVrfString_CreateLocal(const char* s)
             goto cleanup;
 
 #elif RF_OPTION_SOURCE_ENCODING == RF_UTF16_BE// decode the UTF16
-    if(rfUTILS_Endianess() == RF_LITTLE_ENDIAN)
+    if(rfUTILS_Endianness() == RF_LITTLE_ENDIAN)
         if(rfUTF16_Decode_swap(s,&characterLength,codepoints) == false)
             goto cleanup;
     else
@@ -256,7 +256,7 @@ RF_String* i_NVrfString_CreateLocal(const char* s)
             goto cleanup;
 #elif RF_OPTION_SOURCE_ENCODING == RF_UTF32_LE// copy the UTF32 into the codepoint
     memcpy(codepoints,s,i);
-    if(rfUTILS_Endianess != RF_LITTLE_ENDIAN)
+    if(rfUTILS_Endianness != RF_LITTLE_ENDIAN)
     {
         for(j=0;j<i;j+=4)
         {
@@ -265,7 +265,7 @@ RF_String* i_NVrfString_CreateLocal(const char* s)
     }
 #elif RF_OPTION_SOURCE_ENCODING == RF_UTF32_BE// copy the UTF32 into the codepoint
     memcpy(codepoints,s,i);
-    if(rfUTILS_Endianess !RF_BIG_ENDIAN RF_LITTLE_ENDIAN)
+    if(rfUTILS_Endianness !RF_BIG_ENDIAN RF_LITTLE_ENDIAN)
     {
         for(j=0;j<i;j+=4)
         {
@@ -535,11 +535,11 @@ char rfString_Init_f(RF_String* str,float f)
 }
 
 // Allocates and returns a string with the given UTF-16 byte sequence. Given characters have to be in UTF-16. A check for valid sequence of bytes is performed.<b>Can't be used with RF_StringX</b>
-RF_String* rfString_Create_UTF16(const char* s,char endianess)
+RF_String* rfString_Create_UTF16(const char* s,char endianness)
 {
     RF_String* ret;
     RF_MALLOC(ret,sizeof(RF_String));
-    if(rfString_Init_UTF16(ret,s,endianess)==false)
+    if(rfString_Init_UTF16(ret,s,endianness)==false)
     {
         free(ret);
         return 0;
@@ -547,7 +547,7 @@ RF_String* rfString_Create_UTF16(const char* s,char endianess)
     return ret;
 }
 // Initializes a string with the given UTF-16 byte sequence. Given characters have to be in UTF-16. A check for valid sequence of bytes is performed.<b>Can't be used with RF_StringX</b>
-char rfString_Init_UTF16(RF_String* str,const char* s,char endianess)
+char rfString_Init_UTF16(RF_String* str,const char* s,char endianness)
 {
     // decode the utf-16 and get the code points
     uint32_t* codepoints;
@@ -560,12 +560,12 @@ char rfString_Init_UTF16(RF_String* str,const char* s,char endianess)
     }
     byteLength+=3;// for the last utf-16 null termination character
     RF_MALLOC(codepoints,byteLength*2) // allocate the codepoints
-    // parse the given byte stream depending on the endianess parameter
-    switch(endianess)
+    // parse the given byte stream depending on the endianness parameter
+    switch(endianness)
     {
         case RF_LITTLE_ENDIAN:
         case RF_BIG_ENDIAN:
-            if(rfUTILS_Endianess() == endianess)// same endianess as the local
+            if(rfUTILS_Endianness() == endianness)// same endianness as the local
             {
                 if(rfUTF16_Decode(s,&characterLength,codepoints) == false)
                 {
@@ -585,7 +585,7 @@ char rfString_Init_UTF16(RF_String* str,const char* s,char endianess)
             }
         break;
         default:
-            LOG_ERROR("Illegal endianess value provided",RE_INPUT);
+            LOG_ERROR("Illegal endianness value provided",RE_INPUT);
             free(codepoints);
             return false;
         break;
@@ -629,21 +629,21 @@ char rfString_Init_UTF32(RF_String* str,const char* s)
     // first of all check for existence of BOM in the beginning of the sequence
     if(RF_HEXEQ_UI(codeBuffer[0],0xFEFF))// big endian
     {
-        if(rfUTILS_Endianess()==RF_LITTLE_ENDIAN)
+        if(rfUTILS_Endianness()==RF_LITTLE_ENDIAN)
             swapE = true;
     }
     if(RF_HEXEQ_UI(codeBuffer[0],0xFFFE0000))// little
     {
-        if(rfUTILS_Endianess()==RF_BIG_ENDIAN)
+        if(rfUTILS_Endianness()==RF_BIG_ENDIAN)
             swapE = true;
     }
     else// according to the standard no BOM means big endian
     {
-        if(rfUTILS_Endianess() == RF_LITTLE_ENDIAN)
+        if(rfUTILS_Endianness() == RF_LITTLE_ENDIAN)
             swapE = true;
     }
 
-    // if we need to have endianess swapped do it
+    // if we need to have endianness swapped do it
     if(swapE==true)
     {
         while(codeBuffer[i] != 0)
@@ -2055,20 +2055,20 @@ int32_t rfString_Append_fUTF8(RF_String* str,FILE*f,char* eof)
 }
 
 // Allocates and returns a string from file parsing. The file's encoding must be UTF-16.If for some reason (like EOF reached) no string can be read then null is returned. A check for a valid sequence of bytes is performed.
-RF_String* rfString_Create_fUTF16(FILE* f,char endianess,char* eof)
+RF_String* rfString_Create_fUTF16(FILE* f,char endianness,char* eof)
 {
     RF_String* ret;
     RF_MALLOC(ret,sizeof(RF_String));
-    if(rfString_Init_fUTF16(ret,f,endianess,eof) < 0)
+    if(rfString_Init_fUTF16(ret,f,endianness,eof) < 0)
         return 0;
     return ret;
 }
 // Initializes a string from file parsing. The file's encoding must be UTF-16.If for some reason (like EOF reached) no string can be read then null is returned. A check for a valid sequence of bytes is performed.
-int32_t rfString_Init_fUTF16(RF_String* str,FILE* f, char endianess,char* eof)
+int32_t rfString_Init_fUTF16(RF_String* str,FILE* f, char endianness,char* eof)
 {
     int32_t bytesN;
-    // depending on the file's endianess
-    if(endianess == RF_LITTLE_ENDIAN)
+    // depending on the file's endianness
+    if(endianness == RF_LITTLE_ENDIAN)
     {
         if((bytesN=rfFReadLine_UTF16LE(f,&str->bytes,&str->byteLength,eof)) < 0)
         {
@@ -2089,14 +2089,14 @@ int32_t rfString_Init_fUTF16(RF_String* str,FILE* f, char endianess,char* eof)
 }
 
 // Assigns to an already initialized String from File parsing
-int32_t rfString_Assign_fUTF16(RF_String* str,FILE* f, char endianess,char* eof)
+int32_t rfString_Assign_fUTF16(RF_String* str,FILE* f, char endianness,char* eof)
 {
 
     uint32_t utf8ByteLength;
     int32_t bytesN;
     char* utf8 = 0;
-    // depending on the file's endianess
-    if(endianess == RF_LITTLE_ENDIAN)
+    // depending on the file's endianness
+    if(endianness == RF_LITTLE_ENDIAN)
     {
         if((bytesN=rfFReadLine_UTF16LE(f,&utf8,&utf8ByteLength,eof)) < 0)
         {
@@ -2126,13 +2126,13 @@ int32_t rfString_Assign_fUTF16(RF_String* str,FILE* f, char endianess,char* eof)
 }
 
 // Appends to an already initialized String from File parsing
-int32_t rfString_Append_fUTF16(RF_String* str,FILE* f, char endianess,char* eof)
+int32_t rfString_Append_fUTF16(RF_String* str,FILE* f, char endianness,char* eof)
 {
     char*utf8;
     uint32_t utf8ByteLength;
     int32_t bytesN;
-    // depending on the file's endianess
-    if(endianess == RF_LITTLE_ENDIAN)
+    // depending on the file's endianness
+    if(endianness == RF_LITTLE_ENDIAN)
     {
         if((bytesN=rfFReadLine_UTF16LE(f,&utf8,&utf8ByteLength,eof)) < 0)
         {
@@ -2155,11 +2155,11 @@ int32_t rfString_Append_fUTF16(RF_String* str,FILE* f, char endianess,char* eof)
 }
 
 // Allocates and returns a string from file parsing. The file's encoding must be UTF-32.If for some reason (like EOF reached) no string can be read then null is returned. A check for a valid sequence of bytes is performed.
-RF_String* rfString_Create_fUTF32(FILE* f,char endianess,char* eof)
+RF_String* rfString_Create_fUTF32(FILE* f,char endianness,char* eof)
 {
     RF_String* ret;
     RF_MALLOC(ret,sizeof(RF_String));
-    if(rfString_Init_fUTF32(ret,f,endianess,eof) < 0)
+    if(rfString_Init_fUTF32(ret,f,endianness,eof) < 0)
     {
         free(ret);
         return 0;
@@ -2167,11 +2167,11 @@ RF_String* rfString_Create_fUTF32(FILE* f,char endianess,char* eof)
     return ret;
 }
 // Initializes a string from file parsing. The file's encoding must be UTF-32.If for some reason (like EOF reached) no string can be read then null is returned. A check for a valid sequence of bytes is performed.
-int32_t rfString_Init_fUTF32(RF_String* str,FILE* f,char endianess,char* eof)
+int32_t rfString_Init_fUTF32(RF_String* str,FILE* f,char endianness,char* eof)
 {
     int32_t bytesN;
-    // depending on the file's endianess
-    if(endianess == RF_LITTLE_ENDIAN)
+    // depending on the file's endianness
+    if(endianness == RF_LITTLE_ENDIAN)
     {
         if((bytesN=rfFReadLine_UTF32LE(f,&str->bytes,&str->byteLength,eof)) <0)
         {
@@ -2191,13 +2191,13 @@ int32_t rfString_Init_fUTF32(RF_String* str,FILE* f,char endianess,char* eof)
     return bytesN;
 }
 // Assigns the contents of a UTF-32 file to a string
-int32_t rfString_Assign_fUTF32(RF_String* str,FILE* f,char endianess, char* eof)
+int32_t rfString_Assign_fUTF32(RF_String* str,FILE* f,char endianness, char* eof)
 {
     int32_t bytesN;
     char*utf8;
     uint32_t utf8ByteLength;
-    // depending on the file's endianess
-    if(endianess == RF_LITTLE_ENDIAN)
+    // depending on the file's endianness
+    if(endianness == RF_LITTLE_ENDIAN)
     {
         if((bytesN=rfFReadLine_UTF32LE(f,&utf8,&utf8ByteLength,eof)) < 0)
         {
@@ -2226,13 +2226,13 @@ int32_t rfString_Assign_fUTF32(RF_String* str,FILE* f,char endianess, char* eof)
     return bytesN;
 }
 // Appends the contents of a UTF-32 file to a string
-int32_t rfString_Append_fUTF32(RF_String* str,FILE* f,char endianess, char* eof)
+int32_t rfString_Append_fUTF32(RF_String* str,FILE* f,char endianness, char* eof)
 {
     int32_t bytesN;
     char*utf8;
     uint32_t utf8ByteLength;
-    // depending on the file's endianess
-    if(endianess == RF_LITTLE_ENDIAN)
+    // depending on the file's endianness
+    if(endianness == RF_LITTLE_ENDIAN)
     {
         if((bytesN=rfFReadLine_UTF32LE(f,&utf8,&utf8ByteLength,eof)) < 0)
         {
@@ -2273,7 +2273,7 @@ int32_t i_rfString_Fwrite(void* sP,FILE* f,char* encodingP)
         break;
         case RF_UTF16_LE:
             utf16 = rfString_ToUTF16(s,&length);
-            if(rfUTILS_Endianess() != RF_LITTLE_ENDIAN)
+            if(rfUTILS_Endianness() != RF_LITTLE_ENDIAN)
             {
                 for(i=0;i<length;i++)
                 {
@@ -2290,7 +2290,7 @@ int32_t i_rfString_Fwrite(void* sP,FILE* f,char* encodingP)
         break;
         case RF_UTF16_BE:
             utf16 = rfString_ToUTF16(s,&length);
-            if(rfUTILS_Endianess() != RF_BIG_ENDIAN)
+            if(rfUTILS_Endianness() != RF_BIG_ENDIAN)
             {
                 for(i=0;i<length;i++)
                 {
@@ -2307,7 +2307,7 @@ int32_t i_rfString_Fwrite(void* sP,FILE* f,char* encodingP)
         break;
         case RF_UTF32_LE:
             utf32 = rfString_ToUTF32(s,&length);
-            if(rfUTILS_Endianess() != RF_LITTLE_ENDIAN)
+            if(rfUTILS_Endianness() != RF_LITTLE_ENDIAN)
             {
                 for(i=0;i<length;i++)
                 {
@@ -2324,7 +2324,7 @@ int32_t i_rfString_Fwrite(void* sP,FILE* f,char* encodingP)
         break;
         case RF_UTF32_BE:
             utf32 = rfString_ToUTF32(s,&length);
-            if(rfUTILS_Endianess() != RF_BIG_ENDIAN)
+            if(rfUTILS_Endianness() != RF_BIG_ENDIAN)
             {
                 for(i=0;i<length;i++)
                 {

--- a/samples/C/rfc_string.h
+++ b/samples/C/rfc_string.h
@@ -274,10 +274,10 @@ i_DECLIMEX_ char rfString_Init_f(RF_String* str,float f);
 // @notinherited{StringX}
 // Given characters have to be in UTF-16
 // @param s The sequence of bytes for the characters in UTF-16.
-// @param endianess A flag that determined in what endianess the sequence of UTF-16 bytes is in. Possible values here is
+// @param endianness A flag that determined in what endianness the sequence of UTF-16 bytes is in. Possible values here is
 // @c RF_LITTLE_ENDIAN and @c RF_BIG_ENDIAN.
-// @return Returns the initialized RF_string or null in case of failure to initialize, due to invalid utf-16 sequence or illegal endianess value
-i_DECLIMEX_ RF_String* rfString_Create_UTF16(const char* s,char endianess);
+// @return Returns the initialized RF_string or null in case of failure to initialize, due to invalid utf-16 sequence or illegal endianness value
+i_DECLIMEX_ RF_String* rfString_Create_UTF16(const char* s,char endianness);
 // @memberof RF_String
 // @brief Initializes a string with the given UTF-16 byte sequence.
 //
@@ -285,10 +285,10 @@ i_DECLIMEX_ RF_String* rfString_Create_UTF16(const char* s,char endianess);
 // Given characters have to be in UTF-16
 // @param str The string to initialize
 // @param s The sequence of bytes for the characters in UTF-16.
-// @param endianess A flag that determined in what endianess the sequence of UTF-16 bytes is in. Possible values here is
+// @param endianness A flag that determined in what endianness the sequence of UTF-16 bytes is in. Possible values here is
 // @c RF_LITTLE_ENDIAN and @c RF_BIG_ENDIAN.
-// @return Returns true for succesfull initialization and false otherwise due to invalid utf-16 sequence or illegal endianess value
-i_DECLIMEX_ char rfString_Init_UTF16(RF_String* str,const char* s,char endianess);
+// @return Returns true for succesfull initialization and false otherwise due to invalid utf-16 sequence or illegal endianness value
+i_DECLIMEX_ char rfString_Init_UTF16(RF_String* str,const char* s,char endianness);
 
 // @memberof RF_String
 // @cppnotctor
@@ -391,7 +391,7 @@ i_DECLIMEX_ const char* rfString_ToUTF8(RF_String* s);
 //
 // @isinherited{StringX}
 // This function allocates a UTF-16 buffer in which the string's
-// UTF-8 contents are encoded as UTF-16. The endianess of the buffer
+// UTF-8 contents are encoded as UTF-16. The endianness of the buffer
 // is that of the system. The returned buffer needs to be freed by the user
 // later.
 // @param[in] s The string in question
@@ -405,7 +405,7 @@ i_DECLIMEX_ uint16_t* rfString_ToUTF16(RF_String* s,uint32_t* length);
 //
 // @isinherited{StringX}
 // This function allocates a UTF-32 buffer in which the string's
-// UTF-8 contents are encoded as UTF-32. The endianess of the buffer
+// UTF-8 contents are encoded as UTF-32. The endianness of the buffer
 // is that of the system. The returned buffer needs to be freed by the user
 // later.
 // @param[in] s The string in question
@@ -1298,11 +1298,11 @@ i_DECLIMEX_ int32_t rfString_Append_fUTF8(RF_String* str,FILE* f, char* eof);
 // Read the file stream @c f until either a newline character or the EOF is reached and saves it as an RF_StringX
 // The file's encoding must be UTF-16.If for some reason (like EOF reached) no string can be read then null is returned. A check for a valid sequence of bytes is performed.
 // @param f A valid and open file pointer in read mode from which to read the string. The file's encoding must be UTF-16.
-// @param endianess A flag that determines in what endianess the UTF-16 file is encoded in. Possible values here are
+// @param endianness A flag that determines in what endianness the UTF-16 file is encoded in. Possible values here are
 // @c RF_LITTLE_ENDIAN and @c RF_BIG_ENDIAN.
 // @param[out] eof Pass a pointer to a char to receive a true or false value in case the end of file was reached with this initialization
 // @return The initialized string or null pointer in case of failure to read the file
-i_DECLIMEX_ RF_String* rfString_Create_fUTF16(FILE* f, char endianess,char* eof);
+i_DECLIMEX_ RF_String* rfString_Create_fUTF16(FILE* f, char endianness,char* eof);
 // @memberof RF_String
 // @brief Initializes a string from UTF-16 file parsing
 //
@@ -1311,12 +1311,12 @@ i_DECLIMEX_ RF_String* rfString_Create_fUTF16(FILE* f, char endianess,char* eof)
 // The file's encoding must be UTF-16.If for some reason (like EOF reached) no string can be read then null is returned. A check for a valid sequence of bytes is performed.
 // @param str The extended string to initialize
 // @param f A valid and open file pointer in read mode from which to read the string. The file's encoding must be UTF-16.
-// @param endianess A flag that determines in what endianess the UTF-16 file is encoded in. Possible values here are
+// @param endianness A flag that determines in what endianness the UTF-16 file is encoded in. Possible values here are
 // @c RF_LITTLE_ENDIAN and @c RF_BIG_ENDIAN.
 // @param[out] eof Pass a pointer to a char to receive a true or false value in case the end of file was reached with this initialization
 // @return Returns either a positive number for succesfull initialization that represents the bytes read from the file.
 // If there was a problem an error is returned. Possible errors are any of those that @ref rfFReadLine_UTF16LE() can produce.
-i_DECLIMEX_ int32_t rfString_Init_fUTF16(RF_String* str,FILE* f, char endianess,char* eof);
+i_DECLIMEX_ int32_t rfString_Init_fUTF16(RF_String* str,FILE* f, char endianness,char* eof);
 
 // @memberof RF_String
 // @brief Appends the contents of a UTF-16 file a String
@@ -1326,12 +1326,12 @@ i_DECLIMEX_ int32_t rfString_Init_fUTF16(RF_String* str,FILE* f, char endianess,
 // The file's encoding must be UTF-16.If for some reason (like EOF reached) no string can be read then null is returned. A check for a valid sequence of bytes is performed.
 // @param str The extended string to append to
 // @param f A valid and open file pointer in read mode from which to read the string. The file's encoding must be UTF-16.
-// @param endianess A flag that determines in what endianess the UTF-16 file is encoded in. Possible values here are
+// @param endianness A flag that determines in what endianness the UTF-16 file is encoded in. Possible values here are
 // @c RF_LITTLE_ENDIAN and @c RF_BIG_ENDIAN.
 // @param[out] eof Pass a pointer to a char to receive a true or false value in case the end of file was reached with this appending
 // @return Returns either a positive number for succesfull appending that represents the bytes read from the file.
 // If there was a problem an error is returned. Possible errors are any of those that @ref rfFReadLine_UTF16LE() can produce.
-i_DECLIMEX_ int32_t rfString_Append_fUTF16(RF_String* str,FILE* f, char endianess,char* eof);
+i_DECLIMEX_ int32_t rfString_Append_fUTF16(RF_String* str,FILE* f, char endianness,char* eof);
 // @memberof RF_String
 // @brief Assigns the contents of a UTF-16 file to an already initialized string
 //
@@ -1340,12 +1340,12 @@ i_DECLIMEX_ int32_t rfString_Append_fUTF16(RF_String* str,FILE* f, char endianes
 // The file's encoding must be UTF-16.If for some reason (like EOF reached) no string can be read then null is returned. A check for a valid sequence of bytes is performed.
 // @param str The extended string to assign to
 // @param f A valid and open file pointer in read mode from which to read the string. The file's encoding must be UTF-16.
-// @param endianess A flag that determines in what endianess the UTF-16 file is encoded in. Possible values here are
+// @param endianness A flag that determines in what endianness the UTF-16 file is encoded in. Possible values here are
 // @c RF_LITTLE_ENDIAN and @c RF_BIG_ENDIAN.
 // @param[out] eof Pass a pointer to a char to receive a true or false value in case the end of file was reached with this assignment
 // @return Returns either a positive number for succesfull assignment that represents the bytes read from the file.
 // If there was a problem an error is returned. Possible errors are any of those that @ref rfFReadLine_UTF16LE() can produce.
-i_DECLIMEX_ int32_t rfString_Assign_fUTF16(RF_String* str,FILE* f, char endianess,char* eof);
+i_DECLIMEX_ int32_t rfString_Assign_fUTF16(RF_String* str,FILE* f, char endianness,char* eof);
 
 // @memberof RF_String
 // @cppnotctor
@@ -1355,11 +1355,11 @@ i_DECLIMEX_ int32_t rfString_Assign_fUTF16(RF_String* str,FILE* f, char endianes
 // Read the file stream @c f until either a newline character or the EOF is reached and saves it as an RF_StringX
 // The file's encoding must be UTF-32.If for some reason (like EOF reached) no string can be read then null is returned. A check for a valid sequence of bytes is performed.
 // @param f A valid and open file pointer in read mode from which to read the string. The file's encoding must be UTF-32.
-// @param endianess A flag that determines in what endianess the UTF-32 file is encoded in. Possible values here are
+// @param endianness A flag that determines in what endianness the UTF-32 file is encoded in. Possible values here are
 // @c RF_LITTLE_ENDIAN and @c RF_BIG_ENDIAN.
 // @param[out] eof Pass a pointer to a char to receive a true or false value in case the end of file was reached with this initialization
 // @return The initialized string or null pointer in case of failure to read the file
-i_DECLIMEX_ RF_String* rfString_Create_fUTF32(FILE* f,char endianess, char* eof);
+i_DECLIMEX_ RF_String* rfString_Create_fUTF32(FILE* f,char endianness, char* eof);
 // @memberof RF_String
 // @brief Initializes a string from UTF-32 file parsing
 //
@@ -1368,12 +1368,12 @@ i_DECLIMEX_ RF_String* rfString_Create_fUTF32(FILE* f,char endianess, char* eof)
 // The file's encoding must be UTF-32.If for some reason (like EOF reached) no string can be read then null is returned. A check for a valid sequence of bytes is performed.
 // @param str The extended string to initialize
 // @param f A valid and open file pointer in read mode from which to read the string. The file's encoding must be UTF-32.
-// @param endianess A flag that determines in what endianess the UTF-32 file is encoded in. Possible values here are
+// @param endianness A flag that determines in what endianness the UTF-32 file is encoded in. Possible values here are
 // @c RF_LITTLE_ENDIAN and @c RF_BIG_ENDIAN.
 // @param[out] eof Pass a pointer to a char to receive a true or false value in case the end of file was reached with this initialization
 // @return Returns either a positive number for succesfull initialization that represents the bytes read from the file.
 // If there was a problem an error is returned. Possible errors are any of those that @ref rfFReadLine_UTF32LE() can produce.
-i_DECLIMEX_ int32_t rfString_Init_fUTF32(RF_String* str,FILE* f,char endianess, char* eof);
+i_DECLIMEX_ int32_t rfString_Init_fUTF32(RF_String* str,FILE* f,char endianness, char* eof);
 // @memberof RF_String
 // @brief Assigns the contents of a UTF-32 file to a string
 //
@@ -1382,12 +1382,12 @@ i_DECLIMEX_ int32_t rfString_Init_fUTF32(RF_String* str,FILE* f,char endianess, 
 // The file's encoding must be UTF-32.If for some reason (like EOF reached) no string can be read then null is returned. A check for a valid sequence of bytes is performed.
 // @param str The extended string to assign to
 // @param f A valid and open file pointer in read mode from which to read the string. The file's encoding must be UTF-32.
-// @param endianess A flag that determines in what endianess the UTF-32 file is encoded in. Possible values here are
+// @param endianness A flag that determines in what endianness the UTF-32 file is encoded in. Possible values here are
 // @c RF_LITTLE_ENDIAN and @c RF_BIG_ENDIAN.
 // @param[out] eof Pass a pointer to a char to receive a true or false value in case the end of file was reached with this assignment
 // @return Returns either a positive number for succesfull assignment that represents the bytes read from the file.
 // If there was a problem an error is returned. Possible errors are any of those that @ref rfFReadLine_UTF32LE() can produce.
-i_DECLIMEX_ int32_t rfString_Assign_fUTF32(RF_String* str,FILE* f,char endianess, char* eof);
+i_DECLIMEX_ int32_t rfString_Assign_fUTF32(RF_String* str,FILE* f,char endianness, char* eof);
 // @memberof RF_String
 // @brief Appends the contents of a UTF-32 file to a string
 //
@@ -1396,12 +1396,12 @@ i_DECLIMEX_ int32_t rfString_Assign_fUTF32(RF_String* str,FILE* f,char endianess
 // The file's encoding must be UTF-32.If for some reason (like EOF reached) no string can be read then null is returned. A check for a valid sequence of bytes is performed.
 // @param str The extended string to append to
 // @param f A valid and open file pointer in read mode from which to read the string. The file's encoding must be UTF-32.
-// @param endianess A flag that determines in what endianess the UTF-32 file is encoded in. Possible values here are
+// @param endianness A flag that determines in what endianness the UTF-32 file is encoded in. Possible values here are
 // @c RF_LITTLE_ENDIAN and @c RF_BIG_ENDIAN.
 // @param[out] eof Pass a pointer to a char to receive a true or false value in case the end of file was reached with this appending
 // @return Returns either a positive number for succesfull appending that represents the bytes read from the file.
 // If there was a problem an error is returned. Possible errors are any of those that @ref rfFReadLine_UTF32LE() can produce.
-i_DECLIMEX_ int32_t rfString_Append_fUTF32(RF_String* str,FILE* f,char endianess, char* eof);
+i_DECLIMEX_ int32_t rfString_Append_fUTF32(RF_String* str,FILE* f,char endianness, char* eof);
 
 // @memberof RF_String
 // @brief Writes a string to a file depending on the given encoding
@@ -1413,10 +1413,10 @@ i_DECLIMEX_ int32_t rfString_Append_fUTF32(RF_String* str,FILE* f,char endianess
 // @param f A valid and open file pointer into which to write the string.
 // @param encoding \rfoptional{@c RF_UTF8} The encoding of the file. Default is @c RF_UTF8. Can be one of:
 // + @c RF_UTF8: For Unicode UTF-8 encoding
-// + @c RF_UTF16_BE: For Unicode UTF-16 encoding in Big Endian endianess
-// + @c RF_UTF16_LE: For Unicode UTF-16 encoding in Little Endian endianess
-// + @c RF_UTF32_BE: For Unicode UTF-32 encoding in Big Endian endianess
-// + @c RF_UTF32_LE: For Unicode UTF-32 encoding in Little Endian endianess
+// + @c RF_UTF16_BE: For Unicode UTF-16 encoding in Big Endian endianness
+// + @c RF_UTF16_LE: For Unicode UTF-16 encoding in Little Endian endianness
+// + @c RF_UTF32_BE: For Unicode UTF-32 encoding in Big Endian endianness
+// + @c RF_UTF32_LE: For Unicode UTF-32 encoding in Little Endian endianness
 // @return Returns @c RF_SUCCESS for succesfull writting and error otherwise. Possible errors are:
 // + @c RE_FILE_WRITE: There was an unknown write error
 // + @c RE_FILE_WRITE_BLOCK: The write failed because the file was occupied by another thread and the no block flag was set


### PR DESCRIPTION
Fix typos.
<!--- Briefly describe your changes in the field above. -->

## Description
fix 105 typos in the whole repo.
`endianess` -> `endianness`
