### PR TITLE
Add WORKSPACE.bzlmod to Starlark

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7004,6 +7004,7 @@ Starlark:
   color: "#76d275"
   extensions:
   - ".bzl"
+  - ".bzlmod"
   - ".star"
   filenames:
   - BUCK

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7004,7 +7004,6 @@ Starlark:
   color: "#76d275"
   extensions:
   - ".bzl"
-  - ".bzlmod"
   - ".star"
   filenames:
   - BUCK
@@ -7014,6 +7013,7 @@ Starlark:
   - Tiltfile
   - WORKSPACE
   - WORKSPACE.bazel
+  - WORKSPACE.bzlmod
   aliases:
   - bazel
   - bzl

--- a/samples/Starlark/filenames/WORKSPACE.bzlmod
+++ b/samples/Starlark/filenames/WORKSPACE.bzlmod
@@ -1,0 +1,6 @@
+# This file marks the root of the Bazel workspace.
+# See MODULE.bazel for dependencies and setup.
+# It is only used when bzlmod is enabled.
+# This file will generally be kept empty in favor of using MODULE.bazel fully.
+
+workspace(name = "build_bazel_rules_ios")


### PR DESCRIPTION
Bazel's bzlmod dependency manager involves Starlark files with `.bzlmod` file extensions.

https://bazel.build/external/migration#workspace.bzlmod

<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:

- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:

      Please note: bazel-y people tend toward monorepos, so high contributor count vs smaller repo count

      - 8k repos: https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.bzlmod+bazel
      - 108 repos: https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.bzlmod+bzlmod
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/bazel-contrib/rules_dotnet/pull/460 -> https://github.com/bazel-contrib/rules_dotnet/blob/master/examples/WORKSPACE.bzlmod
    - Sample license(s):
  - > [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
  
      Sorry, I don't follow what this one is asking?