### PR TITLE
Add Julia REPL

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3504,6 +3504,7 @@ Julia REPL:
   color: "#a270ba"
   tm_scope: source.julia.console
   group: Julia
+  language_id: 220689142
 Jupyter Notebook:
   type: markup
   ace_mode: json

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3497,6 +3497,13 @@ Julia:
   codemirror_mode: julia
   codemirror_mime_type: text/x-julia
   language_id: 184
+Julia REPL:
+  aliases:
+  - julia-repl
+  type: programming
+  color: "#a270ba"
+  tm_scope: source.julia.console
+  group: Julia
 Jupyter Notebook:
   type: markup
   ace_mode: json


### PR DESCRIPTION
This is a draft PR to add syntax highlighting to the Julia REPL mode `julia-repl`.   


## What is it?
The [Julia programming language](https://github.com/JuliaLang/julia) has an interactive read–eval–print loop (REPL) that requires custom syntax highlighting. Julia's documentation tools distinguish between `julia-repl` and `julia` code blocks for markdown syntax highlighting.

* **Julia Code vs. Julia REPL. Note the green `julia>` prompt and output:**
  ![image](https://github.com/github-linguist/linguist/assets/20258504/2ae01150-9094-4d77-b928-8fd962c50172)

* **Example of Julia REPL syntax highlighting in the [Julia documentation](https://docs.julialang.org/en/v1/manual/variables/):**
  <img width="852" alt="image" src="https://github.com/github-linguist/linguist/assets/20258504/0942c1a8-7206-4e6e-9a99-e56aaa003196">

## Why is it needed?

Since the REPL is used to install and demonstrate packages, `julia-repl` code blocks are widely used in GitHub READMEs, as seen in the [560 results here](https://github.com/search?type=code&q=path%3AREADME.md+%60%60%60julia-repl). Outside of READMEs, `julia-repl` is [used more than 10.000 times in code](https://github.com/search?type=code&q=%60%60%60julia-repl).
However, GitHub doesn't recognize `julia-repl` markdown code blocks, only `julia`.

## Description

Interestingly, a Julia REPL grammar already exists in linguist as `julia.console`:
- [linguist's `grammars.yml`](https://github.com/github-linguist/linguist/blob/e2012cd67867e6287ae5ee96c8fe0b92f9a88efa/grammars.yml#L251-L253)
- [`julia-console.cson`](https://github.com/JuliaEditorSupport/atom-language-julia/blob/master/grammars/julia-console.cson)

I wasn't sure on how to add this to `languages.yml`, since the Julia REPL mode isn't a programming language by itself and therefore doesn't have a custom file type.

**I would love to get some guidance on how to get `julia-repl` markdown blocks working on GitHub.**

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - `julia-repl` is used in 560 READMEs: https://github.com/search?type=code&q=path%3AREADME.md+%60%60%60julia-repl
      - `julia-repl` is used more than 10.000 times in code: https://github.com/search?type=code&q=%60%60%60julia-repl
  - [ ] I have included a real-world usage sample for all extensions added in this  
      - `julia-repl` doesn't have a custom file type
  - [x] I have included a syntax highlighting grammar: [URL to grammar repo]
      - A Julia REPL grammar already exists in linguist as `julia.console`
        - [linguist's `grammars.yml`](https://github.com/github-linguist/linguist/blob/e2012cd67867e6287ae5ee96c8fe0b92f9a88efa/grammars.yml#L251-L253)
        - [`julia-console.cson`](https://github.com/JuliaEditorSupport/atom-language-julia/blob/master/grammars/julia-console.cson)
  - [x] I have added a color
    - Hex value: `#a270ba`
    - Rationale: This is the same color Julia uses
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
    - The Julia REPL mode doesn't have an extension.
