### PR TITLE
Manually remove module in `.git` when replacing grammars

### DIFF
--- a/script/add-grammar
+++ b/script/add-grammar
@@ -123,6 +123,7 @@ if [ "$replace" ]; then
 	log "Deregistering submodule: $replace"
 	git submodule deinit "$replace"
 	git rm -rf "$replace"
+	rm -rf ".git/modules/$replace"
 	script/grammar-compiler update -f >/dev/null 2>&1
 fi
 


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

As discovered in https://github.com/github-linguist/linguist/pull/6985#issuecomment-2284478929, for some reason the `.git/modules/vendor/grammars/:grammar-name` isn't always removed when replacing a grammar when running `script/add-grammar --replace :grammar-name`. This PR adds a manual removal of the submodule in `.git/modules/vendor/grammars/:grammar-name` to ensure that the submodule is removed when replacing grammars.


## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] ~~I have added or updated the tests for the new or changed functionality.~~  N/A
