### PR TITLE
Add `.timer` & various other systemd extensions (fixes #7161)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8468,10 +8468,38 @@ crontab:
   language_id: 705203557
 desktop:
   type: data
+  # https://en.wikipedia.org/wiki/INI_file
+  filenames:
+  - "systemd-system.conf"
+  - "systemd-user.conf"
+  - "logind.conf"
+  - "journald.conf"
+  - "journal-remote.conf"
+  - "journal-upload.conf"
+  - "systemd-sleep.conf"
+  - "timesyncd.conf"
   extensions:
   - ".desktop"
   - ".desktop.in"
+  # systemd unit-file types; extensions from
+  # https://www.freedesktop.org/software/systemd/man/latest/systemd.syntax.html
+  - ".automount"
+  - ".device"
+  - ".link"
+  - ".mount"
+  - ".netdev"
+  - ".network"
+  - ".nspawn"
+  - ".path"
+  - ".scope"
   - ".service"
+  - ".slice"
+  - ".snapshot"
+  - ".socket"
+  - ".swap"
+  - ".target"
+  - ".timer"
+  - ".unit"
   tm_scope: source.desktop
   ace_mode: text
   language_id: 412


### PR DESCRIPTION
## Description

Fixes #7161.

## Checklist:

- [X] **I am adding a new extension to a language.**
  - TODO [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.FOOBAR+KEYWORDS
  - TODO [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [X] I have verified that there is no need to include a change to the heuristics to distinguish my language from others using the same extension (because all these new systemd specific file name extensions are not yet used by other other language). 