### PR TITLE
Optimization: Use `match?` instead of `match`

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -126,7 +126,7 @@ module Linguist
     # Internal: Perform the heuristic
     def call(data)
       matched = @rules.find do |rule|
-        rule['pattern'].match(data)
+        rule['pattern'].match?(data)
       end
       if !matched.nil?
         languages = matched['language']
@@ -145,14 +145,14 @@ module Linguist
       @pats = pats
     end
 
-    def match(input)
-      return !@pats.any? { |pat| !pat.match(input) }
+    def match?(input)
+      return !@pats.any? { |pat| !pat.match?(input) }
     end
 
   end
 
   class AlwaysMatch
-    def match(input)
+    def match?(input)
       return true
     end
   end
@@ -163,8 +163,8 @@ module Linguist
       @pat = pat
     end
 
-    def match(input)
-      return !@pat.match(input)
+    def match?(input)
+      return !@pat.match?(input)
     end
 
   end

--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -146,7 +146,7 @@ module Linguist
     end
 
     def match?(input)
-      return !@pats.any? { |pat| !pat.match?(input) }
+      return @pats.all? { |pat| pat.match?(input) }
     end
 
   end

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -37,7 +37,7 @@ class TestHeuristics < Minitest::Test
   def test_no_match_if_regexp_timeout
     skip("This test requires Ruby 3.2.0 or later") if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.2.0')
 
-    Regexp.any_instance.stubs(:match).raises(Regexp::TimeoutError)
+    Regexp.any_instance.stubs(:match?).raises(Regexp::TimeoutError)
     assert_equal [], Heuristics.call(file_blob("#{fixtures_path}/Generic/stl/STL/cube1.stl"), [Language["STL"]])
   end
 


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

This PR replaces instances of `.match` with `.match?` in heuristics.rb.
This change should have a small performance improvement as discussed [here](https://stackoverflow.com/a/42834177/5958842).

I also removed the double-negation inside `And.match?` to improve readability.

## Checklist:
N/A