### PR TITLE
docs: Add link to Docker build instructions further down in the README to the How To Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ cd /path-to-repository
 github-linguist
 ```
 
+You can locally build the `github-linguist` binary either [using Docker](#docker) or via the [contributing documention](#contributing).
+
 You can try running `github-linguist` on the root directory in this repository itself:
 
 ```console


### PR DESCRIPTION
This is a very minor addition to the README.

Because I was (initially) too dumb to see this, and without a Ruby background, did not immediately know how to build this, in order to contribute.