### PR TITLE
Add varlink

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -842,6 +842,9 @@
 [submodule "vendor/grammars/language-typelanguage"]
 	path = vendor/grammars/language-typelanguage
 	url = https://github.com/goodmind/language-typelanguage
+[submodule "vendor/grammars/language-varlink"]
+	path = vendor/grammars/language-varlink
+	url = https://github.com/varlink/language-varlink
 [submodule "vendor/grammars/language-viml"]
 	path = vendor/grammars/language-viml
 	url = https://github.com/Alhadis/language-viml

--- a/grammars.yml
+++ b/grammars.yml
@@ -799,6 +799,8 @@ vendor/grammars/language-turing:
 - source.turing
 vendor/grammars/language-typelanguage:
 - source.tl
+vendor/grammars/language-varlink:
+- source.varlink
 vendor/grammars/language-viml:
 - source.vim-snippet
 - source.viml

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8590,6 +8590,17 @@ sed:
 templ:
   type: markup
   color: "#66D0DD"
+varlink:
+  type: markup
+  color: "#5882FA"
+  extensions:
+  - ".varlink"
+  ace_mode: text
+  tm_scope: source.varlink
+  language_id: 396563549
+wdl:
+  type: programming
+  color: "#42f1f4"
   extensions:
   - ".templ"
   ace_mode: text

--- a/samples/varlink/com.redhat.system.varlink
+++ b/samples/varlink/com.redhat.system.varlink
@@ -1,0 +1,49 @@
+#
+# Source: https://github.com/varlink/com.redhat.system/blob/master/src/com.redhat.system.varlink
+# Licenses:
+# MIT - https://github.com/varlink/com.redhat.system/blob/master/LICENSE-MIT
+# Apache - https://github.com/varlink/com.redhat.system/blob/master/LICENSE-APACHE
+#
+#
+# The Activator Interface allows to configure and maintain a list of available
+# interfaces. When an interface is accessed by a client, the activator receives
+# the initial message, starts the service which implements this interface, and
+# hands over the listening connection with the initial message.
+interface com.redhat.system
+
+type Executable (
+  path: string,
+  user_id: ?int,
+  group_id: ?int
+)
+
+type Service (
+  address: string,
+  interfaces: [string](),
+  executable: ?Executable,
+  activate_at_startup: ?bool
+)
+
+type Config (
+  vendor: string,
+  product: string,
+  version: string,
+  url: string,
+  services: []Service,
+  systems: [string]string
+)
+
+# Retrieve the current configuration.
+method GetConfig() -> (config: Config)
+
+# Add services to the list of managed services.
+method AddServices(services: []Service) -> ()
+
+# Add systems to the list of known systems.
+method AddSystems(systems: [string]string) -> ()
+
+# Remove and stop services from the list of manages services.
+method RemoveServices(services: []Service) -> ()
+
+# Remove and stop services from the list of manages services.
+method RemoveSystems(systems: []string) -> ()

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -598,6 +598,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **UnrealScript:** [textmate/java.tmbundle](https://github.com/textmate/java.tmbundle)
 - **UrWeb:** [gwalborn/UrWeb-Language-Definition](https://github.com/gwalborn/UrWeb-Language-Definition)
 - **V:** [0x9ef/vscode-vlang](https://github.com/0x9ef/vscode-vlang)
+- **varlink:** [varlink/language-varlink](https://github.com/varlink/language-varlink)
 - **VBA:** [serkonda7/vscode-vba](https://github.com/serkonda7/vscode-vba)
 - **VBScript:** [peters-ben-0007/VBDotNetSyntax](https://github.com/peters-ben-0007/VBDotNetSyntax)
 - **VCL:** [brandonwamboldt/sublime-varnish](https://github.com/brandonwamboldt/sublime-varnish)

--- a/vendor/licenses/grammar/language-varlink.txt
+++ b/vendor/licenses/grammar/language-varlink.txt
@@ -1,0 +1,27 @@
+---
+type: grammar
+name: language-varlink
+license: mit
+---
+
+MIT License
+
+Copyright (c) 2018 Harald Hoyer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Description

https://varlink.org/

Adds varlink grammar and language

[systemd](https://github.com/systemd/systemd) started using it (see https://media.ccc.de/v/all-systems-go-2024-276-varlink-now-), so I think it's getting popular


## Checklist:
- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.varlink
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/varlink/com.redhat.system/blob/master/src/com.redhat.system.varlink
    - Sample license(s):
      - MIT and Apache
  - [x] I have included a syntax highlighting grammar: https://github.com/varlink/language-varlink
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#42f1f4`
    - Rationale: It's the prefered color of varlink
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.
