### PR TITLE
Add support for RON (Rusty Object Notation)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1320,6 +1320,9 @@
 [submodule "vendor/grammars/vscode-rbs-syntax"]
 	path = vendor/grammars/vscode-rbs-syntax
 	url = https://github.com/soutaro/vscode-rbs-syntax.git
+[submodule "vendor/grammars/vscode-ron"]
+	path = vendor/grammars/vscode-ron
+	url = https://github.com/a5huynh/vscode-ron.git
 [submodule "vendor/grammars/vscode-scala-syntax"]
 	path = vendor/grammars/vscode-scala-syntax
 	url = https://github.com/scala/vscode-scala-syntax

--- a/grammars.yml
+++ b/grammars.yml
@@ -1194,6 +1194,8 @@ vendor/grammars/vscode-python:
 - source.pip-requirements
 vendor/grammars/vscode-rbs-syntax:
 - source.rbs
+vendor/grammars/vscode-ron:
+- source.ron
 vendor/grammars/vscode-scala-syntax:
 - source.scala
 vendor/grammars/vscode-singularity:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5768,6 +5768,14 @@ RMarkdown:
   - ".rmd"
   tm_scope: text.md
   language_id: 313
+RON:
+  type: data
+  color: "#a62c00"
+  extensions:
+  - ".ron"
+  ace_mode: rust
+  tm_scope: source.ron
+  language_id: 587855233
 RPC:
   type: programming
   aliases:

--- a/samples/RON/config.ron
+++ b/samples/RON/config.ron
@@ -1,0 +1,15 @@
+Config(
+    root: ".",
+    color: Auto,
+    include_hidden: false,
+    max_rows: 10,
+    exclude: [
+        "target/*",
+        "assets/*",
+    ],
+    output: Output(
+        path: Some("out"),
+        format: Pretty,
+    ),
+    timeout: 3600.0,
+)

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -461,6 +461,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **REALbasic:** [peters-ben-0007/VBDotNetSyntax](https://github.com/peters-ben-0007/VBDotNetSyntax)
 - **REXX:** [mblocker/rexx-sublime](https://github.com/mblocker/rexx-sublime)
 - **RMarkdown:** [wooorm/markdown-tm-language](https://github.com/wooorm/markdown-tm-language)
+- **RON:** [a5huynh/vscode-ron](https://github.com/a5huynh/vscode-ron)
 - **RPC:** [textmate/c.tmbundle](https://github.com/textmate/c.tmbundle)
 - **RPGLE:** [barrettotte/vscode-ibmi-languages](https://github.com/barrettotte/vscode-ibmi-languages)
 - **RPM Spec:** [waveclaw/language-rpm-spec](https://github.com/waveclaw/language-rpm-spec)

--- a/vendor/licenses/git_submodule/vscode-ron.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-ron.dep.yml
@@ -1,0 +1,19 @@
+---
+name: vscode-ron
+version: 8a6f077d64092fa68d638e956784b27b49431240
+type: git_submodule
+homepage: https://github.com/a5huynh/vscode-ron.git
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |+
+    Copyright 2019 Andrew Huynh
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+notices: []
+...


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension (I tried to exclude a few users that were frequently showing up in the search results):
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.ron+Some+NOT+owner%3Aveloren+NOT+owner%3Abevyengine+NOT+owner%3Athetawavegame+NOT+owner%3Athebracket+NOT+owner%3Aoptozorax+NOT+owner%3AcBournhonesque&p=5
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.ron+None+NOT+owner%3Aveloren+NOT+owner%3Abevyengine+NOT+owner%3Athetawavegame+NOT+owner%3Athebracket+NOT+owner%3Aoptozorax+NOT+owner%3AcBournhonesque
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - I wrote this myself -- it's just a sort of generic CLI tool config struct. Let me know if more is needed.
  - [x] I have included a syntax highlighting grammar: https://github.com/a5huynh/vscode-ron
  - [x] I have added a color
    - Hex value: `#a62c00`
    - Rationale: I took this from the controversial https://github.com/github-linguist/linguist/pull/4319. Hopefully it's fine for the object notation :laughing:
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension. (Thanks to https://github.com/github-linguist/linguist/pull/4114 there are no conflicts)
