### PR TITLE
Add :Z to 'docker run -v' so that it works with Podman on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ If you have Docker installed you can build an image and run Linguist within a co
 
 ```console
 $ docker build -t linguist .
-$ docker run --rm -v $(pwd):$(pwd) -w $(pwd) -t linguist
+$ docker run --rm -v $(pwd):$(pwd):Z -w $(pwd) -t linguist
 66.84%  264519     Ruby
 24.68%  97685      C
 6.57%   25999      Go


### PR DESCRIPTION
This fixes #7159.

It's (only) a `README` documentation update (no code changed).