### PR TITLE
Update languages.yml

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2998,9 +2998,11 @@ INI:
   extensions:
   - ".ini"
   - ".cfg"
+  - ".conf"
   - ".cnf"
   - ".dof"
   - ".lektorproject"
+  - ".ovpn"
   - ".prefs"
   - ".pro"
   - ".properties"


### PR DESCRIPTION
Added INI syntax highlighting for config file extensions *.conf and *.ovpn:
  - Some programs (like OpenVPN) use .conf instead of .cnf for config files
  - OpenVPN client .ovpn files are INI config files

<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - [.conf+OpenVPN](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.CONF+OPENVPN)
      - [.ovpn+OpenVPN](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.OVPN+OPENVPN)
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [`OpenVPN-Server.conf`](https://github.com/JW0914/Wikis/blob/master/Scripts%2BConfigs/OpenVPN/OpenVPN-Server.conf) _(Compare to: [`openvpn-server.cnf`](https://github.com/JW0914/Wikis/blob/master/Scripts%2BConfigs/OpenVPN/openvpn-server.cnf))_
      - [`Client.ovpn`](https://github.com/JW0914/Wikis/blob/master/Scripts%2BConfigs/OpenVPN/Client.ovpn)
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
