### PR TITLE
Update extension list for HEEx

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2845,10 +2845,12 @@ HTML+EEX:
   - eex
   - heex
   - leex
+  - neex
   extensions:
-  - ".eex"
-  - ".html.heex"
-  - ".html.leex"
+  - ".html.eex"
+  - ".heex"
+  - ".leex"
+  - ".neex"
   ace_mode: text
   codemirror_mode: htmlmixed
   codemirror_mime_type: text/html

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2845,12 +2845,10 @@ HTML+EEX:
   - eex
   - heex
   - leex
-  - neex
   extensions:
   - ".html.eex"
   - ".heex"
   - ".leex"
-  - ".neex"
   ace_mode: text
   codemirror_mode: htmlmixed
   codemirror_mime_type: text/html

--- a/samples/HTML+EEX/live_component.swiftui.neex
+++ b/samples/HTML+EEX/live_component.swiftui.neex
@@ -1,0 +1,5 @@
+<.csrf_token />
+<Style url={~p"/assets/app.<%= context.format %>.styles"} />
+<NavigationStack>
+  {@inner_content}
+</NavigationStack>

--- a/samples/HTML+EEX/live_component.swiftui.neex
+++ b/samples/HTML+EEX/live_component.swiftui.neex
@@ -1,5 +1,0 @@
-<.csrf_token />
-<Style url={~p"/assets/app.<%= context.format %>.styles"} />
-<NavigationStack>
-  {@inner_content}
-</NavigationStack>


### PR DESCRIPTION
Updates extensions list for [HEEx](https://hexdocs.pm/phoenix/components.html#heex).

cc @patrickt

## Description

I applied the following changes to extensions marked as `HTML+EEx`:

* `.eex` -> `.html.eex` - technically .eex is a more generic templating syntax and is also used with other files, for example `.sh.eex`
* `.html.heex` -> `.heex` - contrarily to the above, this extension by definition implies HTML markup (extended). It is common to still use `.html.heex` files, but semantically `.heex` should be enough.
* `.html.leex` -> `.leex` - it's `.heex` predecessor, same applies.
* ~~added `.neex` - this is a new variant used for native apps markup, it has a different processing engine, but the sytnax is the same.~~

For the reference, the [TextMate grammar](https://github.com/elixir-editors/elixir-tmbundle/blob/master/Syntaxes/HTML%20(EEx).tmLanguage#L7-L10) has also been updated with these changes.