### PR TITLE
VB6: Replace VB.NET's grammar by VBA's grammar

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7639,7 +7639,7 @@ Visual Basic 6.0:
   - ".ctl"
   - ".Dsr"
   - ".frm"
-  tm_scope: source.vbnet
+  tm_scope: source.vba
   aliases:
   - vb6
   - vb 6

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -601,7 +601,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Vim Script:** [Alhadis/language-viml](https://github.com/Alhadis/language-viml)
 - **Vim Snippet:** [Alhadis/language-viml](https://github.com/Alhadis/language-viml)
 - **Visual Basic .NET:** [peters-ben-0007/VBDotNetSyntax](https://github.com/peters-ben-0007/VBDotNetSyntax)
-- **Visual Basic 6.0:** [peters-ben-0007/VBDotNetSyntax](https://github.com/peters-ben-0007/VBDotNetSyntax)
+- **Visual Basic 6.0:** [serkonda7/vscode-vba](https://github.com/serkonda7/vscode-vba)
 - **Volt:** [textmate/d.tmbundle](https://github.com/textmate/d.tmbundle)
 - **Vue:** [vuejs/vue-syntax-highlight](https://github.com/vuejs/vue-syntax-highlight)
 - **Vyper:** [davidhq/SublimeEthereum](https://github.com/davidhq/SublimeEthereum)


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

Considering that : 
* VBA and VB6 are closer in terms of syntax than VB6 and VB.NET. (As discussed in https://github.com/github-linguist/linguist/issues/5824 and https://github.com/github-linguist/linguist/pull/4725).
* There is currently no open source grammar made specifically for VB6.
* The VBA syntax is more colorful (see [comparison](https://github.com/DecimalTurn/VBA-on-GitHub/pull/4#issuecomment-2179313831)).

This PR replaces Visual Basic 6.0's current grammar (made for VB.NET) by the one made for VBA (which is already present in Linguist).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **I am changing the source of a syntax highlighting grammar**
  - Old: https://github.com/peters-ben-0007/VBDotNetSyntax
  - New: https://github.com/serkonda7/vscode-vba