### PR TITLE
Add a TextMate grammar for PowerBuilder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -100,6 +100,9 @@
 [submodule "vendor/grammars/PogoScript.tmbundle"]
 	path = vendor/grammars/PogoScript.tmbundle
 	url = https://github.com/featurist/PogoScript.tmbundle
+[submodule "vendor/grammars/PowerBuilder.tmbundle"]
+	path = vendor/grammars/PowerBuilder.tmbundle
+	url = https://github.com/micha4w/PowerBuilder.tmbundle.git
 [submodule "vendor/grammars/RDoc.tmbundle"]
 	path = vendor/grammars/RDoc.tmbundle
 	url = https://github.com/joshaven/RDoc.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -91,6 +91,8 @@ vendor/grammars/PHP-Twig.tmbundle:
 - text.html.twig
 vendor/grammars/PogoScript.tmbundle:
 - source.pogoscript
+vendor/grammars/PowerBuilder.tmbundle:
+- source.powerbuilder
 vendor/grammars/RDoc.tmbundle:
 - text.rdoc
 vendor/grammars/Racket:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5455,11 +5455,8 @@ PowerBuilder:
   color: "#8f0f8d"
   extensions:
   - ".pbt"
-  - ".pbl"
   - ".sra"
-  - ".srd"
   - ".srf"
-  - ".srq"
   - ".srs"
   - ".sru"
   - ".srw"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5456,8 +5456,6 @@ PowerBuilder:
   extensions:
   - ".pbt"
   - ".sra"
-  - ".srf"
-  - ".srs"
   - ".sru"
   - ".srw"
   tm_scope: source.powerbuilder

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5455,10 +5455,15 @@ PowerBuilder:
   color: "#8f0f8d"
   extensions:
   - ".pbt"
+  - ".pbl"
   - ".sra"
+  - ".srd"
+  - ".srf"
+  - ".srq"
+  - ".srs"
   - ".sru"
   - ".srw"
-  tm_scope: none
+  tm_scope: source.powerbuilder
   ace_mode: text
   language_id: 292
 PowerShell:

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -438,6 +438,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Portugol:** [luisgbr1el/portugol-grammar](https://github.com/luisgbr1el/portugol-grammar)
 - **PostCSS:** [hudochenkov/Syntax-highlighting-for-PostCSS](https://github.com/hudochenkov/Syntax-highlighting-for-PostCSS)
 - **PostScript:** [Alhadis/Atom-PostScript](https://github.com/Alhadis/Atom-PostScript)
+- **PowerBuilder:** [micha4w/PowerBuilder.tmbundle](https://github.com/micha4w/PowerBuilder.tmbundle)
 - **PowerShell:** [PowerShell/EditorSyntax](https://github.com/PowerShell/EditorSyntax)
 - **Praat:** [orhunulusahin/praatvscode](https://github.com/orhunulusahin/praatvscode)
 - **Prisma:** [prisma/vscode-prisma](https://github.com/prisma/vscode-prisma)

--- a/vendor/licenses/git_submodule/PowerBuilder.tmbundle.dep.yml
+++ b/vendor/licenses/git_submodule/PowerBuilder.tmbundle.dep.yml
@@ -1,0 +1,31 @@
+---
+name: PowerBuilder.tmbundle
+version: ac042daf34b23b4cabc187f0766ec371d692c051
+type: git_submodule
+homepage: https://github.com/micha4w/PowerBuilder.tmbundle.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2024 micha4w
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
The PowerBuilder Language was already added a few years ago, but for some reason no Grammar was added.

## Description
I created a TextMate Grammar and added it to the PowerBuilder `tm_scope`.

## Checklist:
- [x] **I am changing the source of a syntax highlighting grammar**
  - Old: -
  - New: https://github.com/micha4w/PowerBuilder.tmbundle

- [x] **I am adding new or changing current functionality**
  - [x] Added the new Grammar to vendor/README.md
