### PR TITLE
Update languages.yml

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8632,3 +8632,12 @@ xBase:
   tm_scope: source.harbour
   ace_mode: text
   language_id: 421
+BynixScript:
+  type: programming
+  color: "#29ca04"
+  extensions:
+  - ".bs"
+  - ".bynixscript"
+  tm_scope: source.bs
+  ace_mode: javascript
+  language_id: 9763900

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -741,6 +741,15 @@ Browserslist:
   tm_scope: text.browserslist
   ace_mode: text
   language_id: 153503348
+BynixScript:
+  type: programming
+  color: "#29ca04"
+  extensions:
+  - ".bs"
+  - ".bynixscript"
+  tm_scope: source.bs
+  ace_mode: javascript
+  language_id: 9763900
 C:
   type: programming
   color: "#555555"
@@ -8632,12 +8641,3 @@ xBase:
   tm_scope: source.harbour
   ace_mode: text
   language_id: 421
-BynixScript:
-  type: programming
-  color: "#29ca04"
-  extensions:
-  - ".bs"
-  - ".bynixscript"
-  tm_scope: source.bs
-  ace_mode: javascript
-  language_id: 9763900

--- a/samples/BynixScript/condition.bs
+++ b/samples/BynixScript/condition.bs
@@ -1,0 +1,10 @@
+var myAge = 14
+var yourAge = 20
+
+if myAge < yourAge:
+    print("You are older")
+elif myAge === yourAge:
+    print("We are the same age")
+else:
+    print("You are younger")
+end:

--- a/samples/BynixScript/dom.bs
+++ b/samples/BynixScript/dom.bs
@@ -1,0 +1,4 @@
+const myElement = createElement("p")
+myElement.text = "Hello There!"
+myElement.addClass("myClass")
+body.addElement(myElement)

--- a/samples/BynixScript/function.bs
+++ b/samples/BynixScript/function.bs
@@ -1,0 +1,6 @@
+func myFunction(param1, param2):
+    const result = param1 + param2
+    print("result: " + result)
+end:
+
+myFunction(2, 4)


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
This PR adds support for the BynixScript programming language in GitHub Linguist.

- Added `.bs` and `.bynixscript` as recognized extensions for BynixScript.
- The language ID is `9763900`.
- Assigned the color `#29ca04` to BynixScript.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am adding a new extension to a language.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.FOOBAR+KEYWORDS
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.FOOBAR+KEYWORDS
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a syntax highlighting grammar: [URL to grammar repo]
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [ ] I have added a color
    - Hex value: `#RRGGBB`
    - Rationale: <!-- Please specify why you chose this color (if it was randomly selected, please say so); it helps arbitrate future requests to change a language's color -->
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  - Old: [URL to grammar repo]
  - New: [URL to grammar repo]

- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

- [ ] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [URL to public discussion]
    - [Optional: URL to official branding guidelines for the language]
