### PR TITLE
Pass custom tree size through `{git,github}-linguist` binaries

### DIFF
--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -10,17 +10,18 @@ require 'tempfile'
 require 'zlib'
 
 class GitLinguist
-  def initialize(path, commit_oid, incremental = true)
+  def initialize(path, commit_oid, incremental = true, tree_size = 100_000)
     @repo_path = path
     @commit_oid = commit_oid
     @incremental = incremental
+    @tree_size = tree_size
   end
 
   def linguist
     if @commit_oid.nil?
       raise "git-linguist must be called with a specific commit OID to perform language computation"
     end
-    repo = Linguist::Repository.new(rugged, @commit_oid)
+    repo = Linguist::Repository.new(rugged, @commit_oid, @tree_size)
 
     if @incremental && stats = load_language_stats
       old_commit_oid, old_stats = stats
@@ -98,6 +99,7 @@ end
 def git_linguist(args)
   incremental = true
   commit = nil
+  tree_size = 100_000
 
   parser = OptionParser.new do |opts|
     opts.banner = <<~HELP
@@ -110,12 +112,13 @@ def git_linguist(args)
 
     opts.on("-f", "--force", "Force a full rescan") { incremental = false }
     opts.on("-c", "--commit=COMMIT", "Commit to index") { |v| commit = v}
+    opts.on("-t", "--tree-size=NUMBER", "Maximum number of files scanned to detect languages (default: 100,000)" ) { |t| tree_size = t }
   end
 
   parser.parse!(args)
   git_dir = `git rev-parse --git-dir`.strip
   raise "git-linguist must be run in a Git repository" unless $?.success?
-  wrapper = GitLinguist.new(git_dir, commit, incremental)
+  wrapper = GitLinguist.new(git_dir, commit, incremental, tree_size)
 
   case args.pop
   when "stats"

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -13,13 +13,14 @@ Linguist v#{Linguist::VERSION}
 Detect language type and determine language breakdown for a given Git repository.
 
 Usage: linguist <path>
-       linguist <path> [--rev REV] [--breakdown] [--json]
-       linguist [--rev REV] [--breakdown] [--json]
+       linguist <path> [--rev REV] [--tree-size] [--breakdown] [--json]
+       linguist [--rev REV] [--tree-size] [--breakdown] [--json]
 HELP
 
 def github_linguist(args)
   breakdown = false
   json_output = false
+  tree_size = 100_000
   rev = 'HEAD'
   path = Dir.pwd
 
@@ -32,6 +33,7 @@ def github_linguist(args)
     opts.on("-r", "--rev REV", String,
             "Analyze specific git revision",
             "defaults to HEAD, see gitrevisions(1) for alternatives") { |r| rev = r }
+    opts.on("-t", "--tree-size=NUMBER", "Maximum number of files scanned to detect languages (default: 100,000)") { |t| tree_size = t }
     opts.on("-h", "--help", "Display a short usage summary, then exit") do
       puts opts
       exit
@@ -56,7 +58,7 @@ def github_linguist(args)
       puts "invalid revision '#{rev}' for repo '#{path}'"
       exit 1
     end
-    repo = Linguist::Repository.new(rugged, target_oid)
+    repo = Linguist::Repository.new(rugged, target_oid, tree_size)
 
     full_results = {}
     repo.languages.each do |language, size|


### PR DESCRIPTION
## Description

- I missed this part in #6806, which meant that when I tried to use it for our experiments there were too many args because the actual binaries that the Git servers call didn't know about `tree_size` being a new (optional) parameter to `Linguist::Repository.new`.

## Checklist:
- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.