### PR TITLE
Add vimscript alias to Vim Script

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7583,6 +7583,8 @@ Vim Script:
   - vim
   - viml
   - nvim
+  - vim script
+  - vimscript
   extensions:
   - ".vim"
   - ".vba"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7583,7 +7583,6 @@ Vim Script:
   - vim
   - viml
   - nvim
-  - vim script
   - vimscript
   extensions:
   - ".vim"


### PR DESCRIPTION
Add two aliases for vimscript

## Description
Using `vimscript` as a language tag does not cause it to be recognized and highlighted. This adds `vimscript` as an alias to allow that.

## Checklist:
[ Removed as it doensn't apply]