### PR TITLE
Add NMODL Language

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -469,6 +469,8 @@ disambiguations:
   rules:
   - language: XML
     pattern: '<!ENTITY '
+  - language: NMODL
+    pattern: '\b(NEURON|INITIAL|UNITS)\b'
   - language: Modula-2
     pattern: '^\s*(?i:MODULE|END) [\w\.]+;'
   - language: [Linux Kernel Module, AMPL]

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4466,6 +4466,14 @@ NL:
   tm_scope: none
   ace_mode: text
   language_id: 241
+NMODL:
+  type: programming
+  color: "#00356B"
+  extensions:
+  - ".mod"
+  tm_scope: none
+  ace_mode: text
+  language_id: 136456478
 NPM Config:
   type: data
   color: "#cb3837"

--- a/samples/NMODL/fornetcon.mod
+++ b/samples/NMODL/fornetcon.mod
@@ -1,0 +1,40 @@
+: Each NetCon maintains a count of external events.
+: And time of last external event
+: On each internal event all connecting NetCon get the internal event count.
+: And time of last external event
+
+NEURON {
+  POINT_PROCESS ForNetConTest
+  RANGE tbegin
+}
+
+UNITS {
+}
+
+PARAMETER {
+  tbegin = 0 (ms)
+}
+
+INITIAL {
+  net_send(tbegin, 1)
+}
+
+NET_RECEIVE(w, npre, tpre (ms), npost, tpost (ms)) {
+  INITIAL {
+    npre=0  tpre=-1  npost=0  tpost=-1
+  }
+
+  if (flag == 0) { : external (pre) event
+    npre = npre + 1
+    tpre = t
+  }
+
+  if (flag == 1) { : internal (post) event
+    FOR_NETCONS(w, fnpre, ftpre (ms), fnpost, ftpost (ms)) {
+      fnpost = fnpost + 1
+      ftpost = t
+    }
+    net_send(3, 1) : in 3 ms another 1 event
+    net_event(t)
+  }
+}

--- a/samples/NMODL/k3st.mod
+++ b/samples/NMODL/k3st.mod
@@ -1,0 +1,62 @@
+: Three state kinetic scheme for HH-like potassium channel
+: Steady-state v-dependent state transitions have been fit
+: Needs v-dependent time constants from tables created under hoc
+NEURON {
+    SUFFIX k3st
+    USEION k READ ek WRITE ik
+    RANGE g, gbar
+    RANGE tau1_rec, tau2_rec
+}
+UNITS { (mV) = (millivolt) }
+PARAMETER {
+    gbar = 33 (millimho/cm2)
+    d1 = -38 (mV)
+    k1 = 0.151 (/mV)
+    d2 = -25 (mV)
+    k2 = 0.044 (/mV)
+}
+
+ASSIGNED {
+    v     (mV)
+    ek    (mV)
+    g     (millimho/cm2)
+    ik    (milliamp/cm2)
+    kf1 (/ms)
+    kb1 (/ms)
+    kf2 (/ms)
+    kb2 (/ms)
+    tau1_rec
+    tau2_rec
+}
+
+STATE { c1 c2 o }
+
+BREAKPOINT {
+    SOLVE kin METHOD sparse
+    g = gbar*o
+    ik = g*(v - ek)*(1e-3)
+}
+
+INITIAL { SOLVE kin STEADYSTATE sparse }
+
+KINETIC kin {
+    rates(v)
+    ~ c1 <-> c2 (kf1, kb1)
+    ~ c2 <-> o (kf2, kb2)
+    CONSERVE c1 + c2 + o = 1
+}
+
+FUNCTION_TABLE tau1(v(mV)) (ms)
+FUNCTION_TABLE tau2(v(mV)) (ms)
+
+PROCEDURE rates(v(millivolt)) {
+    LOCAL K1, K2
+    K1 = exp(k2*(d2 - v) - k1*(d1 - v))
+    kf1 = K1/(tau1(v)*(1+K1))
+    kb1 = 1/(tau1(v)*(1+K1))
+    K2 = exp(-k2*(d2 - v))
+    kf2 = K2/(tau2(v)*(1+K2))
+    kb2 = 1/(tau2(v)*(1+K2))
+    tau1_rec = tau1(v)
+    tau2_rec = tau2(v)
+}

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -689,6 +689,7 @@ class TestHeuristics < Minitest::Test
   def test_mod_by_heuristics
     assert_heuristics({
       "Modula-2" => all_fixtures("Modula-2", "*.mod"),
+      "NMODL" => all_fixtures("NMODL", "*.mod"),
       "XML" => all_fixtures("XML", "*.mod"),
       ["Linux Kernel Module", "AMPL"] => all_fixtures("Linux Kernel Module", "*.mod"),
       ["Linux Kernel Module", "AMPL"] => all_fixtures("AMPL", "*.mod"),


### PR DESCRIPTION
This is the NEURON extension to MODL, a model description language used
within the neuroscientific community.  See also:

https://www.neuron.yale.edu/neuron/static/py_doc/modelspec/programmatic/mechanisms/nmodl2.html

<!--- Briefly describe your changes in the field above. -->

## Description

I am involved in the neuroscientific community around the NEURON simulator.  It has its
own DSL used to describe neuron processes. We have noticed that a lot of the code files
are misclassified as AMPL, and would like to fix that.

The linked search matches 12.7k files, which I think constitutes a strong case to
recognize the language within Github.  I have included two samples from the main NEURON
repository showcasing the syntax.

The extension is shared by kernel modules and AMPL.  I have looked into providing more
samples for the latter, but I am not sure which licenses these examples would be.
Comparing the two languages, they seem very different. Do you have any advise?

I will contact the author(s) of existing syntax highlighting to see if they can provide
their syntax highlighting under a compatible license.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.mod+NEURON
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/neuronsimulator/nrn/blob/master/docs/nmodl/mod/fornetcon.mod
      - https://github.com/neuronsimulator/nrn/blob/master/docs/nmodl/mod/k3st.mod
    - Sample license(s): BSD
  - [ ] I have included a syntax highlighting grammar: [URL to grammar repo]
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#00356B`
    - Rationale: Color used by Yale, the primary institution at which NEURON was developed.
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.
