### PR TITLE
Rely on the `Linguist::Repository::MAX_TREE_SIZE` default value more

### DIFF
--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -10,7 +10,7 @@ require 'tempfile'
 require 'zlib'
 
 class GitLinguist
-  def initialize(path, commit_oid, incremental = true, tree_size = 100_000)
+  def initialize(path, commit_oid, incremental = true, tree_size = Linguist::Repository.MAX_TREE_SIZE)
     @repo_path = path
     @commit_oid = commit_oid
     @incremental = incremental
@@ -99,7 +99,7 @@ end
 def git_linguist(args)
   incremental = true
   commit = nil
-  tree_size = 100_000
+  tree_size = Linguist::Repository::MAX_TREE_SIZE
 
   parser = OptionParser.new do |opts|
     opts.banner = <<~HELP

--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -112,7 +112,8 @@ def git_linguist(args)
 
     opts.on("-f", "--force", "Force a full rescan") { incremental = false }
     opts.on("-c", "--commit=COMMIT", "Commit to index") { |v| commit = v}
-    opts.on("-t", "--tree-size=NUMBER", Integer, "Maximum number of files scanned to detect languages (default: 100,000)" ) { |t| tree_size = t }
+    opts.on("-t", "--tree-size=NUMBER", Integer,
+            "Maximum number of files scanned to detect languages (default: #{Linguist::Repository::MAX_TREE_SIZE})" ) { |t| tree_size = t }
   end
 
   parser.parse!(args)

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -20,7 +20,7 @@ HELP
 def github_linguist(args)
   breakdown = false
   json_output = false
-  tree_size = 100_000
+  tree_size = Linguist::Repository::MAX_TREE_SIZE
   rev = 'HEAD'
   path = Dir.pwd
 
@@ -33,7 +33,8 @@ def github_linguist(args)
     opts.on("-r", "--rev REV", String,
             "Analyze specific git revision",
             "defaults to HEAD, see gitrevisions(1) for alternatives") { |r| rev = r }
-    opts.on("-t", "--tree-size=NUMBER", Integer, "Maximum number of files scanned to detect languages (default: 100,000)") { |t| tree_size = t }
+    opts.on("-t", "--tree-size=NUMBER", Integer,
+            "Maximum number of files scanned to detect languages (default: #{Linguist::Repository::MAX_TREE_SIZE})") { |t| tree_size = t }
     opts.on("-h", "--help", "Display a short usage summary, then exit") do
       puts opts
       exit


### PR DESCRIPTION
## Description

- Changing it won't be such a problem in future if there's just one place to change it. I hadn't realised it had propagated so much!

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.