### PR TITLE
Add SSH config aliases

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6522,6 +6522,11 @@ SRecode Template:
 SSH Config:
   type: data
   group: INI
+  aliases:
+  - sshconfig
+  - sshdconfig
+  - ssh_config
+  - sshd_config
   filenames:
   - ssh-config
   - ssh_config


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
Add aliases to SSH config for the various forms people use to match the filenames.

Closes https://github.com/github-linguist/linguist/issues/7041

Rest of template removed as it doesn't apply.