### PR TITLE
Add `.easignore` as Ignore List filename

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3111,6 +3111,7 @@ Ignore List:
   - ".coffeelintignore"
   - ".cvsignore"
   - ".dockerignore"
+  - ".easignore"
   - ".eleventyignore"
   - ".eslintignore"
   - ".gitignore"

--- a/samples/Ignore List/filenames/.easignore
+++ b/samples/Ignore List/filenames/.easignore
@@ -1,0 +1,101 @@
+# OSX
+#
+.DS_Store
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+*.hprof
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# BUCK
+buck-out/
+\.buckd/
+*.keystore
+!debug.keystore
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/
+
+*/fastlane/report.xml
+*/fastlane/Preview.html
+*/fastlane/screenshots
+
+# Bundle artifact
+*.jsbundle
+
+# Ruby / CocoaPods
+/ios/Pods/
+/vendor/bundle/
+
+# Testing
+coverage/
+junit.xml
+artifacts
+
+# Web bundle outputs
+/dist/
+
+# Expo
+.expo/
+dist/
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+*.orig.*
+web-build/
+
+# Temporary files created by Metro to check the health of the file watcher
+.metro-health-check*
+
+# VSCode
+.vscode
+
+# gitignore and github actions
+!.gitignore
+!.github
+
+
+# Android & iOS folders
+/android/
+/ios/
+
+# environment variables
+.env.*
+
+# Firebase (Android) Google services
+# INCLUDED: google-services.json


### PR DESCRIPTION
## Description

This is probably on the edge of being popular enough. Without limiting the search to common keywords, there's a little over \>300 results. Apologies if this isn't popular enough yet.

## Checklist:
- [x] **I am adding a new ~~extension~~ filename to a language.**
  - [x] The new ~~extension~~ filename is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A%2F%28%5E%7C%5C%2F%29%5C.easignore%24%2F+node_modules
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/bluesky-social/social-app/blob/3bab7f7540273a50501780b2f92076fbe41c8022/.easignore
    - Sample license(s):
      - [MIT](https://github.com/bluesky-social/social-app/blob/3bab7f7540273a50501780b2f92076fbe41c8022/LICENSE)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.