### PR TITLE
Support `.envrc` file

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6535,6 +6535,7 @@ Shell:
   - shell-script
   - bash
   - zsh
+  - envrc
   extensions:
   - ".sh"
   - ".bash"
@@ -6557,6 +6558,7 @@ Shell:
   - ".bash_profile"
   - ".bashrc"
   - ".cshrc"
+  - ".envrc"
   - ".flaskenv"
   - ".kshrc"
   - ".login"

--- a/samples/Shell/filenames/.envrc
+++ b/samples/Shell/filenames/.envrc
@@ -1,0 +1,1 @@
+export JAVA_HOME=`/usr/libexec/java_home -v 1.8`


### PR DESCRIPTION
## Description

`.envrc` are files used by [direnv](https://direnv.net/). direnv loads the file into a bash sub-shell, making this file effectively bash.

Taking some of the other `Shell/filenames` samples as an example, I figured a smaller sample would be OK. Possibly preferable, since a larger sample would likely repeat `export` a bunch. If a larger sample is preferable, [this](https://github.com/prisma/prisma/blob/6705e78302ffac44f25943c39dd77ce73a2d1b91/.envrc) might work.

## Checklist:
- [x] **I am adding a new ~~extension~~ filename to a language.**
  - [x] The new ~~extension~~ filename is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A.envrc+export
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/jenkinsci/mesos-plugin/blob/7da7bc60883eec7fbb8e1fe888500d735bd297ba/.envrc
    - Sample license(s):
      - https://github.com/jenkinsci/mesos-plugin/blob/7da7bc60883eec7fbb8e1fe888500d735bd297ba/LICENSE
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
