### PR TITLE
Make `max_tree_size` configurable per-repository

### DIFF
--- a/lib/linguist/repository.rb
+++ b/lib/linguist/repository.rb
@@ -10,9 +10,11 @@ module Linguist
   class Repository
     attr_reader :repository
 
+    MAX_TREE_SIZE = 100_000
+
     # Public: Create a new Repository based on the stats of
     # an existing one
-    def self.incremental(repo, commit_oid, old_commit_oid, old_stats, max_tree_size = 100_000)
+    def self.incremental(repo, commit_oid, old_commit_oid, old_stats, max_tree_size = MAX_TREE_SIZE)
       repo = self.new(repo, commit_oid, max_tree_size)
       repo.load_existing_stats(old_commit_oid, old_stats)
       repo
@@ -24,10 +26,10 @@ module Linguist
     # repo - a Rugged::Repository object
     # commit_oid - the sha1 of the commit that will be analyzed;
     #              this is usually the master branch
-    # max_tree_size - the maximum tree size to consider for analysis (default: 100,000)
+    # max_tree_size - the maximum tree size to consider for analysis (default: MAX_TREE_SIZE)
     #
     # Returns a Repository
-    def initialize(repo, commit_oid, max_tree_size = 100_000)
+    def initialize(repo, commit_oid, max_tree_size = MAX_TREE_SIZE)
       @repository = repo
       @commit_oid = commit_oid
       @max_tree_size = max_tree_size
@@ -131,7 +133,6 @@ module Linguist
     end
 
     protected
-
     def compute_stats(old_commit_oid, cache = nil)
       return {} if current_tree.count_recursive(@max_tree_size) >= @max_tree_size
 

--- a/lib/linguist/repository.rb
+++ b/lib/linguist/repository.rb
@@ -12,8 +12,8 @@ module Linguist
 
     # Public: Create a new Repository based on the stats of
     # an existing one
-    def self.incremental(repo, commit_oid, old_commit_oid, old_stats)
-      repo = self.new(repo, commit_oid)
+    def self.incremental(repo, commit_oid, old_commit_oid, old_stats, max_tree_size = 100_000)
+      repo = self.new(repo, commit_oid, max_tree_size)
       repo.load_existing_stats(old_commit_oid, old_stats)
       repo
     end
@@ -24,11 +24,13 @@ module Linguist
     # repo - a Rugged::Repository object
     # commit_oid - the sha1 of the commit that will be analyzed;
     #              this is usually the master branch
+    # max_tree_size - the maximum tree size to consider for analysis (default: 100,000)
     #
     # Returns a Repository
-    def initialize(repo, commit_oid)
+    def initialize(repo, commit_oid, max_tree_size = 100_000)
       @repository = repo
       @commit_oid = commit_oid
+      @max_tree_size = max_tree_size
 
       @old_commit_oid = nil
       @old_stats = nil
@@ -129,10 +131,9 @@ module Linguist
     end
 
     protected
-    MAX_TREE_SIZE = 100_000
 
     def compute_stats(old_commit_oid, cache = nil)
-      return {} if current_tree.count_recursive(MAX_TREE_SIZE) >= MAX_TREE_SIZE
+      return {} if current_tree.count_recursive(@max_tree_size) >= @max_tree_size
 
       old_tree = old_commit_oid && Rugged::Commit.lookup(repository, old_commit_oid).tree
       read_index

--- a/test/test_repository.rb
+++ b/test/test_repository.rb
@@ -87,8 +87,8 @@ class TestRepository < Minitest::Test
 
     # With some .gitattributes data
     attr_commit = '7ee006cbcb2d7261f9e648510a684ee9ac64126b'
-    # It's incremental but should bust the cache
-    new_repo = Linguist::Repository.incremental(rugged_repository, attr_commit, old_commit, old_repo.cache)
+    # It's incremental but now is scanning more data and should bust the cache
+    new_repo = Linguist::Repository.incremental(rugged_repository, attr_commit, old_commit, old_repo.cache, 350_000)
 
     assert new_repo.breakdown_by_file["Java"].include?("lib/linguist.rb")
   end


### PR DESCRIPTION
Supersedes #6805 since that was from my personal fork.

## Description

- For GitHub Code Scanning functionality, we want to be able to enable Default Setup on more repos. That relies on Linguist for the language detection.
- We found that in very large repos, the `MAX_TREE_SIZE` constant was not high enough.
- This makes the `max_tree_size` value configurable in both `initialize` and `incremental` methods, with a default value of 100,000.
- ❓ This is my first contribution to Linguist and I have no idea if this is "the way".

## Checklist:

- [x] **I am adding new or changing current functionality**
  - [x] I have added or updated the tests for the new or changed functionality.