### PR TITLE
Hide .snap snapshot files by insta.rs framework

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -74,6 +74,7 @@ module Linguist
       npm_shrinkwrap_or_package_lock? ||
       pnpm_lock? ||
       terraform_lock? ||
+      insta_snap? ||
       generated_yarn_plugnplay? ||
       godeps? ||
       generated_by_zephir? ||
@@ -562,6 +563,17 @@ module Linguist
       !!name.match(/(?:^|\/)\.terraform\.lock\.hcl$/)
     end
 
+    # Internal: Is this a Rust test snapshot file by Insta?
+    # 
+    # By default these files are stored in `.../snapshots/*.snap`,
+    # but user may modify the location.
+    # See <https://insta.rs/docs/snapshot-files/>
+    #
+    # Returns true or false.
+    def insta_snap?
+      !!name.match(/(?:^|\/)\.snap$/)
+    end
+        
     # Internal: Is it a KiCAD or GFortran module file?
     #
     # KiCAD module files contain:


### PR DESCRIPTION
## Description
`*.snap` are snapshot files stored by the popular Rust [Insta](https://insta.rs/docs/snapshot-files/)  framework, and are auto-generated when the test results are accepted. Subsequent test runs just match results against these files.

By default .snap files are stored in the `.../snapshots/*.snap`, but user may modify the location. For now, I marked all `.snap` files as internal, but this may need to be revisited if other common extension is also .snap

Examples of [/snapshots/*.snap](https://github.com/search?q=path%3A%2F%5C%2Fsnapshots%5C%2F%5B%5E%5C%2F%5D%2B%5C.snap%24%2F&type=code) - 103k instances.

Note that it appears `.snap` is often used by other repositories for similar purpose, so I think it might be OK to hide it for them as well.  [Code search without /snapshots/ prefix](https://github.com/search?q=path%3A%2F%5C.snap%24%2F&type=code)

## Checklist:
- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.