### PR TITLE
Update heuristics to fallback to TSX language if .tsx file is not XML

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -780,10 +780,9 @@ disambiguations:
   - language: Scilab
 - extensions: ['.tsx']
   rules:
-  - language: TSX
-    pattern: '^\s*(import.+(from\s+|require\()[''"]react|\/\/\/\s*<reference\s)'
   - language: XML
     pattern: '(?i:^\s*<\?xml\s+version)'
+  - language: TSX
 - extensions: ['.txt']
   rules:
     # The following RegExp is simply a collapsed and simplified form of the


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
This PR fixes the syntax highlighting issue for .tsx files in the TSX language. Previously, the heuristic required detecting a React import pattern in the code. However, in recent versions of React, importing React is no longer necessary, which often resulted in the file being treated as plain text.

The behavior has now been updated to first check for matches with XML languages. If no match is found, it will assume the file is a TSX.

Closes #7039

## Checklist:


- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
