### PR TITLE
add `.vyi` to allowed Vyper extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7588,6 +7588,7 @@ Vyper:
   type: programming
   extensions:
   - ".vy"
+  - ".vyi"
   color: "#2980b9"
   ace_mode: text
   tm_scope: source.vyper


### PR DESCRIPTION
## Description
vyper 0.4.0 adds `.vyi` files for defining standalone interfaces (see https://github.com/vyperlang/vyper/commit/c6f457a73db40e4b113497883bd330e0dcec28d1 / https://github.com/vyperlang/vyper/pull/3663).

## Checklist:
- [x] **I am adding a new extension to a language.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.vyi
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/vyperlang/vyper/blob/master/vyper/builtins/interfaces/IERC20.vyi
    - Sample license(s):
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.

potential distinguishing syntax (if necessary): `def`, `event`, `struct` and `#` for comments