### PR TITLE
Detect .A86 Files As Assembly Language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -412,6 +412,7 @@ Assembly:
   - nasm
   extensions:
   - ".asm"
+  - ".a86"
   - ".a51"
   - ".i"
   - ".inc"


### PR DESCRIPTION
Added .A86 to the list of extensions for assembly language. .A86 was an extension used by 8086 assembly language source files in the late 70s and early 80s.

<!--- Briefly describe your changes in the field above. -->

## Description
This pull request makes linguist detect .A86 files as x86 assembly language source code. People used to cross assemble 8086 code from 8080/Z80 machines, and .ASM was already reserved for the native assembly language of those machines, so they used .A86 instead. CP/M-86's ASM-86 and Seattle Computer Products' 8086 Cross Assembler, two of the earliest 8086 assemblers, both used the .A86 extension. GitHub currently does not detect .A86 files as assembly language.



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.A86+JNZ
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/antlr/grammars-v4/blob/master/asm/asm8086/examples/ROM.A86
      - https://github.com/erkyrath/infocom-zcode-terps/blob/master/cpm86/zip.a86
      - https://github.com/the-grue/OpenDOS/blob/master/IBMDOS/FDOS.A86
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
