### PR TITLE
Dependabot configuration to update actions in workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,14 @@
 version: 2
 updates:
-  # Only check for Ruby gem updates
+  # Check for Ruby gem updates
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
       interval: "daily"
+  # Check for GitHub Actions updates
+  - package-ecosystem: "github-actions"
+    # Look for GitHub Actions workflows in the `root` directory
+    directory: "/"
+    # Check the for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Description

Noticed a few actions used in the workflows here are outdated, proposing a Dependabot configuration to update - reference https://docs.github.com/en/actions/security-guides/using-githubs-security-features-to-secure-your-use-of-github-actions#keeping-the-actions-in-your-workflows-secure-and-up-to-date

Suggest enabling https://docs.github.com/en/code-security/dependabot/working-with-dependabot/about-dependabot-on-github-actions-runners#enabling-or-disabling-for-your-repository as well.
