### PR TITLE
Detect zig zon files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8182,6 +8182,7 @@ Zig:
   color: "#ec915c"
   extensions:
   - ".zig"
+  - ".zig.zon"
   tm_scope: source.zig
   ace_mode: text
   language_id: 646424281

--- a/samples/Zig/build.zig.zon
+++ b/samples/Zig/build.zig.zon
@@ -1,0 +1,6 @@
+.{
+    .name = "envy",
+    .version = "0.2.1",
+    .minimum_zig_version = "0.12.0",
+    .paths = .{""},
+}


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

Add support for [Zig](https://github.com/ziglang/zig) package manager file extension `.zig.zon` files introduced in [0.11.0](https://ziglang.org/download/0.11.0/release-notes.html#Package-Management). Care was taken to be precise with the package managers conventions because I also found non-zig files doing a [code search for just `.zon` files](https://github.com/search?utf8=%E2%9C%93&q=path%3A*.zon&type=code&ref=searchresults).

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

Zig `.zon` files were introduced zig's 0.11.0 release to fulfill the build tools declarative package management story for describing a project and its dependencies. Additional documentation on the format can be found [here](https://github.com/ziglang/zig/blob/master/doc/build.zig.zon.md). It's syntax is valid zig, (essentially a these are struct files) so these files may be parsed and syntax highlighted the same as regular zig files. Today these have no syntax highlighting.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] **I am adding a new extension to a language.**
  - [X] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.zig.zon
  - [X] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [[URL to each sample source, if applicable]](https://github.com/softprops/zig-envy/blob/main/build.zig.zon)
    - Sample license(s): MIT
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.FOOBAR+KEYWORDS
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a syntax highlighting grammar: [URL to grammar repo]
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [ ] I have added a color
    - Hex value: `#RRGGBB`
    - Rationale: <!-- Please specify why you chose this color (if it was randomly selected, please say so); it helps arbitrate future requests to change a language's color -->
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  - Old: [URL to grammar repo]
  - New: [URL to grammar repo]

- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

- [ ] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [URL to public discussion]
    - [Optional: URL to official branding guidelines for the language]
