### PR TITLE
Remove atomic groups

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -952,7 +952,7 @@ named_patterns:
   gsc:
   - '^\s*#\s*(?:using|insert|include|define|namespace)[ \t]+\w'
   - '^\s*((?:autoexec|private)\s+){0,2}function\s+((?:autoexec|private)\s+){0,2}\w+\s*\('
-  - '\b(?:level|self)[ \t]+thread[ \t]+(?:\[\[[ \t]*(\w+\.)*\w+[ \t]*\]\]|\w+)[ \t]*\([^\r\n\)]*\)[ \t]*;'
+  - '\b(?:level|self)[ \t]+thread[ \t]+(?:\[\[[ \t]*(\w+\.)+[ \t]*\]\]|\w+)[ \t]*\([^\r\n\)]*\)[ \t]*;'
   - '^[ \t]*#[ \t]*(?:precache|using_animtree)[ \t]*\('
   json: '\A\s*[{\[]'
   key_equals_value: '^[^#!;][^=]*='

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -465,7 +465,7 @@ disambiguations:
 - extensions: ['.mc']
   rules:
   - language: Win32 Message File
-    pattern: '(?i)^[ \t]*(?>\/\*\s*)?MessageId=|^\.$'
+    pattern: '(?i)^[ \t]*(\/\*\s*)?MessageId=|^\.$'
   - language: M4
     pattern: '^dnl|^divert\((?:-?\d+)?\)|^\w+\(`[^\r\n]*?''[),]'
   - language: Monkey C
@@ -880,7 +880,7 @@ disambiguations:
 - extensions: ['.url']
   rules:
   - language: INI
-    pattern: '^\[InternetShortcut\](?:\r?\n|\r)(?>[^\s\[][^\r\n]*(?:\r?\n|\r))*URL='
+    pattern: '^\[InternetShortcut\](?:\r?\n|\r)([^\s\[][^\r\n]*(?:\r?\n|\r)){0,20}URL='
 - extensions: ['.v']
   rules:
   - language: Coq
@@ -951,8 +951,8 @@ named_patterns:
   - '(?i)^[ \t]*dim( shared)? [a-z_][a-z0-9_]* as [a-z_][a-z0-9_]* ptr'
   gsc:
   - '^\s*#\s*(?:using|insert|include|define|namespace)[ \t]+\w'
-  - '^\s*(?>(?:autoexec|private)\s+){0,2}function\s+(?>(?:autoexec|private)\s+){0,2}\w+\s*\('
-  - '\b(?:level|self)[ \t]+thread[ \t]+(?:\[\[[ \t]*(?>\w+\.)*\w+[ \t]*\]\]|\w+)[ \t]*\([^\r\n\)]*\)[ \t]*;'
+  - '^\s*((?:autoexec|private)\s+){0,2}function\s+((?:autoexec|private)\s+){0,2}\w+\s*\('
+  - '\b(?:level|self)[ \t]+thread[ \t]+(?:\[\[[ \t]*(\w+\.)*\w+[ \t]*\]\]|\w+)[ \t]*\([^\r\n\)]*\)[ \t]*;'
   - '^[ \t]*#[ \t]*(?:precache|using_animtree)[ \t]*\('
   json: '\A\s*[{\[]'
   key_equals_value: '^[^#!;][^=]*='


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

Atomic groups (aka. Non-backtracking subexpression or possessive match) aren't supported in re2. I've removed them to increase portability accross libraries that use Linguist's heuristics.

Note that atomic groups can be useful to increase performance, but the risk of excessive backtracking in the cases here is minimal or I've added other countermesures when needed.

***Win32 Message File***

There was no real use of atomic grouping there since `\/\*\s*` can't really cause any branching in this context.

***INI***

The original use of an atomic group in `(?>[^\s\[][^\r\n]*(?:\r?\n|\r))*` can prevent some backtracking in case a file contains "InternetShortcut]", but no "URL" property afterwards. However, even without the atomic grouping, the execution time remains linear since the capture group doesn't have multiple ways of matching a whole line. I've also added a limit of 20 lines for the "URL" property to appear since that should be more than enough.

***GSC***

First pattern: The atomic grouping was only preventing minor backtracking due to the presence of 2 options.

Second pattern: That was probably the most useful case of atomic grouping among the one presented here. However, simply combining `(?>\w+\.)*\w+` into `(\w+\.)+` like proposed in this PR will already prevent the vast majority of potential backtracking.
