### PR TITLE
Refactor `Linguist::Repository` to isolate Rugged usage 

### DIFF
--- a/lib/linguist/repository.rb
+++ b/lib/linguist/repository.rb
@@ -1,5 +1,6 @@
 require 'linguist/lazy_blob'
-require 'rugged'
+require 'linguist/source/repository'
+require 'linguist/source/rugged'
 
 module Linguist
   # A Repository is an abstraction of a Grit::Repo or a basic file
@@ -23,14 +24,19 @@ module Linguist
     # Public: Initialize a new Repository to be analyzed for language
     # data
     #
-    # repo - a Rugged::Repository object
+    # repo - a Linguist::Source::Repository object
     # commit_oid - the sha1 of the commit that will be analyzed;
     #              this is usually the master branch
     # max_tree_size - the maximum tree size to consider for analysis (default: MAX_TREE_SIZE)
     #
     # Returns a Repository
     def initialize(repo, commit_oid, max_tree_size = MAX_TREE_SIZE)
-      @repository = repo
+      @repository = if repo.is_a? Linguist::Source::Repository
+        repo
+      else
+        # Allow this for backward-compatibility purposes
+        Linguist::Source::RuggedRepository.new(repo)
+      end
       @commit_oid = commit_oid
       @max_tree_size = max_tree_size
 
@@ -123,26 +129,25 @@ module Linguist
     end
 
     def read_index
-      attr_index = Rugged::Index.new
-      attr_index.read_tree(current_tree)
-      repository.index = attr_index
+      raise NotImplementedError, "read_index is deprecated" unless repository.is_a? Linguist::Source::RuggedRepository
+      repository.set_attribute_source(@commit_oid)
     end
 
     def current_tree
-      @tree ||= Rugged::Commit.lookup(repository, @commit_oid).tree
+      raise NotImplementedError, "current_tree is deprecated" unless repository.is_a? Linguist::Source::RuggedRepository
+      repository.get_tree(@commit_oid)
     end
 
     protected
     def compute_stats(old_commit_oid, cache = nil)
-      return {} if current_tree.count_recursive(@max_tree_size) >= @max_tree_size
+      return {} if repository.get_tree_size(@commit_oid, @max_tree_size) >= @max_tree_size
 
-      old_tree = old_commit_oid && Rugged::Commit.lookup(repository, old_commit_oid).tree
-      read_index
-      diff = Rugged::Tree.diff(repository, old_tree, current_tree)
+      repository.set_attribute_source(@commit_oid)
+      diff = repository.diff(old_commit_oid, @commit_oid)
 
       # Clear file map and fetch full diff if any .gitattributes files are changed
       if cache && diff.each_delta.any? { |delta| File.basename(delta.new_file[:path]) == ".gitattributes" }
-        diff = Rugged::Tree.diff(repository, old_tree = nil, current_tree)
+        diff = repository.diff(nil, @commit_oid)
         file_map = {}
       else
         file_map = cache ? cache.dup : {}
@@ -153,7 +158,7 @@ module Linguist
         new = delta.new_file[:path]
 
         file_map.delete(old)
-        next if delta.binary
+        next if delta.binary?
 
         if [:added, :modified].include? delta.status
           # Skip submodules and symlinks

