### PR TITLE
Added PowerBI (.pbix) support to GitHub Linguist

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5637,6 +5637,15 @@ PostScript:
   - postscr
   ace_mode: text
   language_id: 291
+PowerBI:
+  type: data
+  extensions:
+    - .pbix
+  color: "#EC4D37"  
+  group: "Data"
+  tm_scope: text.powerbi
+  ace_mode: text
+  searchable: true
 PowerBuilder:
   type: programming
   color: "#8f0f8d"


### PR DESCRIPTION
## Summary
This PR adds support for Power BI `.pbix` files to GitHub Linguist. 

## Why?
- Power BI is widely used for data visualization and business intelligence.
- `.pbix` files are commonly shared in repositories for reports and dashboards.
- Adding this will help users categorize and recognize Power BI projects in GitHub repositories.

## Changes Made
- Added a new language entry for `PowerBI` in `languages.yml`.
- Defined `.pbix` as a recognized file extension.
- Assigned a unique color (`#EC4D37`) and metadata.

Please review and consider merging this PR. Thank you!
