### PR TITLE
Update Ruby versions used in testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.2', '3.1', '3.0' ]
+        ruby: [ '3.3', '3.2', '3.1' ]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby
@@ -57,7 +57,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.2'
+        ruby-version: '3.3'
         bundler-cache: true
     - name: Build
       run: bundle exec rake samples


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

This PR updates the versions of Ruby we run CI against.

Ruby 3.0 was EoL'd 23 Apr 2024 and Ruby 3.3 is now the latest so we should be testing against it too.

Rest of template removed as it doesn't apply.