--- a/lib/linguist/source/diff.rb
+++ b/lib/linguist/source/diff.rb
@@ -1,0 +1,72 @@
+require 'linguist/generated'
+require 'cgi'
+require 'charlock_holmes'
+require 'mini_mime'
+require 'yaml'
+
+module Linguist
+  module Source
+    # Diff is an interface representing a diff between two trees. It is composed
+    # of a collection of iterable deltas between before/after states of files.
+    class Diff
+      # A Delta represents a single file's before/after state in a diff.
+      class Delta
+        # Public: get the status of the file's "after" state as compared to
+        # "before". Valid status values include:
+        #
+        # - :added
+        # - :deleted
+        # - :modified
+        # - :renamed
+        # - :copied
+        # - :ignored
+        # - :untracked
+        # - :typechange
+        #
+        # Returns the status.
+        def status
+          raise NotImplementedError
+        end
+
+        # Public: determine whether the file delta is binary.
+        #
+        # Returns true if the delta is binary, false otherwise.
+        def binary?
+          raise NotImplementedError
+        end
+
+        # Public: get the metadata of the "before" file in the delta. The
+        # metadata is represented as a Hash with the keys:
+        #
+        # - :path (string)
+        # - :oid (string)
+        # - :mode (integer)
+        #
+        # Returns the entry metadata hash.
+        def old_file
+          raise NotImplementedError
+        end
+
+        # Public: get the metadata of the "after" file in the delta. The
+        # metadata is represented as a Hash with the keys:
+        #
+        # - :path (string)
+        # - :oid (string)
+        # - :mode (integer)
+        #
+        # Returns the entry metadata hash.
+        def new_file
+          raise NotImplementedError
+        end
+      end
+
+      # Public: iterate through each delta of the given diff. Yields a single
+      # delta to the given block.
+      #
+      # Returns nothing.
+      def each_delta
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/linguist/source/repository.rb
+++ b/lib/linguist/source/repository.rb
@@ -1,0 +1,64 @@
+module Linguist
+  module Source
+    # Repository is an interface for providing direct access to functionality in
+    # a repository of files whose contents can be scanned for language
+    # information.
+    class Repository
+      # Public: get the number of entries in the root tree of the given commit,
+      # with an optional maximum value.
+      #
+      # commit_id - the string unique identifier of the commit to analyze.
+      # limit     - (Optional) the integer maximum number of tree entries to
+      #             count.
+      #
+      # Returns the number of entries in the tree or 'limit', whichever is
+      # smaller.
+      def get_tree_size(commit_id, limit = nil)
+        raise NotImplementedError
+      end
+
+      # Public: set the commit whose .gitattributes file(s) should be used as
+      # the source of attribute information in 'load_attributes_for_path'.
+      #
+      # commit_id - the string unique identifier of the attribute source commit.
+      #
+      # Returns nothing.
+      def set_attribute_source(commit_id)
+        raise NotImplementedError
+      end
+
+      # Public: read the data and size information for the specified file blob.
+      #
+      # blob_id  - the string unique identifier of the blob to read.
+      # max_size - the integer maximum size in bytes to read from the blob.
+      #
+      # Returns the (possibly truncated) byte string of blob content and
+      # the full, untruncated size of the blob.
+      def load_blob(blob_id, max_size)
+        raise NotImplementedError
+      end
+
+      # Public: look up the attribute values for a given path.
+      #
+      # path       - the path for which we want attribute values.
+      # attr_names - the attributes to read for the given path.
+      #
+      # Returns a Hash mapping attribute names to their corresponding values.
+      def load_attributes_for_path(path, attr_names)
+        raise NotImplementedError
+      end
+
+      # Public: compute the diff between the given old and new commits.
+      #
+      # old_commit - the string unique identifier of the "before" state of the
+      #              diff, or nil (representing an empty tree).
+      # new_commit - the string unique identifier of the "after" state of the
+      #              diff, or nil (representing an empty tree).
+      #
+      # Returns a Source::Diff.
+      def diff(old_commit, new_commit)
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/linguist/source/rugged.rb
+++ b/lib/linguist/source/rugged.rb
@@ -1,0 +1,91 @@
+require 'rugged'
+require 'linguist/source/diff'
+
+module Linguist
+  module Source
+    # RuggedRepository is an implementation of the Source::Repository abstract
+    # class. It represents a Git repository that is accessed using the libgit2
+    # wrapper Rugged.
+    class RuggedRepository < Linguist::Source::Repository
+
+      class Diff < Linguist::Source::Diff
+        class Delta < Linguist::Source::Diff::Delta
+          def initialize(rugged_delta)
+            @delta = rugged_delta
+          end
+
+          def status; @delta.status; end
+
+          def binary?; @delta.binary; end
+
+          def old_file; @delta.old_file; end
+
+          def new_file; @delta.new_file; end
+        end
+
+        def initialize(rugged_diff)
+          @diff = rugged_diff
+        end
+
+        def each_delta(&block)
+          @diff.each_delta.map do |delta|
+            Delta.new(delta)
+          end.each(&block)
+        end
+      end
+
+      GIT_ATTR_OPTS = { :priority => [:index], :skip_system => true }
+      GIT_ATTR_FLAGS = Rugged::Repository::Attributes.parse_opts(GIT_ATTR_OPTS)
+
+      def initialize(rugged)
+        @rugged = rugged
+        @tree_map = {}
+        @attr_source = nil
+      end
+
+      def get_tree_size(commit_id, limit)
+        get_tree(commit_id).count_recursive(limit)
+      end
+
+      def set_attribute_source(commit_id)
+        tree = get_tree(commit_id)
+        return if @attr_source == tree
+
+        @attr_source = tree
+        attr_index = Rugged::Index.new
+        attr_index.read_tree(@attr_source)
+        @rugged.index = attr_index
+      end
+
+      def load_attributes_for_path(path, attr_names)
+        @rugged.fetch_attributes(path, attr_names, GIT_ATTR_FLAGS)
+      end
+
+      def load_blob(blob_id, max_size)
+        Rugged::Blob.to_buffer(@rugged, blob_id, max_size)
+      end
+
+      def diff(old_commit, new_commit)
+        old_tree = old_commit.nil? ? nil : get_tree(old_commit)
+        new_tree = new_commit.nil? ? nil : get_tree(new_commit)
+
+        Diff.new(Rugged::Tree.diff(@rugged, old_tree, new_tree))
+      end
+
+      # Internal: get the Rugged::Tree associated with a given commit ID. This
+      # method should not be used outside of Linguist itself and is subject to
+      # change or be removed.
+      #
+      # commit_id - the object ID of the commit whose tree instance we want.
+      #
+      # Returns the Rugged::Tree of the specified commit.
+      def get_tree(commit_id)
+        tree = @tree_map[commit_id]
+        return tree if tree
+
+        @tree_map[commit_id] = Rugged::Commit.lookup(@rugged, commit_id).tree
+        @tree_map[commit_id]
+      end
+    end
+  end
+end

