### PR TITLE
Carbon language support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -994,6 +994,7 @@ Carbon:
   ace_mode: golang
   codemirror_mode: go
   codemirror_mime_type: text/x-go
+  tm_scope: source.v
   language_id: 55627273
 CartoCSS:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -990,7 +990,6 @@ Carbon:
   type: programming
   color: "#222222"
   extensions:
-  - ".cb"
   - ".carbon"
   ace_mode: text
   language_id: 55627273

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -986,6 +986,14 @@ Cap'n Proto:
   - ".capnp"
   ace_mode: text
   language_id: 52
+Carbon:
+  type: programming
+  color: "#222222"
+  extensions:
+  - ".cb"
+  - ".carbon"
+  ace_mode: text
+  language_id: 53
 CartoCSS:
   type: programming
   aliases:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -993,7 +993,7 @@ Carbon:
   - ".cb"
   - ".carbon"
   ace_mode: text
-  language_id: 53
+  language_id: 55627273
 CartoCSS:
   type: programming
   aliases:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -991,7 +991,9 @@ Carbon:
   color: "#222222"
   extensions:
   - ".carbon"
-  ace_mode: text
+  ace_mode: golang
+  codemirror_mode: go
+  codemirror_mime_type: text/x-go
   language_id: 55627273
 CartoCSS:
   type: programming

--- a/samples/Carbon/Shapes.carbon
+++ b/samples/Carbon/Shapes.carbon
@@ -1,0 +1,73 @@
+package Shapes api;
+import Math;
+
+// Circle
+
+class Circle {
+    var Radius: f32 = 1;
+    const var Diameter: f32 = self.Radius * 2;
+
+    const var Pi: f32 = Math.Pi;
+
+    fn Area() -> self;
+    fn Circumference() -> self;
+}
+
+fn Circle.Area() -> self {
+    return Math.Pi * .Radius ^ 2
+}
+
+fn Circle.Circumference() -> self {
+    return 2 * Math.Pi * .Radius
+}
+
+// Rectangle
+
+class Rectangle {
+    var Width: f32 = 3;
+    var Height: f32 = 1;
+
+    fn Area() -> self;
+}
+
+fn Rectangle.Area() -> self {
+    return .Width * .Height;
+}
+
+// Square (Note: Provides same functions as "Rectangle" class.)
+
+class Square {
+    var Width: f32 = 3;
+    var Height: f32 = 1;
+
+    fn Area() -> self;
+}
+
+fn Square.Area() -> self {
+    return .Width * .Height;
+}
+
+// Triangle
+
+class Triangle {
+    var Width: f32 = 3;
+    var Height: f32 = 3;
+
+    fn Area() -> self;
+}
+
+fn Triangle.Area() -> self {
+    return (.Width * .Height) / 2;
+}
+
+// Hexagon
+
+class Hexagon {
+    var Side: f32 = 5;
+
+    fn Area() -> self;
+}
+
+fn Hexagon.Area() -> self {
+    return ((3 * 1.732) / 2) * .Side ^ 2
+}

--- a/samples/Carbon/main.carbon
+++ b/samples/Carbon/main.carbon
@@ -1,0 +1,16 @@
+// Part of linguist/samples
+
+import Shapes;
+import "some/graphics/library"; // This does not exist (read below)
+
+fn main() -> i32 {
+  // This sample does not show the usage of a real graphics library since there is no major usable graphics library for Carbon.
+  // As the language grows, some UI library will emerge for it and this sample can be updated.
+
+  var newGraphicRectangle: Shapes.Rectangle = {Width = 500, Height = 1250 };
+
+  var graphicsWindow: auto = Graphics.Window(newGraphicRectangle, "Window Name");
+  graphicsWindow.Show(true);
+
+  return 0;
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -91,6 +91,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Cairo:** [xshitaka/atom-language-cairo](https://github.com/xshitaka/atom-language-cairo)
 - **CameLIGO:** [pewulfman/Ligo-grammar](https://github.com/pewulfman/Ligo-grammar)
 - **Cap'n Proto:** [textmate/capnproto.tmbundle](https://github.com/textmate/capnproto.tmbundle)
+- **Carbon:** [0x9ef/vscode-vlang](https://github.com/0x9ef/vscode-vlang)
 - **CartoCSS:** [yohanboniface/carto-atom](https://github.com/yohanboniface/carto-atom)
 - **Ceylon:** [jeancharles-roger/ceylon-sublimetext](https://github.com/jeancharles-roger/ceylon-sublimetext)
 - **Chapel:** [chapel-lang/chapel-tmbundle](https://github.com/chapel-lang/chapel-tmbundle)


### PR DESCRIPTION
Adds support for the Carbon language. Carbon is an experimental language developed by Google.
- [Source code repository (carbon-language/carbon-lang)](https://github.com/carbon-language/carbon-lang)

## Checklist
- [X] **I am adding a new language.**
  - [X] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  .carbon: https://github.com/search?q=path%3A*.carbon&type=Code&ref=advsearch&l=&l=
  - [X] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - .carbon: https://github.com/github-linguist/linguist/pull/7011/commits/6193d8ef20e9600309315c5512022932ad02fefd#diff-e2449d8cdec8d56e7a85d9ef16521ab0192a58afe147dbe907d3cac76d3b0fab
  - [ ] I have included a syntax highlighting grammar
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [X] I have added a color
    - Hex value: `#222222`
    - Rationale: Carbon uses a black circle with a C in it. This is not `#000000`, but they are similar.
  - [X] I have updated the heuristics to distinguish my language from others using the same extension.
 
Closes https://github.com/github-linguist/linguist/issues/6013