### PR TITLE
Added Modu support

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -862,6 +862,8 @@ vendor/grammars/mint-vscode:
 - source.mint
 vendor/grammars/mlir-grammar:
 - source.mlir
+vendor/grammars/modu-grammar:
+- source.modu
 vendor/grammars/mojo-syntax:
 - source.mojo
 vendor/grammars/monkey:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4143,6 +4143,14 @@ MLIR:
   tm_scope: source.mlir
   ace_mode: text
   language_id: 448253929
+Modu:
+  type: programming
+  color: "#F5AAAA"
+  extensions:
+  - ".modu"
+  tm_scope: source.modu
+  ace_mode: text
+  language_id: 448253930
 MQL4:
   type: programming
   color: "#62A8D6"

--- a/samples/Modu/helloworld.modu
+++ b/samples/Modu/helloworld.modu
@@ -1,0 +1,5 @@
+fn yap(something) {
+    print(something);
+}
+
+yap("Hello, World!");

--- a/samples/Modu/math.modu
+++ b/samples/Modu/math.modu
@@ -1,0 +1,12 @@
+import "math" as *
+
+let a = 1;
+let b = 2;
+
+let c = div(a, b);
+
+if c == 1 {
+    print("a == b");
+} if c != 1 {
+    print("a != b");
+}


### PR DESCRIPTION
## Description
In December 2024, Cyteon created the Modu programming language, that aims to be readable and fast, even tho it's interpreted. I like the project, so i decided to add support for it in GitHub's linguist. The project is improving every day, it's criminally underrated!

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.modu
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - samples/Modu/helloworld.modu (shows a simple function declaration and hello world)
      - samples/Modu/math.modu (showcases if statements and library imports
    - Sample license(s):
  - [x] I have included a syntax highlighting grammar
  - [x] I have added a color
    - Hex value: `#F5AAAA`
    - Rationale: The color was picked on Modu's logo, available in https://cyteon.tech/modu
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.
