### PR TITLE
Replace Just grammar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1298,7 +1298,7 @@
 	url = https://github.com/jest-community/vscode-jest
 [submodule "vendor/grammars/vscode-just"]
 	path = vendor/grammars/vscode-just
-	url = https://github.com/skellock/vscode-just.git
+	url = https://github.com/nefrob/vscode-just.git
 [submodule "vendor/grammars/vscode-lean"]
 	path = vendor/grammars/vscode-lean
 	url = https://github.com/leanprover/vscode-lean

--- a/.gitmodules
+++ b/.gitmodules
@@ -1298,7 +1298,7 @@
 	url = https://github.com/jest-community/vscode-jest
 [submodule "vendor/grammars/vscode-just"]
 	path = vendor/grammars/vscode-just
-	url = https://github.com/nefrob/vscode-just.git
+	url = https://github.com/skellock/vscode-just.git
 [submodule "vendor/grammars/vscode-lean"]
 	path = vendor/grammars/vscode-lean
 	url = https://github.com/leanprover/vscode-lean

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -288,7 +288,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Julia:** [JuliaEditorSupport/atom-language-julia](https://github.com/JuliaEditorSupport/atom-language-julia)
 - **Julia REPL:** [JuliaEditorSupport/atom-language-julia](https://github.com/JuliaEditorSupport/atom-language-julia)
 - **Jupyter Notebook:** [Nixinova/NovaGrammars](https://github.com/Nixinova/NovaGrammars)
-- **Just:** [skellock/vscode-just](https://github.com/skellock/vscode-just)
+- **Just:** [nefrob/vscode-just](https://github.com/nefrob/vscode-just)
 - **Kaitai Struct:** [atom/language-yaml](https://github.com/atom/language-yaml)
 - **KakouneScript:** [kakoune-editor/language-kak](https://github.com/kakoune-editor/language-kak)
 - **KerboScript:** [KSP-KOS/language-kerboscript](https://github.com/KSP-KOS/language-kerboscript)

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -288,7 +288,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Julia:** [JuliaEditorSupport/atom-language-julia](https://github.com/JuliaEditorSupport/atom-language-julia)
 - **Julia REPL:** [JuliaEditorSupport/atom-language-julia](https://github.com/JuliaEditorSupport/atom-language-julia)
 - **Jupyter Notebook:** [Nixinova/NovaGrammars](https://github.com/Nixinova/NovaGrammars)
-- **Just:** [nefrob/vscode-just](https://github.com/nefrob/vscode-just)
+- **Just:** [skellock/vscode-just](https://github.com/skellock/vscode-just)
 - **Kaitai Struct:** [atom/language-yaml](https://github.com/atom/language-yaml)
 - **KakouneScript:** [kakoune-editor/language-kak](https://github.com/kakoune-editor/language-kak)
 - **KerboScript:** [KSP-KOS/language-kerboscript](https://github.com/KSP-KOS/language-kerboscript)

--- a/vendor/licenses/git_submodule/vscode-just.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-just.dep.yml
@@ -1,15 +1,15 @@
 ---
 name: vscode-just
-version: c105c0543bdcdc67dadb7a9c769190f05cf1c9a2
+version: 326d6dd1afb291df516cc782626f2fcad973eec1
 type: git_submodule
-homepage: https://github.com/nefrob/vscode-just.git
+homepage: https://github.com/skellock/vscode-just.git
 license: mit
 licenses:
 - sources: LICENSE
   text: |
-    MIT License
+    The MIT License (MIT)
 
-    Copyright (c) 2024 Robert Neff
+    Copyright (c) 2016-3016 Steve Kellock
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/vendor/licenses/git_submodule/vscode-just.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-just.dep.yml
@@ -1,15 +1,15 @@
 ---
 name: vscode-just
-version: 326d6dd1afb291df516cc782626f2fcad973eec1
+version: c105c0543bdcdc67dadb7a9c769190f05cf1c9a2
 type: git_submodule
-homepage: https://github.com/skellock/vscode-just.git
+homepage: https://github.com/nefrob/vscode-just.git
 license: mit
 licenses:
 - sources: LICENSE
   text: |
-    The MIT License (MIT)
+    MIT License
 
-    Copyright (c) 2016-3016 Steve Kellock
+    Copyright (c) 2024 Robert Neff
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/vendor/licenses/git_submodule/vscode-just.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-just.dep.yml
@@ -1,15 +1,15 @@
 ---
 name: vscode-just
-version: 326d6dd1afb291df516cc782626f2fcad973eec1
+version: d1f2dc90a5f8dd3c7ffa6a9549c414c0ff73e958
 type: git_submodule
-homepage: https://github.com/skellock/vscode-just.git
+homepage: https://github.com/nefrob/vscode-just.git
 license: mit
 licenses:
 - sources: LICENSE
   text: |
-    The MIT License (MIT)
+    MIT License
 
-    Copyright (c) 2016-3016 Steve Kellock
+    Copyright (c) 2024 Robert Neff
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Update just language grammar to use maintained https://github.com/nefrob/vscode-just. This has been updated as the suggested vscode extension by the just language repo here: https://github.com/casey/just?tab=readme-ov-file#visual-studio-code.

## Checklist:
- [x] **I am changing the source of a syntax highlighting grammar**
  - Old: https://github.com/skellock/vscode-just
  - New: https://github.com/nefrob/vscode-just