### PR TITLE
Add support for `HOSTS.TXT` files

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -773,6 +773,32 @@ disambiguations:
     # VIM_MODELINE pattern in `./lib/linguist/strategy/modeline.rb`.
   - language: Vim Help File
     pattern: '(?:(?:^|[ \t])(?:vi|Vi(?=m))(?:m[<=>]?[0-9]+|m)?|[ \t]ex)(?=:(?=[ \t]*set?[ \t][^\r\n:]+:)|:(?![ \t]*set?[ \t]))(?:(?:[ \t]*:[ \t]*|[ \t])\w*(?:[ \t]*=(?:[^\\\s]|\\.)*)?)*[ \t:](?:filetype|ft|syntax)[ \t]*=(help)(?=$|\s|:)'
+  - language: Hosts File
+    pattern: |-
+      (?xi) ^
+
+      # IPv4 address
+      (?<ipv4>
+        (?!\.)
+        (?:\.?
+          (?: 25[0-5]  # 250-255
+          |   2[0-4]\d # 200-249
+          |   1\d\d    # 100-199
+          |   [1-9]?\d # 0-99
+          )\b
+      ){4})
+
+      # CIDR notation: /[0-32]
+      (?<cidr>/(3[0-2]|[12]?\d)\b)?
+
+      # Domains list
+      (?<domains>
+        [ \t]+
+        \w[-\w]* (?:\.\w[-\w]*)*
+        (?<!-)\b
+      )*+
+
+      (?=$|\s)
   - language: Adblock Filter List
     pattern: |-
       (?x)\A

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2946,6 +2946,7 @@ Hosts File:
   filenames:
   - HOSTS
   - hosts
+  - hosts.txt
   aliases:
   - hosts
   tm_scope: source.hosts

--- a/samples/Hosts File/filenames/hosts
+++ b/samples/Hosts File/filenames/hosts
@@ -1,2 +1,4 @@
-127.0.0.1 localhost
-::1       localhost
+127.0.0.1	localhost labs
+255.255.255.255	broadcasthost
+::1	localhost
+fe80::1%lo0	localhost

--- a/samples/Hosts File/filenames/hosts.txt
+++ b/samples/Hosts File/filenames/hosts.txt
@@ -1,0 +1,95 @@
+#
+# License:									MIT License (MIT)
+# File encoding: 							UTF-8 Dos/Windows 1252
+# Original maintainer:						CHEF-KOCH
+# Notice:									
+# Version:									000000000011
+# Homepage: 								http://chef-koch.github.io/NSABlocklist/HOSTS.txt
+#
+127.0.0.1 localhost						#[IPv4 only]
+127.0.0.1 localhost.localdomain			#
+127.0.0.1 255.255.255.255 broadcasthost #Unix/Mac serv.
+#::1 localhost							#[IPv6 only]
+#127.0.0.1 local 						#Unix only
+#
+
+# NSABlocklist begins here
+0.0.0.0 adm.kemoge.net
+0.0.0.0 taosha.cc
+0.0.0.0 ns1.automattic.com
+0.0.0.0 dns.ns1.edgecastcdn.net
+0.0.0.0 skewednews.net
+0.0.0.0 open-tx.org
+0.0.0.0 razor-qt.org
+0.0.0.0 nickknowlson.com
+0.0.0.0 springfuse.com
+0.0.0.0 ns4.1-800-hosting.com
+0.0.0.0 ns7.dns-net.de
+0.0.0.0 coffeehausblog.com
+0.0.0.0 ns1.dns-net.de
+0.0.0.0 newjunk4u.com
+0.0.0.0 suddenplot.com
+0.0.0.0 ns2.21vianet.com.cn
+0.0.0.0 martinharrigan.ie
+0.0.0.0 DARKNESS.SU
+0.0.0.0 WEED.SU
+0.0.0.0 MEZIAMUSSUCEMAQUEUE.SU
+0.0.0.0 UMBXD15896.SU
+0.0.0.0 STYXB1TCH35.SU
+0.0.0.0 J1NXFYR3.SU
+0.0.0.0 dns1.wiresix.com
+0.0.0.0 andyshora.com
+0.0.0.0 monster-ads.net
+0.0.0.0 nickleplatedads.com
+0.0.0.0 chrissharkey.com
+0.0.0.0 ns2.olemiss.edu
+0.0.0.0 dns2.accesscomm.ca
+0.0.0.0 ns2.pnap.net
+0.0.0.0 dns2.artelecom.pt
+0.0.0.0 ns.relc.com
+0.0.0.0 ns.ukrnet.net
+0.0.0.0 ns.ua.net
+0.0.0.0 ns.lucky.net
+0.0.0.0 ns.adams.net
+0.0.0.0 electronicfrontierfoundation.org
+0.0.0.0 ns2.acnusa.net
+0.0.0.0 ns2.eatel.net
+0.0.0.0 gamma.aei.ca
+0.0.0.0 delta.aei.ca
+
+# GOV Pages only
+0.0.0.0 ABERDEENWA.GOV
+0.0.0.0 ABINGDON-VA.GOV
+0.0.0.0 ABINGTONMA.GOV
+0.0.0.0 ABSECONNJ.GOV
+0.0.0.0 ACTON-MA.GOV
+0.0.0.0 ACTONMA.GOV
+0.0.0.0 ADAK-AK.GOV
+0.0.0.0 ADAMN.GOV
+0.0.0.0 ADDISONTX.GOV
+0.0.0.0 AFTONWYOMING.GOV
+0.0.0.0 AKRONOHIO.GOV
+0.0.0.0 ALAMEDACA.GOV
+0.0.0.0 ALGONAWA.GOV
+0.0.0.0 ALIQUIPPAPA.GOV
+0.0.0.0 ALLIANCEOH.GOV
+0.0.0.0 ALMONTMICHIGAN.GOV
+0.0.0.0 ALSTEADNH.GOV
+0.0.0.0 ALTAVISTAVA.GOV
+0.0.0.0 ALTON-TX.GOV
+0.0.0.0 ALTUSOK.GOV
+0.0.0.0 ALVIN-TX.GOV
+0.0.0.0 AMARILLO.GOV
+0.0.0.0 AMENIANY.GOV
+0.0.0.0 AMERICUSGA.GOV
+0.0.0.0 AMERYWI.GOV
+0.0.0.0 AMITYARKANSAS.GOV
+0.0.0.0 AMSTERDAMNY.GOV
+0.0.0.0 ANDOVERMN.GOV
+0.0.0.0 ANGELFIRENM.GOV
+0.0.0.0 ANGELSCAMP.GOV
+0.0.0.0 ZIONSVILLE-IN.GOV
+0.0.0.0 dsdn-gh1-uea05.nsa.gov
+0.0.0.0 emvm-gh1-uea08.nsa.gov
+# /GOV Pages
+#/NSABlocklist ends here

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -73,7 +73,10 @@ class TestHeuristics < Minitest::Test
   def test_all_extensions_are_listed
     Heuristics.all.all? do |rule|
       rule.languages.each do |lang|
