### PR TITLE
Add .containerfile extension to Dockerfile

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1632,6 +1632,7 @@ Dockerfile:
   tm_scope: source.dockerfile
   extensions:
   - ".dockerfile"
+  - ".containerfile"
   filenames:
   - Containerfile
   - Dockerfile

--- a/samples/Dockerfile/debian-systemd.Containerfile
+++ b/samples/Dockerfile/debian-systemd.Containerfile
@@ -1,0 +1,9 @@
+FROM debian:bullseye
+
+RUN apt-get update && apt-get install -y systemd systemd-sysv && apt-get clean
+RUN systemctl mask systemd-logind systemd-udevd
+
+RUN apt-get install bash-completion
+RUN echo "source /usr/share/bash-completion/bash_completion" >> /root/.bashrc
+
+CMD ["/lib/systemd/systemd"]


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

Add `.containerfile` to the Dockerfile language.

Closes https://github.com/github-linguist/linguist/issues/6799

## Checklist:
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?q=NOT%20is%3Afork%20path%3A*.containerfile&type=code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/saucelabs/forwarder/blob/02c3e9f05eaccb2f59dbca7a5b580fb1639b5980/local/linux/debian-systemd.Containerfile#L4
    - Sample license(s): MPL-2.0