--- a/lib/linguist/source/rugged.rb
+++ b/lib/linguist/source/rugged.rb
@@ -86,6 +86,10 @@ module Linguist
         @tree_map[commit_id] = Rugged::Commit.lookup(@rugged, commit_id).tree
         @tree_map[commit_id]
       end
+
+      def method_missing(method_name, *args, &block)
+        @rugged.send(method_name, *args, &block)
+      end
     end
   end
 end

--- a/test/test_repository.rb
+++ b/test/test_repository.rb
@@ -1,16 +1,16 @@
 require_relative "./helper"
 
-class TestRepository < Minitest::Test
-  def rugged_repository
-    @rugged ||= Rugged::Repository.new(File.expand_path("../../.git", __FILE__))
-  end
-
+class TestRuggedRepository < Minitest::Test
   def master_oid
     '7dbcffcf982e766fc711e633322de848f2b60ba5'
   end
 
   def linguist_repo(oid = master_oid)
-    Linguist::Repository.new(rugged_repository, oid)
+    Linguist::Repository.new(source_repository, oid)
+  end
+
+  def source_repository
+    @rugged ||= Rugged::Repository.new(File.expand_path("../../.git", __FILE__))
   end
 
   def test_linguist_language
@@ -38,7 +38,7 @@ class TestRepository < Minitest::Test
     assert old_repo.languages['Ruby'] > 10_000
     assert old_repo.size > 30_000
 
-    new_repo = Linguist::Repository.incremental(rugged_repository, master_oid, old_commit, old_repo.cache)
+    new_repo = Linguist::Repository.incremental(source_repository, master_oid, old_commit, old_repo.cache)
 
     assert new_repo.languages['Ruby'] > old_repo.languages['Ruby']
     assert new_repo.size > old_repo.size
@@ -88,16 +88,16 @@ class TestRepository < Minitest::Test
     # With some .gitattributes data
     attr_commit = '7ee006cbcb2d7261f9e648510a684ee9ac64126b'
     # It's incremental but now is scanning more data and should bust the cache
-    new_repo = Linguist::Repository.incremental(rugged_repository, attr_commit, old_commit, old_repo.cache, 350_000)
+    new_repo = Linguist::Repository.incremental(source_repository, attr_commit, old_commit, old_repo.cache, 350_000)
 
     assert new_repo.breakdown_by_file["Java"].include?("lib/linguist.rb")
   end
 
   def test_linguist_override_vendored?
     attr_commit = '72a89fc9dcd3585250056ab591f9d7e2411d5fa1'
-    linguist_repo(attr_commit).read_index
+    linguist_repo(attr_commit).repository.set_attribute_source(attr_commit)
 
-    override_vendored = Linguist::LazyBlob.new(rugged_repository, attr_commit, 'Gemfile')
+    override_vendored = Linguist::LazyBlob.new(source_repository, attr_commit, 'Gemfile')
 
     # overridden .gitattributes
     assert override_vendored.vendored?
@@ -105,12 +105,12 @@ class TestRepository < Minitest::Test
 
   def test_linguist_override_unvendored?
     attr_commit = '01d6b9c637a7a6581fe456c600725b68f355b295'
-    linguist_repo(attr_commit).read_index
+    linguist_repo(attr_commit).repository.set_attribute_source(attr_commit)
 
     # lib/linguist/vendor.yml defines this as vendored.