-        unlisted = rule.extensions.reject { |ext| lang.extensions.include? ext }
+        unlisted = rule.extensions.reject do |ext|
+          lang.extensions.include?(ext) or
+          lang.filenames.select {|n| n.downcase.end_with? ext.downcase}
+        end
         assert_equal [], unlisted, (<<~EOF).chomp
           The extension '#{unlisted.first}' is not assigned to #{lang.name}.
           Add it to `languages.yml` or update the heuristic which uses it

--- a/vendor/licenses/git_submodule/language-etc.dep.yml
+++ b/vendor/licenses/git_submodule/language-etc.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: language-etc
-version: 4b11ef18f53f60004e1985d62474d6d0b62592ba
+version: 0b57931aafbbf2cc4a8b0506b44a9d7b411bd8ac
 type: git_submodule
 homepage: https://github.com/Alhadis/language-etc
 license: isc


### PR DESCRIPTION
## Description
This pull-request adds support for [Hosts files](https://en.wikipedia.org/wiki/Hosts_(file)) that use a `.txt` extension.

In-the-wild usage checks out, though I'm not sure how many `.txt` files named _“hosts”_ would be misclassified by this addition. In any case, it doesn't appear as if heuristics support filenames in addition to extensions, so I'll avoid assuming too much for the time being.

/cc @larsbrinkhoff I noticed you [forked](https://github.com/larsbrinkhoff/hosts.txt) the legacy <samp>HOSTS.TXT</samp> tables, so you might have input concerning the (mis)classification of files named `hosts.txt`.

## Checklist
-	[x] **I am adding a new** ~~extension~~ **_filename_ to a language.**
	-	[x] **The new filename is used in hundreds of repositories on GitHub:**  
		[~2,400 search results](https://github.com/search?q=path%3A**%2Fhosts.txt&type=code) for files named `hosts.txt`.
	-	[x] **I have included real-world usage samples:**
		-	[`filenames/hosts`][1]: My MacBook's (old)[^1]﻿[^2] `/etc/hosts` file, which only contains commonly-used defaults.[^3]
		- [`filenames/hosts.txt`][2]: Heavily-truncated copy of the [NSA Blocklist](https://github.com/VPNSox/NSABlocklist/blob/dec1cfe71385683029bfe9a3f4ba88e7d8fb5727/HOSTS.txt), released under the [MIT license](https://github.com/VPNSox/NSABlocklist/blob/dec1cfe71385683029bfe9a3f4ba88e7d8fb5727/LICENSE)
	-	[x] **I have included a change to the heuristics.**  
		This was necessary because of the circuitous way in which we disambiguate between different `.txt` files. I don't know if filename conflicts can be resolved by heuristics in the way that file extensions are.

[1]: https://github.com/github-linguist/linguist/commit/e27613bd52a92686dee7e92de624ecde31ec05c2/samples/Hosts%20File/filenames/hosts
[2]: https://github.com/github-linguist/linguist/commit/e27613bd52a92686dee7e92de624ecde31ec05c2/samples/Hosts%20File/filenames/hosts.txt
[^1]: https://github.com/Alhadis/.files/blob/4b6e915/etc/install/README.md?plain=1#L71-L78
[^2]: https://github.com/Alhadis/.files/blob/4b6e915/etc/install/README.md#:~:text=Update%20/etc/hosts
[^3]: https://superuser.com/q/241642