### PR TITLE
Add GPX to XML extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8112,6 +8112,7 @@ XML:
   - ".glade"
   - ".gml"
   - ".gmx"
+  - ".gpx"
   - ".grxml"
   - ".gst"
   - ".hzp"

--- a/samples/XML/route-gas-works-lake-union-loop.gpx
+++ b/samples/XML/route-gas-works-lake-union-loop.gpx
@@ -1,0 +1,85 @@
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="Race Condition Running">
+  <metadata>
+    <name>gas-works-lake-union-loop</name>
+    <desc>Gas Works, Lake Union Loop (6.3 mi)</desc>
+    <link href="https://raceconditionrunning.com/routes/gas-works-lake-union-loop">
+      <text>Race Condition Running: Gas Works, Lake Union Loop</text>
+    </link>
+    <author>
+      <name>Race Condition Running</name>
+      <link href="https://raceconditionrunning.com">
+        <text>Race Condition Running</text>
+      </link>
+    </author>
+  </metadata>
+  <trk>
+    <name>gas-works-lake-union-loop</name>
+    <desc>Gas Works, Lake Union Loop (6.3 mi)</desc>
+    <trkseg>
+      <trkpt lat="47.64694" lon="-122.33451"><ele>11.14</ele></trkpt>
+      <trkpt lat="47.64693" lon="-122.33835"><ele>9.97</ele></trkpt>
+      <trkpt lat="47.64758" lon="-122.33943"><ele>9.54</ele></trkpt>
+      <trkpt lat="47.64813" lon="-122.34077"><ele>11.35</ele></trkpt>
+      <trkpt lat="47.64907" lon="-122.34696"><ele>9.12</ele></trkpt>
+      <trkpt lat="47.64893" lon="-122.34713"><ele>8.62</ele></trkpt>
+      <trkpt lat="47.64784" lon="-122.34723"><ele>7.73</ele></trkpt>
+      <trkpt lat="47.64763" lon="-122.34757"><ele>7.15</ele></trkpt>
+      <trkpt lat="47.64755" lon="-122.34837"><ele>7.61</ele></trkpt>
+      <trkpt lat="47.64788" lon="-122.34928"><ele>7.86</ele></trkpt>
+      <trkpt lat="47.64809" lon="-122.34957"><ele>8.22</ele></trkpt>
+      <trkpt lat="47.64803" lon="-122.34964"><ele>7.87</ele></trkpt>
+      <trkpt lat="47.64812" lon="-122.34966"><ele>8.38</ele></trkpt>
+      <trkpt lat="47.64668" lon="-122.34965"><ele>17.05</ele></trkpt>
+      <trkpt lat="47.64622" lon="-122.34948"><ele>17.15</ele></trkpt>
+      <trkpt lat="47.64568" lon="-122.34873"><ele>15.98</ele></trkpt>
+      <trkpt lat="47.64453" lon="-122.34594"><ele>10.76</ele></trkpt>
+      <trkpt lat="47.64463" lon="-122.34564"><ele>8.56</ele></trkpt>
+      <trkpt lat="47.64414" lon="-122.34464"><ele>8.5</ele></trkpt>
+      <trkpt lat="47.64243" lon="-122.34311"><ele>8.37</ele></trkpt>
+      <trkpt lat="47.64094" lon="-122.34226"><ele>8.11</ele></trkpt>
+      <trkpt lat="47.63924" lon="-122.34109"><ele>8.48</ele></trkpt>
+      <trkpt lat="47.63849" lon="-122.34065"><ele>8.39</ele></trkpt>
+      <trkpt lat="47.63704" lon="-122.34008"><ele>8.21</ele></trkpt>
+      <trkpt lat="47.6341" lon="-122.34002"><ele>8.61</ele></trkpt>
+      <trkpt lat="47.63344" lon="-122.34016"><ele>8.48</ele></trkpt>
+      <trkpt lat="47.63218" lon="-122.3407"><ele>8.43</ele></trkpt>
+      <trkpt lat="47.62991" lon="-122.34069"><ele>8.52</ele></trkpt>
+      <trkpt lat="47.62911" lon="-122.34055"><ele>8.55</ele></trkpt>
+      <trkpt lat="47.62781" lon="-122.33959"><ele>8.79</ele></trkpt>
+      <trkpt lat="47.62709" lon="-122.33915"><ele>7.98</ele></trkpt>
+      <trkpt lat="47.62708" lon="-122.33639"><ele>6.52</ele></trkpt>
+      <trkpt lat="47.62628" lon="-122.33622"><ele>7.9</ele></trkpt>
+      <trkpt lat="47.62639" lon="-122.33564"><ele>7.83</ele></trkpt>
+      <trkpt lat="47.62636" lon="-122.33456"><ele>8.79</ele></trkpt>
+      <trkpt lat="47.62646" lon="-122.3343"><ele>8.76</ele></trkpt>
+      <trkpt lat="47.62637" lon="-122.33415"><ele>8.82</ele></trkpt>
+      <trkpt lat="47.62644" lon="-122.33402"><ele>9.09</ele></trkpt>
+      <trkpt lat="47.63209" lon="-122.32674"><ele>9.96</ele></trkpt>
+      <trkpt lat="47.63228" lon="-122.32691"><ele>9.17</ele></trkpt>
+      <trkpt lat="47.63485" lon="-122.32691"><ele>8.57</ele></trkpt>
+      <trkpt lat="47.63536" lon="-122.32706"><ele>8.68</ele></trkpt>
+      <trkpt lat="47.63588" lon="-122.32749"><ele>8.77</ele></trkpt>
+      <trkpt lat="47.63689" lon="-122.3292"><ele>8.94</ele></trkpt>
+      <trkpt lat="47.63727" lon="-122.32943"><ele>8.8</ele></trkpt>
+      <trkpt lat="47.64217" lon="-122.32941"><ele>6.29</ele></trkpt>
+      <trkpt lat="47.64321" lon="-122.32867"><ele>8.14</ele></trkpt>
+      <trkpt lat="47.6432" lon="-122.32601"><ele>27.18</ele></trkpt>
+      <trkpt lat="47.64327" lon="-122.32589"><ele>27.15</ele></trkpt>
+      <trkpt lat="47.64561" lon="-122.32585"><ele>22.34</ele></trkpt>
+      <trkpt lat="47.65175" lon="-122.32128"><ele>17.12</ele></trkpt>
+      <trkpt lat="47.65551" lon="-122.31841"><ele>29.2</ele></trkpt>
+      <trkpt lat="47.65552" lon="-122.31878"><ele>23.78</ele></trkpt>
+      <trkpt lat="47.65529" lon="-122.31881"><ele>20.23</ele></trkpt>
+      <trkpt lat="47.65559" lon="-122.32028"><ele>19.43</ele></trkpt>
+      <trkpt lat="47.65556" lon="-122.32156"><ele>19.21</ele></trkpt>
+      <trkpt lat="47.65477" lon="-122.3258"><ele>17.61</ele></trkpt>
+      <trkpt lat="47.65438" lon="-122.32679"><ele>17.87</ele></trkpt>
+      <trkpt lat="47.65353" lon="-122.32782"><ele>15.47</ele></trkpt>
+      <trkpt lat="47.65208" lon="-122.32929"><ele>14.28</ele></trkpt>
+      <trkpt lat="47.65053" lon="-122.33145"><ele>14.22</ele></trkpt>
+      <trkpt lat="47.64716" lon="-122.33344"><ele>11.21</ele></trkpt>
+      <trkpt lat="47.64693" lon="-122.33393"><ele>11.06</ele></trkpt>
+      <trkpt lat="47.64694" lon="-122.33453"><ele>11.12</ele></trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/test/test_strategies.rb
+++ b/test/test_strategies.rb
@@ -186,6 +186,7 @@ class TestStrategies < Minitest::Test
       "#{samples_path}/XML/sample.targets",
       "#{samples_path}/XML/Default.props",
       "#{samples_path}/XML/racoon.mjml",
+      "#{samples_path}/XML/route-gas-works-lake-union-loop.gpx",
       "#{samples_path}/XML/some-ideas.mm",
       "#{samples_path}/XML/GMOculus.project.gmx",
       "#{samples_path}/XML/obj_control.object.gmx",


### PR DESCRIPTION
[GPS Exchange Format](https://en.wikipedia.org/wiki/GPS_Exchange_Format) is a common XML schema. The root XML tag is left out often enough that it warrants adding to linguist.

## Description

Adds `.gpx` to XML extensions and a rootless sample of my creation for testing. 

## Checklist:

- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - 6.5k `.gpx` without `<?xml`: https://github.com/search?q=NOT+is%3Afork+path%3A*.gpx+NOT+%22%3C%3Fxml%22&type=code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s): Self-created
    - Sample license(s): Self-created
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