-    override_unvendored = Linguist::LazyBlob.new(rugged_repository, attr_commit, 'test/fixtures/foo.rb')
+    override_unvendored = Linguist::LazyBlob.new(source_repository, attr_commit, 'test/fixtures/foo.rb')
     # test -linguist-vendored attribute method
-    override_unvendored_minus = Linguist::LazyBlob.new(rugged_repository, attr_commit, 'samples/CSS/bootstrap.css')
+    override_unvendored_minus = Linguist::LazyBlob.new(source_repository, attr_commit, 'samples/CSS/bootstrap.css')
 
     # overridden .gitattributes
     refute override_unvendored.vendored?
@@ -119,12 +119,12 @@ class TestRepository < Minitest::Test
 
   def test_linguist_override_documentation?
     attr_commit = "01d6b9c637a7a6581fe456c600725b68f355b295"
-    linguist_repo(attr_commit).read_index
+    linguist_repo(attr_commit).repository.set_attribute_source(attr_commit)
 
-    readme = Linguist::LazyBlob.new(rugged_repository, attr_commit, "README.md")
-    arduino = Linguist::LazyBlob.new(rugged_repository, attr_commit, "samples/Arduino/hello.ino")
+    readme = Linguist::LazyBlob.new(source_repository, attr_commit, "README.md")
+    arduino = Linguist::LazyBlob.new(source_repository, attr_commit, "samples/Arduino/hello.ino")
     # test -linguist-documentation attribute method
-    minus = Linguist::LazyBlob.new(rugged_repository, attr_commit, "LICENSE")
+    minus = Linguist::LazyBlob.new(source_repository, attr_commit, "LICENSE")
 
     # overridden by .gitattributes
     refute_predicate readme, :documentation?
@@ -134,11 +134,11 @@ class TestRepository < Minitest::Test
 
   def test_linguist_override_generated?
     attr_commit = "01d6b9c637a7a6581fe456c600725b68f355b295"
-    linguist_repo(attr_commit).read_index
+    linguist_repo(attr_commit).repository.set_attribute_source(attr_commit)
 
-    rakefile = Linguist::LazyBlob.new(rugged_repository, attr_commit, "Rakefile")
+    rakefile = Linguist::LazyBlob.new(source_repository, attr_commit, "Rakefile")
     # test  -linguist-generated attribute method
-    minus = Linguist::LazyBlob.new(rugged_repository, attr_commit, "samples/CSS/bootstrap.min.css")
+    minus = Linguist::LazyBlob.new(source_repository, attr_commit, "samples/CSS/bootstrap.min.css")
     # overridden .gitattributes
     assert rakefile.generated?
     refute minus.generated?
@@ -146,16 +146,87 @@ class TestRepository < Minitest::Test
 
   def test_linguist_override_detectable?
     attr_commit = "01d6b9c637a7a6581fe456c600725b68f355b295"
-    linguist_repo(attr_commit).read_index
+    linguist_repo(attr_commit).repository.set_attribute_source(attr_commit)
 
     # markdown is overridden by .gitattributes to be detectable, html to not be detectable
-    markdown = Linguist::LazyBlob.new(rugged_repository, attr_commit, "samples/Markdown/tender.md")
-    html = Linguist::LazyBlob.new(rugged_repository, attr_commit, "samples/HTML/pages.html")
+    markdown = Linguist::LazyBlob.new(source_repository, attr_commit, "samples/Markdown/tender.md")
+    html = Linguist::LazyBlob.new(source_repository, attr_commit, "samples/HTML/pages.html")
     # test  -linguist-detectable attribute method
-    minus = Linguist::LazyBlob.new(rugged_repository, attr_commit, "samples/CoffeeScript/browser.coffee")
+    minus = Linguist::LazyBlob.new(source_repository, attr_commit, "samples/CoffeeScript/browser.coffee")
 
     assert_predicate markdown, :detectable?
     refute_predicate html, :detectable?
     refute_predicate minus, :detectable?
