### PR TITLE
Update number of acceptable classification errors.

### DIFF
--- a/script/cross-validation
+++ b/script/cross-validation
@@ -6,7 +6,7 @@ ACCEPTABLE_ERRORS = 14
 
 # Number of acceptable classification errors when using --all.
 # It should only be decreased.
-ACCEPTABLE_ERRORS_ALL = 777
+ACCEPTABLE_ERRORS_ALL = 744
 
 # Avoid buffering output.
 STDOUT.sync = true

--- a/script/cross-validation
+++ b/script/cross-validation
@@ -2,7 +2,7 @@
 
 # Number of acceptable classification errors.
 # It should only be decreased.
-ACCEPTABLE_ERRORS = 19
+ACCEPTABLE_ERRORS = 14
 
 # Number of acceptable classification errors when using --all.
 # It should only be decreased.


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

With the introduciton of the new classifier (https://github.com/github-linguist/linguist/pull/5103), the number of classification errors went from 19 to 14. 🎉

`Number of errors (14) is within the acceptable threshold (19)`
https://github.com/github-linguist/linguist/actions/runs/10663397934/job/29552498132?pr=7021

This means we have to change the threshold number to 14, otherwise it won't catch new errors that could be introduced in new PRs.

## Checklist:
N/A