### PR TITLE
Add `tsx` to TypeScript interpreters

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7283,6 +7283,7 @@ TypeScript:
   interpreters:
   - deno
   - ts-node
+  - tsx
   extensions:
   - ".ts"
   - ".cts"


### PR DESCRIPTION
## Description
Not to be confused with JSX-aware TypeScript, [`tsx`](https://github.com/privatenumber/tsx) is a drop-in replacement for <samp>node(1)</samp> that compiles and runs TypeScript programs on-the-fly (à la Deno). This PR simply tells Linguist to classify as TypeScript any program with a hashbang[^1] like `#!/usr/bin/env tsx`.

[^1]: privatenumber/tsx@5738e8a

_(Checklist removed as it doesn't apply)._