### PR TITLE
Add `.buckconfig` to INI filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3058,6 +3058,7 @@ INI:
   - ".properties"
   - ".url"
   filenames:
+  - ".buckconfig"
   - ".coveragerc"
   - ".flake8"
   - ".pylintrc"

--- a/samples/INI/filenames/.buckconfig
+++ b/samples/INI/filenames/.buckconfig
@@ -1,0 +1,6 @@
+
+[android]
+  target = Google Inc.:Google APIs:23
+
+[maven_repositories]
+  central = https://repo1.maven.org/maven2


### PR DESCRIPTION
## Description

This file uses the INI format ([source](https://buck.build/files-and-dirs/buckconfig.html))

## Checklist:
- [x] **I am adding a new ~~extension~~ filename to a language.**
  - [x] The new ~~extension~~ is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A%2F%28%5E%7C%5C%2F%29%5C.buckconfig%2F+root
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/bluesky-social/social-app/blob/017b7647b18cc67201c5b4e9c5da36a53257daa9/.buckconfig
    - Sample license(s):
      - https://github.com/bluesky-social/social-app/blob/3bab7f7540273a50501780b2f92076fbe41c8022/LICENSE
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.