### PR TITLE
The `--tree-size` arg should always be an Integer

### DIFF
--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -112,7 +112,7 @@ def git_linguist(args)
 
     opts.on("-f", "--force", "Force a full rescan") { incremental = false }
     opts.on("-c", "--commit=COMMIT", "Commit to index") { |v| commit = v}
-    opts.on("-t", "--tree-size=NUMBER", "Maximum number of files scanned to detect languages (default: 100,000)" ) { |t| tree_size = t }
+    opts.on("-t", "--tree-size=NUMBER", Integer, "Maximum number of files scanned to detect languages (default: 100,000)" ) { |t| tree_size = t }
   end
 
   parser.parse!(args)

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -33,7 +33,7 @@ def github_linguist(args)
     opts.on("-r", "--rev REV", String,
             "Analyze specific git revision",
             "defaults to HEAD, see gitrevisions(1) for alternatives") { |r| rev = r }
-    opts.on("-t", "--tree-size=NUMBER", "Maximum number of files scanned to detect languages (default: 100,000)") { |t| tree_size = t }
+    opts.on("-t", "--tree-size=NUMBER", Integer, "Maximum number of files scanned to detect languages (default: 100,000)") { |t| tree_size = t }
     opts.on("-h", "--help", "Display a short usage summary, then exit") do
       puts opts
       exit


### PR DESCRIPTION
## Description

- Otherwise we can't `>= tree_size` further along in the chain.
- I tested this change by editing the local vendored files and it worked. This is hopefully my final change here. 😳

```
RepositoryLanguageAnalysisDependencyTest#test__includes_files_in_language__true_if_the_repo_contains_files_written_in_a_given_language_L90:
GitRPC::Error: git-linguist failed: wrong argument type String (expected Integer)
/workspaces/github/vendor/gems/3.3.1/ruby/3.3.0/gems/github-linguist-7.29.0.2.g32ae1b425/lib/linguist/repository.rb:137:in `count_recursive'
```

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.