### PR TITLE
Add *.tiltfile extension for Starlark files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6920,6 +6920,7 @@ Starlark:
   extensions:
   - ".bzl"
   - ".star"
+  - ".tiltfile"
   filenames:
   - BUCK
   - BUILD


### PR DESCRIPTION
## Description
Adds `*.tiltfile` extension to Starlark.

## Checklist:
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.tiltfile
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/tilt-dev/tilt/blob/7375e5c286a80c7e9524c35a706025a5830d1e21/web/storybook.tiltfile
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
