### PR TITLE
Add `.clangd` as a filename for YAML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8254,6 +8254,7 @@ YAML:
   filenames:
   - ".clang-format"
   - ".clang-tidy"
+  - ".clangd"
   - ".gemrc"
   - CITATION.cff
   - glide.lock

--- a/samples/YAML/filenames/.clangd
+++ b/samples/YAML/filenames/.clangd
@@ -1,0 +1,41 @@
+CompileFlags:
+  CompilationDatabase: "cmake-build"
+  Add: [
+    -pedantic,
+    -Wall,
+    -Wextra,
+    -Wconversion,
+    -Wshadow,
+    -Wfloat-equal,
+    -Wmisleading-indentation,
+    -Wimplicit-fallthrough,
+  ]
+Diagnostics:
+  Suppress:
+    - variadic_device_fn
+    - attributes_not_allowed
+  UnusedIncludes: Strict
+  ClangTidy:
+    Add: ['*']
+    Remove:
+      - abseil-*
+      - altera-*
+      - android-*
+      - fuchsia-*
+      - google-*
+      - llvm*
+      - modernize-use-trailing-return-type
+      - zircon-*
+      - readability-else-after-return
+      - readability-static-accessed-through-instance
+      - readability-avoid-const-params-in-decls
+      - cppcoreguidelines-non-private-member-variables-in-classes
+      - misc-non-private-member-variables-in-classes
+    CheckOptions:
+      readability-identifier-naming.VariableCase: lower_case
+      readability-identifier-naming.FunctionCase: lower_case
+      readability-identifier-naming.ClassCase: Leading_upper_snake_case
+      readability-identifier-naming.StructCase: Leading_upper_snake_case
+      cppcoreguidelines-init-variables.IncludeStyle: google
+InlayHints:
+  BlockEnd: true


### PR DESCRIPTION
This PR classifies `.clangd` as a name for files that use the YAML language.

## Description

clangd uses YAML-formatted files with the name `.clangd` for its project-level configuration.

Reference: [clangd’s documentation for configuration files](https://clangd.llvm.org/config#files)

Also potentially of interest: [JSON Schema specification for `.clangd` files](https://json.schemastore.org/clangd.json)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A.clangd+CompileFlags
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s): I wrote the sample file based on some options I commonly use.
    - Sample license(s): MIT License
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
