### PR TITLE
Feat/plc support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1428,3 +1428,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/vscode-st"]
+	path = vendor/grammars/vscode-st
+	url = https://github.com/Serhioromano/vscode-st.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1239,6 +1239,10 @@ vendor/grammars/vscode-singularity:
 vendor/grammars/vscode-slice:
 - source.ice
 - source.slice
+vendor/grammars/vscode-st:
+- markdown.iecst.codeblock
+- source.st
+- xml.iecst.codeblock
 vendor/grammars/vscode-vba:
 - source.vba
 - source.wwb

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5149,6 +5149,15 @@ Oz:
   codemirror_mode: oz
   codemirror_mime_type: text/x-oz
   language_id: 270
+PLC:
+  type: programming
+  color: "#D67C26"
+  extensions:
+  - ".st"
+  - ".scl"
+  - ".exp"
+  tm_scope: source.st
+  ace_mode: text
 P4:
   type: programming
   color: "#7055b5"

--- a/vendor/licenses/git_submodule/vscode-st.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-st.dep.yml
@@ -1,0 +1,31 @@
+---
+name: vscode-st
+version: ab2e521465eae34190bc9394cbe12270d1cc38ce
+type: git_submodule
+homepage: https://github.com/Serhioromano/vscode-st.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2018 Sergey Romanov
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
This adds PLC support to Linguist.
I can't find any examples in plain text, but hopefully someone can find it.

## Description

It just adds PLC to languages.yml and adds PLC grammar from https://github.com/Serhioromano/vscode-st.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] **I am adding a new language.**
  - [X] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  https://github.com/search?q=%28path%3A*.st+OR+path%3A*.scl+OR+path%3A*.exp%29+IF+END&type=code&ref=advsearch **219k files matched**, probably more if we're including private repositories
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [X] I have included a syntax highlighting grammar: https://github.com/Serhioromano/vscode-st
  - [X] I have added a color
    - Hex value: `#D67C26`
    - Rationale: Took it from a wood plank image from online because I can't find a PLC logo or anything.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
