### PR TITLE
Add `Cargo.toml.orig` as TOML filename

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -60,6 +60,7 @@ module Linguist
       generated_net_specflow_feature_file? ||
       composer_lock? ||
       cargo_lock? ||
+      cargo_orig? ||
       flake_lock? ||
       node_modules? ||
       go_vendor? ||
@@ -475,6 +476,13 @@ module Linguist
     # Returns true or false.
     def cargo_lock?
       !!name.match(/Cargo\.lock/)
+    end
+
+    # Internal: Is the blob a generated Rust Cargo original file?
+    #
+    # Returns true or false.
+    def cargo_orig?
+      !!name.match(/Cargo\.toml\.orig/)
     end
 
     # Internal: Is the blob a generated Nix flakes lock file?

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6992,6 +6992,7 @@ TOML:
   - ".toml"
   filenames:
   - Cargo.lock
+  - Cargo.toml.orig
   - Gopkg.lock
   - Pipfile
   - pdm.lock

--- a/samples/TOML/filenames/Cargo.toml.orig
+++ b/samples/TOML/filenames/Cargo.toml.orig
@@ -1,0 +1,24 @@
+
+[package]
+name = "windows-core"
+version = "0.51.1"
+authors = ["Microsoft"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Rust for Windows"
+repository = "https://github.com/microsoft/windows-rs"
+readme = "../../../docs/readme.md"
+rust-version = "1.56"
+categories = ["os::windows-apis"]
+
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"
+targets = []
+
+[dependencies.windows-targets]
+version = "0.48.3"
+path = "../targets"
+
+[features]
+default = []
+implement = []

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -191,6 +191,9 @@ class TestGenerated < Minitest::Test
     generated_fixture_loading_data("Generated/Haxe/Main.cs")
     generated_fixture_loading_data("Generated/Haxe/Main.php")
 
+    # Cargo
+    generated_sample_without_loading_data("TOML/filenames/Cargo.toml.orig")
+
     # jOOQ
     generated_sample_loading_data("Java/generated-jooq-table.java")
 


### PR DESCRIPTION
This is a file that is generated by commands like `cargo package`.

## Checklist:
- [x] **I am adding a new ~~extension~~ filename to a language.**
  - [x] The new ~~extension~~ filename is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3ACargo.toml.orig
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [source](https://github.com/makepad/makepad/blob/a978a7c97a56fad24f392bb899571a93f82b1011/libs/windows-core/Cargo.toml.orig)
    - Sample license(s):
      - [MIT](https://github.com/makepad/makepad/blob/a978a7c97a56fad24f392bb899571a93f82b1011/LICENSE)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
- [x] **I am adding new or changing current functionality**
  - [x] I have added or updated the tests for the new or changed functionality.