### PR TITLE
Add `.ignore` as ignore list filename

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3114,6 +3114,7 @@ Ignore List:
   - ".eleventyignore"
   - ".eslintignore"
   - ".gitignore"
+  - ".ignore"
   - ".markdownlintignore"
   - ".nodemonignore"
   - ".npmignore"

--- a/samples/Ignore List/filenames/.ignore
+++ b/samples/Ignore List/filenames/.ignore
@@ -1,0 +1,6 @@
+.git/
+# Prevent tooling from reading vendored files
+vendor/
+dist/
+
+*.log


### PR DESCRIPTION
## Description

Surprisingly, this generic filename wasn't yet added :laughing: It's been gaining some traction, being used for popular tools like [scc](https://github.com/boyter/scc) and [ripgrep](https://github.com/BurntSushi/ripgrep)

## Checklist:
- [x] **I am adding a new ~~extension~~ filename to a language.**
  - [x] The new ~~extension~~ filename is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?q=path%3A%2F%28%5E%7C%5C%2F%29%5C.ignore%24%2F+NOT+is%3Afork&type=code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - This was manually written, given the simplicity of ignore lists