### PR TITLE
Change CSS colour to `rebeccapurple`

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -908,7 +908,7 @@ CSS:
   ace_mode: css
   codemirror_mode: css
   codemirror_mime_type: text/css
-  color: "#563d7c"
+  color: "#663399"
   extensions:
   - ".css"
   language_id: 50


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

This PR changes the CSS color to be in line with the new CSS logo that was recently adopted.
The discussion related to the change took place in a GitHub issue (see link below) and the new color got almost 500 🎉, so the consensus is there.

Also, the change remains minor since this is a change from a shade of purple to another. However, for people that know about [the meaning of rebeccapurple](https://dev.to/joacod/the-special-meaning-behind-the-new-css-logo-rebeccapurple-2205), it's a nice touch.

Current: `#563d7c`
Suggested: `#663399`

Fixes https://github.com/github-linguist/linguist/issues/7132

## Checklist:

- [x] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [x] I have obtained agreement from the wider language community on this color change.
    - https://github.com/CSS-Next/css-next/issues/105#issuecomment-2445341089