+  end
+
+  def test_read_index
+    attr_commit = '72a89fc9dcd3585250056ab591f9d7e2411d5fa1'
+    repo = linguist_repo(attr_commit)
+    repo.read_index
+
+    expected_tree = '9dd86972f2d3caa295588b329f9f195bcb409204'
+    assert_equal expected_tree, @rugged.index.write_tree
+  end
+
+  def test_current_tree
+    repo = linguist_repo
+
+    expected_tree = 'f6cb65aeaee0b206b961746175ecaf4449f73c56'
+    assert_equal expected_tree, repo.current_tree.oid
+  end
+end
+
+################################################################################
+
+class TestEmptyRepository < Minitest::Test
+  def source_repository
+    @source ||= EmptyRepository.new
+  end
+
+  def linguist_repo
+    Linguist::Repository.new(source_repository, "1234567890123456789012345678901234567890")
+  end
+
+  def test_linguist_language
+    assert_nil linguist_repo.language
+  end
+
+  def test_linguist_size
+    assert_equal 0, linguist_repo.size
+  end
+
+  def test_read_index_raises_error
+    assert_raises(NotImplementedError) { linguist_repo.read_index }
+  end
+
+  def test_current_tree_raises_error
+    assert_raises(NotImplementedError) { linguist_repo.current_tree }
+  end
+end
+
+class EmptyRepository < Linguist::Source::Repository
+  class Diff < Linguist::Source::Diff
+    def each_delta(&block)
+      [].each(&block)
+    end
+  end
+
+  def get_tree_size(commit_id, limit)
+    0
+  end
+
+  def set_attribute_source(commit_id)
+  end
+
+  def load_attributes_for_path(path, attr_names)
+    {}
+  end
+
+  def load_blob(blob_id, max_size)
+    ["", 0]
+  end
+
+  def diff(old_commit, new_commit)
+    Diff.new
   end
 end


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
The goal of this change is to add flexibility to how repository data is accessed by `Linguist::Repository` & `Linguist::LazyBlob`, allowing users to easily configure an alternative to `Rugged`. 

Internally, `Linguist::Repository` and `Linguist::LazyBlob` use Rugged to read Git repository data, including diff, attribute, and blob information. While this works for most repositories, it has limits:

- Rugged/libgit2 can lag behind feature support in Git (e.g. [reftable](https://github.com/libgit2/libgit2/issues/5352), previously SHA-256).
- Rugged is a Git API, which makes using Linguist with other SCMs challenging.

The approach taken here is to replace the `Rugged::Repository` instance in the `Linguist::Repository` with a new `Linguist::Source::Repository` instance. The "source" repository contains functions wrapping what were previously Rugged operations (diff, attribute lookup, etc.). Users can then write their custom implementations of those functions and pass their `Linguist::Source::Repository` into `Linguist::Repository` to use them seamlessly. 

This isn't intended to be a breaking change, so there are a few extra things done to avoid compatibility issues with existing usage:

- If a `Rugged::Repository` is passed in as the first argument to either the `Linguist::Repository` or `LazyBlob` initializer, it is wrapped in a `Linguist::Source::RuggedRepository` internally.
- `GIT_ATTR_OPTS` & `GIT_ATTR_FLAGS` are Rugged-specific so they're moved to `RuggedRepository`, but the `LazyBlob` constants are not removed and instead point to their `RuggedRepository` counterparts.
- `current_tree` and `read_index` don't make sense for non-Rugged repos (the former returns a Rugged tree instance, the latter is specific to how Rugged needs to look up attributes). They raise `NotImplementedError` with a message referencing deprecation _only_ if called on a non-Rugged repository instance; otherwise they behave the same way as before.
- A `method_missing` implementation is added to `Linguist::RuggedRepository` to delegate any unmatched method calls to the internal `Rugged::Repository` instance (in case users are calling `Linguist::Repository.repository` directly).

The only possible compatibility issue I can imagine is if a user does some kind of type check on `Linguist::Repository.repository` (previously it was a `Rugged::Repository`, now it'll be a `Linguist::Source::RuggedRepository`). That seems highly unlikely, though, and should be a simple fix if needed.

---

The commits on this branch are organized to be atomic and incrementally reviewable: 

- Commit 1 adds the generic `Linguist::Source:Repository` and `Linguist::Source::Diff` interfaces, with all methods raising `NotImplementedError` to ensure they are overridden by a subclass implementation.
- Commit 2 adds a Rugged implementation of `Linguist::Source::Repository` matching existing usage in `compute_stats` and `Linguist::LazyBlob`.
- Commit 3 updates `Linguist::Repository` to use a `Linguist::Source::Repository` instead of a `Rugged::Repository` to read repository content.
- Commit 4 adds the `method_missing` implementation to `RuggedRepository`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am adding a new extension to a language.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.FOOBAR+KEYWORDS
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.FOOBAR+KEYWORDS
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a syntax highlighting grammar: [URL to grammar repo]
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [ ] I have added a color
    - Hex value: `#RRGGBB`
    - Rationale: <!-- Please specify why you chose this color (if it was randomly selected, please say so); it helps arbitrate future requests to change a language's color -->
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  - Old: [URL to grammar repo]
  - New: [URL to grammar repo]

- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.

- [ ] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [URL to public discussion]
    - [Optional: URL to official branding guidelines for the language]
