### PR TITLE
Add Fels programming language support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2080,6 +2080,14 @@ Faust:
   tm_scope: source.faust
   ace_mode: text
   language_id: 622529198
+Fels:
+  type: programming
+  color: "#ff502a"
+  extensions:
+    - ".fels"
+  tm_scope: source.fels
+  ace_mode: text
+  language_id: 9196543228
 Fennel:
   type: programming
   tm_scope: source.fnl


### PR DESCRIPTION
Add Fels programming language support
[Fels programming language](https://github.com/FelekDevYT/Fels-programming-language)
Add to lib/linguist/languages.yml:
```YML
Fels:
  type: programming
  color: "#ff502a"
  extensions:
    - ".fels"
  tm_scope: source.fels
  ace_mode: text
  language_id: 9196543228
```