### PR TITLE
Fix heuristic for extension `.yy` (JSON vs Yacc)

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -698,13 +698,13 @@ module Linguist
     # Internal: Is this a generated Game Maker Studio (2) metadata file?
     #
     # All Game Maker Studio 2 generated files will be JSON, .yy or .yyp, and have
-    # a part that looks like "modelName: GMname" on the 3rd line
+    # a line that looks like "modelName: GMname" or "resourceType: GMname"
     #
     # Return true or false
     def generated_gamemakerstudio?
       return false unless ['.yy', '.yyp'].include? extname
       return false unless lines.count > 3
-      return lines[2].match(/\"(modelName|resourceType)\"\:\s*\"GM/) ||
+      return lines.any? { |line| line.match(/\"(modelName|resourceType)\"\:\s*\"GM/) } ||
              lines[0] =~ /^\d\.\d\.\d.+\|\{/
     end
 

--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -704,7 +704,7 @@ module Linguist
     def generated_gamemakerstudio?
       return false unless ['.yy', '.yyp'].include? extname
       return false unless lines.count > 3
-      return lines[2].match(/\"modelName\"\:\s*\"GM/) ||
+      return lines[2].match(/\"(modelName|resourceType)\"\:\s*\"GM/) ||
              lines[0] =~ /^\d\.\d\.\d.+\|\{/
     end
 

--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -704,7 +704,7 @@ module Linguist
     def generated_gamemakerstudio?
       return false unless ['.yy', '.yyp'].include? extname
       return false unless lines.count > 3
-      return lines.any? { |line| line.match(/\"(modelName|resourceType)\"\:\s*\"GM/) } ||
+      return lines.first(3).join('').match?(/^\s*[\{\[]/) ||
              lines[0] =~ /^\d\.\d\.\d.+\|\{/
     end
 

--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -697,9 +697,6 @@ module Linguist
 
     # Internal: Is this a generated Game Maker Studio (2) metadata file?
     #
-    # All Game Maker Studio 2 generated files will be JSON, .yy or .yyp, and have
-    # a line that looks like "modelName: GMname" or "resourceType: GMname"
-    #
     # Return true or false
     def generated_gamemakerstudio?
       return false unless ['.yy', '.yyp'].include? extname

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -351,7 +351,7 @@ disambiguations:
 - extensions: ['.ice']
   rules:
   - language: JSON
-    pattern: '\A\s*[{\[]'
+    named_pattern: json
   - language: Slice
 - extensions: ['.inc']
   rules:
@@ -848,7 +848,7 @@ disambiguations:
 - extensions: ['.yy']
   rules:
   - language: JSON
-    pattern: '\"(modelName|resourceType)\"\:\s*\"GM'
+    named_pattern: json
   - language: Yacc
 named_patterns:
   cpp:
@@ -870,6 +870,7 @@ named_patterns:
   - '^\s*(?>(?:autoexec|private)\s+){0,2}function\s+(?>(?:autoexec|private)\s+){0,2}\w+\s*\('
   - '\b(?:level|self)[ \t]+thread[ \t]+(?:\[\[[ \t]*(?>\w+\.)*\w+[ \t]*\]\]|\w+)[ \t]*\([^\r\n\)]*\)[ \t]*;'
   - '^[ \t]*#[ \t]*(?:precache|using_animtree)[ \t]*\('
+  json: '\A\s*[{\[]'
   key_equals_value: '^[^#!;][^=]*='
   m68k:
   - '(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b'

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -848,7 +848,7 @@ disambiguations:
 - extensions: ['.yy']
   rules:
   - language: JSON
-    pattern: '\"modelName\"\:\s*\"GM'
+    pattern: '\"(modelName|resourceType)\"\:\s*\"GM'
   - language: Yacc
 named_patterns:
   cpp:

--- a/samples/JSON/VCT.yy
+++ b/samples/JSON/VCT.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"VCT",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"VCT",
+  "parent":{
+    "name":"VCT",
+    "path":"folders/VCT.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -152,6 +152,7 @@ class TestGenerated < Minitest::Test
     # Game Maker Studio 2
     generated_sample_loading_data("JSON/GMS2_Project.yyp")
     generated_sample_loading_data("JSON/2ea73365-b6f1-4bd1-a454-d57a67e50684.yy")
+    generated_sample_loading_data("JSON/VCT.yy")
     generated_fixture_loading_data("Generated/options_main.inherited.yy")
 
     # Pipenv


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

Closes https://github.com/github-linguist/linguist/issues/6517
[496k+ files](https://github.com/search?q=lang%3Ayacc+path%3A*.yy+%2F%5C%22resourceType%5C%22%5C%3A%5Cs*%5C%22GM%2F&type=code) affected

~~Implements fix suggested by @lildude and backed by @RobQuistNL in https://github.com/github-linguist/linguist/issues/6517#issuecomment-1680403065.~~

See this comment for the approach used: https://github.com/github-linguist/linguist/pull/6976#issuecomment-2264230000

## Checklist:

- [x] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language:
    - Sample source: https://github.com/Ttanasart-pt/Pixel-Composer/blob/363a1dec53f6785ee58a7b3f3b8407a48dcdd2c2/scripts/VCT/VCT.yy
    - Sample License: [MIT license](https://github.com/Ttanasart-pt/Pixel-Composer#)
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.

