### PR TITLE
Remove backreferences in regex patterns for `XML Property List` and `JavaScript`

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -226,7 +226,7 @@ disambiguations:
   - language: Erlang
     pattern: '^\s*(?:%%|main\s*\(.*?\)\s*->)'
   - language: JavaScript
-    pattern: '\/\/|("|'')use strict\1|export\s+default\s|\/\*(?:.|[\r\n])*?\*\/'
+    pattern: '\/\/|["'']use strict["'']|export\s+default\s|\/\*(?:.|[\r\n])*?\*\/'
 - extensions: ['.ex']
   rules:
   - language: Elixir
@@ -552,7 +552,7 @@ disambiguations:
 - extensions: ['.plist']
   rules:
   - language: XML Property List
-    pattern: '^\s*(?:<\?xml\s|<!DOCTYPE\s+plist|<plist(?:\s+version\s*=\s*(["''])\d+(?:\.\d+)?\1)?\s*>\s*$)'
+    pattern: '^\s*(?:<\?xml\s|<!DOCTYPE\s+plist|<plist(?:\s+version\s*=\s*["'']\d+(?:\.\d+)?["''])?\s*>\s*$)'
   - language: OpenStep Property List
 - extensions: ['.plt']
   rules:


### PR DESCRIPTION
There is currently 2 discrepencies between Linguist and Enry that can be explained by the fact that RE2 doesn't support backreference:

 - [Heuristic for ".plist" extension](https://github.com/github-linguist/linguist/blob/b5432ebc7e78f25415b98d48c2fbacddbf8df317/lib/linguist/heuristics.yml#L524) in 'XML Property List', due to unsupported backreference in RE2 regexp engine.
 - [Heuristics for ".es" extension](https://github.com/github/linguist/blob/e761f9b013e5b61161481fcb898b59721ee40e3d/lib/linguist/heuristics.yml#L103) in JavaScript could not be parsed, due to unsupported backreference in RE2 regexp engine.

From: https://github.com/go-enry/go-enry#divergences-from-linguist

In both cases, this is because the regex pattern is trying to make sure that the quotation mark used is the same to start and end the string. That's something important when performing syntax highlighting, but that doesn't provide much value in terms of distinguishing one language from another. 

For that reason, the proposed changes won't make a noticable difference from Linguist's side, but it will remove the presence of backreferences for Enry.
