### PR TITLE
Add ISPC language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -569,6 +569,9 @@
 [submodule "vendor/grammars/ionide-fsgrammar"]
 	path = vendor/grammars/ionide-fsgrammar
 	url = https://github.com/ionide/ionide-fsgrammar
+[submodule "vendor/grammars/ispc.syntax"]
+	path = vendor/grammars/ispc.syntax
+	url = https://github.com/ispc/ispc.syntax.git
 [submodule "vendor/grammars/jade-tmbundle"]
 	path = vendor/grammars/jade-tmbundle
 	url = https://github.com/davidrios/jade-tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -475,6 +475,8 @@ vendor/grammars/ionide-fsgrammar:
 - source.fsharp.fsx
 - source.paket.dependencies
 - source.paket.lock
+vendor/grammars/ispc.syntax:
+- source.ispc
 vendor/grammars/jade-tmbundle:
 - source.pyjade
 - text.jade

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3108,6 +3108,16 @@ IRC log:
   codemirror_mode: mirc
   codemirror_mime_type: text/mirc
   language_id: 164
+ISPC:
+  type: programming
+  color: "#2D68B1"
+  extensions:
+  - ".ispc"
+  tm_scope: source.ispc
+  ace_mode: c_cpp
+  codemirror_mode: clike
+  codemirror_mime_type: text/x-csrc
+  language_id: 327071
 Idris:
   type: programming
   color: "#b30000"

--- a/samples/ISPC/VideoFunctions.ispc
+++ b/samples/ISPC/VideoFunctions.ispc
@@ -1,0 +1,88 @@
+export struct VideoData {
+    uint16 width;
+    uint16 height;
+    uint16 buffer_width;
+    uint16 buffer_height;
+    int16 yoffset;
+    int16 xoffset;
+    int16 ytail;
+    int16 xtail;
+    bool transparentBlack;
+    int16 transparentBlackLevel;
+    int16 image_width;
+    int16 image_height;
+    int32 startx;
+    int32 starty;
+    int32 sampleSpacing;
+
+    int8 ch;
+    uint8* image;
+    void* bufferData;
+};
+
+export void VideoEffectProcess(const uniform VideoData &data,
+                               uniform int startIdx, uniform int endIdx,
+                               uniform uint8<4> result[])
+{
+    uniform int ch = data.ch;
+
+
+    foreach (index = startIdx...endIdx) {
+        float fidx = index;
+        float y = (floor)(fidx / data.buffer_width);
+        float x = fidx - (y * data.buffer_width);
+        int newIndex = x + data.startx + ((y + data.starty) * data.buffer_width);
+
+        uint8* ptr = data.image + (data.image_height - 1 - y - data.yoffset) * (data.image_width * ch) + (data.xoffset * ch) + (x * ch);
+        uint8<4> c;
+        c.x = *(ptr);
+        c.y = *(ptr + 1);
+        c.z = *(ptr + 2);
+        c.w = ch == 3 ? 255 : *(ptr + 3);
+        uint16 level = (uint16)c[0] + (uint16)c[1] + (uint16)c[2];
+        if (data.transparentBlack) {
+            if (level > data.transparentBlackLevel) {
+                result[newIndex] = c;
+            }
+        } else {
+            result[newIndex] = c;
+        }
+    }
+}
+
+export void VideoEffectProcessSample(const uniform VideoData &data,
+                                        uniform int startIdx, uniform int endIdx, 
+                                        uniform uint8<4> result[]) {
+    uniform float width = data.width;
+    uniform float rszw = 1.0 / width;
+    uniform float height = data.height;
+    uniform int ch = data.ch;
+
+    foreach (index = startIdx ... endIdx) {
+        float fidx = index;
+        float y = (floor)(fidx * rszw + 0.00001);
+        float x = fidx - (y * width);
+        float newIndex = (y * width) + x;
+
+        int curx = data.startx + x * data.sampleSpacing;
+        int cury = data.starty + y * data.sampleSpacing;
+
+        if (curx >= 0 && curx < data.image_width && cury >= 0 && cury < data.image_height) {
+
+            uint8* ptr = data.image + (data.image_height - 1 - cury) * data.image_width * ch + curx * ch;
+            uint8<4> c;
+            c.x = *(ptr);
+            c.y = *(ptr + 1);
+            c.z = *(ptr + 2);
+            c.w = ch == 3 ? 255 : *(ptr + 3);
+            if (data.transparentBlack) {
+                uint16 level = (uint16)c[0] + (uint16)c[1] + (uint16)c[2];
+                if (level > data.transparentBlackLevel) {
+                    result[newIndex] = c;
+                }
+            } else {
+                result[newIndex] = c;
+            }
+        }
+    }
+}

--- a/samples/ISPC/program_city.ispc
+++ b/samples/ISPC/program_city.ispc
@@ -1,0 +1,182 @@
+// https://www.shadertoy.com/view/XlsyWB
+
+const float streetDistance = 0.6;
+const vec3 streetColor = { 4.0, 8.0, 10.0 };
+
+const float fogDensity = 0.5;
+const float fogDistance = 4.0;
+const vec3 fogColor = { 0.34, 0.37, 0.4 };
+
+const float windowSize = 0.1;
+const float windowDivergence = 0.2;
+const vec3 windowColor = { 0.1, 0.2, 0.5 };
+
+const float beaconProb = 0.0003;
+const float beaconFreq = 0.6;
+const vec3 beaconColor = { 1.5, 0.2, 0.0 };
+
+
+const float tau = 6.283185;
+
+float hash1(vec2 p2) {
+    p2 = fract(p2 * vec2(5.3983, 5.4427));
+    p2 += dot(p2.yx, p2.xy + vec2(21.5351, 14.3137));
+    return fract(p2.x * p2.y * 95.4337);
+}
+
+float hash1(vec2 p2, float p) {
+    vec3 p3 = fract(vec3(5.3983 * p2.x, 5.4427 * p2.y, 6.9371 * p));
+    p3 += dot(p3, p3.yzx + 19.19);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+vec2 hash2(vec2 p2) {
+    vec3 p3 = fract(vec3(5.3983 * p2.x, 5.4427 * p2.y, 6.9371 * p2.x));
+    p3 += dot(p3, p3.yzx + 19.19);
+    return fract((p3.xx + p3.yz) * p3.zy);
+}
+
+vec2 hash2(vec2 p2, float p) {
+    vec3 p3 = fract(vec3(5.3983 * p2.x, 5.4427 * p2.y, 6.9371 * p));
+    p3 += dot(p3, p3.yzx + 19.19);
+    return fract((p3.xx + p3.yz) * p3.zy);
+}
+
+vec3 hash3(vec2 p2) {
+    vec3 p3 = fract(vec3(p2.xyx) * vec3(5.3983, 5.4427, 6.9371));
+    p3 += dot(p3, p3.yxz + 19.19);
+    return fract((p3.xxy + p3.yzz) * p3.zyx);
+}
+
+float noise1(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    vec2 u = f * f * (3.0 - 2.0 * f);
+    return mix(mix(hash1(i + vec2(0.0, 0.0)), 
+                   hash1(i + vec2(1.0, 0.0)), u.x),
+               mix(hash1(i + vec2(0.0, 1.0)), 
+                   hash1(i + vec2(1.0, 1.0)), u.x), u.y);
+}
+
+vec4 castRay(vec3 eye, vec3 ray) {
+    vec2 block = floor(eye.xy);
+    vec3 ri = 1.0 / ray;
+    vec3 rs = sign(ray);
+    vec3 side = 0.5 + 0.5 * rs;
+    vec2 ris = ri.xy * rs.xy;
+    vec2 dis = (block - eye.xy + 0.5 + rs.xy * 0.5) * ri.xy;
+    
+    float beacon = 0.0;
+    
+    for (int i = 0; i < 200; ++i) {
+        vec2 lo0 = vec2(block + 0.01);
+        vec2 loX = vec2(0.3, 0.3);
+        vec2 hi0 = vec2(block + 0.69);
+        vec2 hiX = vec2(0.3, 0.3);
+        float height = (0.5 + hash1(block)) * (2.0 + 4.0 * pow(noise1(0.1 * block), 2.5));
+        
+        float dist = 500.0;
+        float face = 0.0;
+        for (int j = 0; j < 3; ++j) {
+            float top = height * (1.0 - 0.1 * float(j));
+            vec3 lo = vec3(lo0 + loX * hash2(block, float(j)), 0.0);
+            vec3 hi = vec3(hi0 + hiX * hash2(block, float(j) + 0.5), top);
+
+            vec3 wall = mix(hi, lo, side);
+            vec3 t = (wall - eye) * ri;
+
+            vec3 dim = step(t.zxy, t) * step(t.yzx, t);            
+            float maxT = dot(dim, t);
+            float maxFace = 1.0 - dim.z;
+            
+            vec3 p = eye + maxT * ray;
+            dim += step(lo, p) * step(p, hi);
+            if (dim.x * dim.y * dim.z > 0.5 && maxT < dist) {
+                dist = maxT;
+                face = maxFace;
+            }
+        }
+        
+        float prob = beaconProb * pow(height, 3.0);
+        vec2 h = hash2(block);
+        if (h.x < prob) {
+            vec3 center = vec3(block + 0.5, height + 0.2);
+            float t = dot(center - eye, ray);
+            if (t < dist) {
+                vec3 p = eye + t * ray;
+                float fog = (exp(-p.z / fogDistance) - exp(-eye.z / fogDistance)) / ray.z;
+                fog = exp(fogDensity * fog);
+
+                t = distance(center, p);
+                fog *= smoothstep(1.0, 0.5, cos(tau * (beaconFreq * iTime + h.y)));
+                beacon += fog * pow(clamp(1.0 - 2.0 * t, 0.0, 1.0), 4.0);
+            }
+        }
+        
+        if (dist < 400.0) {
+            return vec4(dist, beacon, face, 1.0);
+        }
+
+        float t = eye.z * ri.z;
+        vec3 p = eye - t * ray;
+        vec2 g = p.xy - block;
+        if (g.x > 0.0 && g.x < 1.0 && g.y > 0.0 && g.y < 1.0) {
+            return vec4(-t, beacon, 0.0, 1.0);
+        }
+        
+        vec2 dim = step(dis.xy, dis.yx); 
+        dis += dim * ris;
+        block += dim * rs.xy;
+    }
+    
+    if (ray.z < 0.0) {
+        return vec4(-eye.z * ri.z, beacon, 0.0, 1.0);
+    }
+
+    return vec4(0.0, beacon, 0.0, 0.0);
+}
+
+inline void mainImage(vec4& fragColor, vec2 fragCoord)
+{
+    vec2 m = vec2(0.03 * iTime, 0.8);
+    if (iMouse.z > 0.0)
+        m = iMouse.xy / iResolution.xy;
+    m *= tau * vec2(1.0, 0.25);
+    
+    vec3 center = vec3(6.0 * iTime, 0.5, 3.0);
+    float dist = 20.0;
+    vec3 eye = center + vec3(dist * sin(m.x) * sin(m.y), dist * cos(m.x) * sin(m.y), dist * cos(m.y));
+    float zoom = 3.0;
+    
+    vec3 forward = normalize(center - eye);
+    vec3 right = normalize(cross(forward, vec3(0.0, 0.0, 1.0)));
+    vec3 up = cross(right, forward);
+    vec2 xy = 2.0 * fragCoord - iResolution.xy;
+    zoom *= iResolution.y;
+    vec3 ray = normalize(xy.x * right + xy.y * up + zoom * forward);
+    
+    vec4 res = castRay(eye, ray);
+    vec3 p = eye + res.x * ray;
+
+    vec2 block = floor(p.xy);
+    vec3 window = floor(p / windowSize);
+    float x = hash1(block, window.x);
+    float y = hash1(block, window.y);
+    float z = hash1(block, window.z);
+    vec3 color = windowColor + windowDivergence * (hash3(block) - 0.5);
+    color *= smoothstep(0.1, 0.9, fract(2.5 * (x * y * z)));
+
+    vec3 streetLevel = streetColor * exp(-p.z / streetDistance);
+    color += streetLevel;
+    color = clamp(mix(0.25 * streetLevel, color, res.z), 0.0, 1.0);
+
+    float fog = (exp(-p.z / fogDistance) - exp(-eye.z / fogDistance)) / ray.z;
+    fog = exp(fogDensity * fog);
+    color = mix(fogColor, color, fog);
+    
+    color = mix(fogColor, color, res.w);
+    color += res.y * beaconColor;
+    color += pow(res.y, 2.0);
+
+    fragColor = vec4(color, 1.0);
+}

--- a/samples/ISPC/volume.ispc
+++ b/samples/ISPC/volume.ispc
@@ -1,0 +1,316 @@
+/*
+  Copyright (c) 2011-2023, Intel Corporation
+
+  SPDX-License-Identifier: BSD-3-Clause
+*/
+
+typedef float<3> float3;
+
+struct Ray {
+    float3 origin, dir;
+};
+
+
+static void
+generateRay(const uniform float raster2camera[4][4],
+            const uniform float camera2world[4][4],
+            float x, float y, Ray &ray) {
+    // transform raster coordinate (x, y, 0) to camera space
+    float camx = raster2camera[0][0] * x + raster2camera[0][1] * y + raster2camera[0][3];
+    float camy = raster2camera[1][0] * x + raster2camera[1][1] * y + raster2camera[1][3];
+    float camz = raster2camera[2][3];
+    float camw = raster2camera[3][3];
+    camx /= camw;
+    camy /= camw;
+    camz /= camw;
+
+    ray.dir.x = camera2world[0][0] * camx + camera2world[0][1] * camy + camera2world[0][2] * camz;
+    ray.dir.y = camera2world[1][0] * camx + camera2world[1][1] * camy + camera2world[1][2] * camz;
+    ray.dir.z = camera2world[2][0] * camx + camera2world[2][1] * camy + camera2world[2][2] * camz;
+
+    ray.origin.x = camera2world[0][3] / camera2world[3][3];
+    ray.origin.y = camera2world[1][3] / camera2world[3][3];
+    ray.origin.z = camera2world[2][3] / camera2world[3][3];
+}
+
+
+static inline bool
+Inside(float3 p, float3 pMin, float3 pMax) {
+    return (p.x >= pMin.x && p.x <= pMax.x &&
+            p.y >= pMin.y && p.y <= pMax.y &&
+            p.z >= pMin.z && p.z <= pMax.z);
+}
+
+
+static bool
+IntersectP(Ray ray, float3 pMin, float3 pMax, float &hit0, float &hit1) {
+    float t0 = -1e30, t1 = 1e30;
+
+    float3 tNear = (pMin - ray.origin) / ray.dir;
+    float3 tFar  = (pMax - ray.origin) / ray.dir;
+    if (tNear.x > tFar.x) {
+        float tmp = tNear.x;
+        tNear.x = tFar.x;
+        tFar.x = tmp;
+    }
+    t0 = max(tNear.x, t0);
+    t1 = min(tFar.x, t1);
+
+    if (tNear.y > tFar.y) {
+        float tmp = tNear.y;
+        tNear.y = tFar.y;
+        tFar.y = tmp;
+    }
+    t0 = max(tNear.y, t0);
+    t1 = min(tFar.y, t1);
+
+    if (tNear.z > tFar.z) {
+        float tmp = tNear.z;
+        tNear.z = tFar.z;
+        tFar.z = tmp;
+    }
+    t0 = max(tNear.z, t0);
+    t1 = min(tFar.z, t1);
+
+    if (t0 <= t1) {
+        hit0 = t0;
+        hit1 = t1;
+        return true;
+    }
+    else
+        return false;
+}
+
+
+static inline float Lerp(float t, float a, float b) {
+    return (1.f - t) * a + t * b;
+}
+
+
+static inline float D(int x, int y, int z, uniform int nVoxels[3],
+                      uniform float density[]) {
+    x = clamp(x, 0, nVoxels[0]-1);
+    y = clamp(y, 0, nVoxels[1]-1);
+    z = clamp(z, 0, nVoxels[2]-1);
+
+    #pragma ignore warning(perf)
+    return density[z*nVoxels[0]*nVoxels[1] + y*nVoxels[0] + x];
+}
+
+
+static inline float3 Offset(float3 p, float3 pMin, float3 pMax) {
+    return (p - pMin) / (pMax - pMin);
+}
+
+
+static float Density(float3 Pobj, float3 pMin, float3 pMax,
+                     uniform float density[], uniform int nVoxels[3]) {
+    if (!Inside(Pobj, pMin, pMax))
+        return 0;
+    // Compute voxel coordinates and offsets for _Pobj_
+    float3 vox = Offset(Pobj, pMin, pMax);
+    vox.x = vox.x * nVoxels[0] - .5f;
+    vox.y = vox.y * nVoxels[1] - .5f;
+    vox.z = vox.z * nVoxels[2] - .5f;
+    int vx = (int)(vox.x), vy = (int)(vox.y), vz = (int)(vox.z);
+    float dx = vox.x - vx, dy = vox.y - vy, dz = vox.z - vz;
+
+    // Trilinearly interpolate density values to compute local density
+    float d00 = Lerp(dx, D(vx, vy, vz, nVoxels, density),
+                     D(vx+1, vy, vz, nVoxels, density));
+    float d10 = Lerp(dx, D(vx, vy+1, vz, nVoxels, density),
+                     D(vx+1, vy+1, vz, nVoxels, density));
+    float d01 = Lerp(dx, D(vx, vy, vz+1, nVoxels, density),
+                     D(vx+1, vy, vz+1, nVoxels, density));
+    float d11 = Lerp(dx, D(vx, vy+1, vz+1, nVoxels, density),
+                     D(vx+1, vy+1, vz+1, nVoxels, density));
+    float d0 = Lerp(dy, d00, d10);
+    float d1 = Lerp(dy, d01, d11);
+    return Lerp(dz, d0, d1);
+}
+
+
+/* Returns the transmittance between two points p0 and p1, in a volume
+   with extent (pMin,pMax) with transmittance coefficient sigma_t,
+   defined by nVoxels[3] voxels in each dimension in the given density
+   array. */
+static float
+transmittance(uniform float3 p0, float3 p1, uniform float3 pMin,
+              uniform float3 pMax, uniform float sigma_t,
+              uniform float density[], uniform int nVoxels[3]) {
+    float rayT0, rayT1;
+    Ray ray;
+    ray.origin = p1;
+    ray.dir = p0 - p1;
+
+    // Find the parametric t range along the ray that is inside the volume.
+    if (!IntersectP(ray, pMin, pMax, rayT0, rayT1))
+        return 1.;
+
+    rayT0 = max(rayT0, 0.f);
+
+    // Accumulate beam transmittance in tau
+    float tau = 0;
+    float rayLength = sqrt(ray.dir.x * ray.dir.x + ray.dir.y * ray.dir.y +
+                           ray.dir.z * ray.dir.z);
+    uniform float stepDist = 0.2;
+    float stepT = stepDist / rayLength;
+
+    float t = rayT0;
+    float3 pos = ray.origin + ray.dir * rayT0;
+    float3 dirStep = ray.dir * stepT;
+    while (t < rayT1) {
+        tau += stepDist * sigma_t * Density(pos, pMin, pMax, density, nVoxels);
+        pos = pos + dirStep;
+        t += stepT;
+    }
+
+    return exp(-tau);
+}
+
+
+static inline float
+distanceSquared(float3 a, float3 b) {
+    float3 d = a-b;
+    return d.x*d.x + d.y*d.y + d.z*d.z;
+}
+
+
+static float
+raymarch(uniform float density[], uniform int nVoxels[3], Ray ray) {
+    float rayT0, rayT1;
+    uniform float3 pMin = {.3, -.2, .3}, pMax = {1.8, 2.3, 1.8};
+    uniform float3 lightPos = { -1, 4, 1.5 };
+
+    cif (!IntersectP(ray, pMin, pMax, rayT0, rayT1))
+        return 0.;
+
+    rayT0 = max(rayT0, 0.f);
+
+    // Parameters that define the volume scattering characteristics and
+    // sampling rate for raymarching
+    uniform float Le = .25;            // Emission coefficient
+    uniform float sigma_a = 10;        // Absorption coefficient
+    uniform float sigma_s = 10;        // Scattering coefficient
+    uniform float stepDist = 0.025;    // Ray step amount
+    uniform float lightIntensity = 40; // Light source intensity
+
+    float tau = 0.f;  // accumulated beam transmittance
+    float L = 0;      // radiance along the ray
+    float rayLength = sqrt(ray.dir.x * ray.dir.x + ray.dir.y * ray.dir.y +
+                           ray.dir.z * ray.dir.z);
+    float stepT = stepDist / rayLength;
+
+    float t = rayT0;
+    float3 pos = ray.origin + ray.dir * rayT0;
+    float3 dirStep = ray.dir * stepT;
+    cwhile (t < rayT1) {
+        float d = Density(pos, pMin, pMax, density, nVoxels);
+
+        // terminate once attenuation is high
+        float atten = exp(-tau);
+        if (atten < .005)
+            break;
+
+        // direct lighting
+        float Li = lightIntensity / distanceSquared(lightPos, pos) *
+            transmittance(lightPos, pos, pMin, pMax, sigma_a + sigma_s,
+                          density, nVoxels);
+        L += stepDist * atten * d * sigma_s * (Li + Le);
+
+        // update beam transmittance
+        tau += stepDist * (sigma_a + sigma_s) * d;
+
+        pos = pos + dirStep;
+        t += stepT;
+    }
+
+    // Gamma correction
+    return pow(L, 1.f / 2.2f);
+}
+
+
+/* Utility routine used by both the task-based and the single-core entrypoints.
+   Renders a tile of the image, covering [x0,x0) * [y0, y1), storing the
+   result into the image[] array.
+ */
+static void
+volume_tile(uniform int x0, uniform int y0, uniform int x1,
+            uniform int y1, uniform float density[], uniform int nVoxels[3],
+            const uniform float raster2camera[4][4],
+            const uniform float camera2world[4][4],
+            uniform int width, uniform int height, uniform float image[]) {
+    // Work on 4x4=16 pixel big tiles of the image.  This function thus
+    // implicitly assumes that both (x1-x0) and (y1-y0) are evenly divisble
+    // by 4.
+    for (uniform int y = y0; y < y1; y += 4) {
+        for (uniform int x = x0; x < x1; x += 4) {
+            foreach (o = 0 ... 16) {
+                // These two arrays encode the mapping from [0,15] to
+                // offsets within the 4x4 pixel block so that we render
+                // each pixel inside the block
+                const uniform int xoffsets[16] = { 0, 1, 0, 1, 2, 3, 2, 3,
+                                                   0, 1, 0, 1, 2, 3, 2, 3 };
+                const uniform int yoffsets[16] = { 0, 0, 1, 1, 0, 0, 1, 1,
+                                                   2, 2, 3, 3, 2, 2, 3, 3 };
+
+                // Figure out the pixel to render for this program instance
+                int xo = x + xoffsets[o], yo = y + yoffsets[o];
+
+                // Use viewing parameters to compute the corresponding ray
+                // for the pixel
+                Ray ray;
+                generateRay(raster2camera, camera2world, xo, yo, ray);
+
+                // And raymarch through the volume to compute the pixel's
+                // value
+                int offset = yo * width + xo;
+                #pragma ignore warning(perf)
+                image[offset] = raymarch(density, nVoxels, ray);
+            }
+        }
+    }
+}
+
+
+task void
+volume_task(uniform float density[], uniform int nVoxels[3],
+            const uniform float raster2camera[4][4],
+            const uniform float camera2world[4][4],
+            uniform int width, uniform int height, uniform float image[]) {
+    uniform int dx = 8, dy = 8; // must match value in volume_ispc_tasks
+    uniform int xbuckets = (width + (dx-1)) / dx;
+    uniform int ybuckets = (height + (dy-1)) / dy;
+
+    uniform int x0 = (taskIndex % xbuckets) * dx;
+    uniform int y0 = (taskIndex / xbuckets) * dy;
+    uniform int x1 = x0 + dx, y1 = y0 + dy;
+    x1 = min(x1, width);
+    y1 = min(y1, height);
+
+    volume_tile(x0, y0, x1, y1, density, nVoxels, raster2camera,
+                 camera2world, width, height, image);
+}
+
+
+export void
+volume_ispc(uniform float density[], uniform int nVoxels[3],
+            const uniform float raster2camera[4][4],
+            const uniform float camera2world[4][4],
+            uniform int width, uniform int height, uniform float image[]) {
+    volume_tile(0, 0, width, height, density, nVoxels, raster2camera,
+                camera2world, width, height,  image);
+}
+
+
+export void
+volume_ispc_tasks(uniform float density[], uniform int nVoxels[3],
+                  const uniform float raster2camera[4][4],
+                  const uniform float camera2world[4][4],
+                  uniform int width, uniform int height, uniform float image[]) {
+    // Launch tasks to work on (dx,dy)-sized tiles of the image
+    uniform int dx = 8, dy = 8;
+    uniform int nTasks = ((width+(dx-1))/dx) * ((height+(dy-1))/dy);
+    launch[nTasks] volume_task(density, nVoxels, raster2camera, camera2world,
+                               width, height, image);
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -259,6 +259,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **IDL:** [mgalloy/idl.tmbundle](https://github.com/mgalloy/idl.tmbundle)
 - **IGOR Pro:** [byte-physics/language-igor](https://github.com/byte-physics/language-igor)
 - **INI:** [textmate/ini.tmbundle](https://github.com/textmate/ini.tmbundle)
+- **ISPC:** [ispc/ispc.syntax](https://github.com/ispc/ispc.syntax)
 - **Idris:** [idris-hackers/idris-sublime](https://github.com/idris-hackers/idris-sublime)
 - **Ignore List:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **Imba:** [imba/imba-linguist-grammar](https://github.com/imba/imba-linguist-grammar)

--- a/vendor/licenses/git_submodule/ispc.syntax.dep.yml
+++ b/vendor/licenses/git_submodule/ispc.syntax.dep.yml
@@ -1,0 +1,42 @@
+---
+name: ispc.syntax
+version: 399977add2be5381f85fe725b3034a57a2538296
+type: git_submodule
+homepage: https://github.com/ispc/ispc.syntax.git
+license: bsd-3-clause
+licenses:
+- sources: LICENSE
+  text: |-
+    Copyright Intel Corporation
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+
+        * Redistributions in binary form must reproduce the above copyright
+          notice, this list of conditions and the following disclaimer in the
+          documentation and/or other materials provided with the distribution.
+
+        * Neither the name of Intel Corporation nor the names of its
+          contributors may be used to endorse or promote products derived from
+          this software without specific prior written permission.
+
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+notices:
+- sources: NOTICE.md
+  text: These contents may have been developed with support from one or more Intel-operated
+    generative artificial intelligence solutions.


### PR DESCRIPTION
Adds the ISPC language, full name "Intel® Implicit SPMD Program Compiler" https://github.com/ispc/ispc, extension `.ispc`, along with its header files `.isph`.
ISPC is a C-based language with extensions for SIMD programming.
ISPC is used across different game engines (e.g. Unreal Engine, Unity), production renderers (e.g Dreamworks' MoonRay) and ray tracing libraries (e.g. Intel(R) Ospray)

Closes https://github.com/github-linguist/linguist/issues/5042

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.ispc - 8.7k
      -  ~~https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.isph - 644~~
  - [x] I have included a real-world usage sample for all extensions added in this PR:
         - [samples/ISPC/VideoFunctions.ispc](https://github.com/xLightsSequencer/xLights/blob/master/xLights/effects/ispc/VideoFunctions.ispc), [GPL-3](https://github.com/xLightsSequencer/xLights?tab=GPL-3.0-1-ov-file)
         - [samples/ISPC/volume.ispc](https://github.com/ispc/ispc/blob/main/examples/cpu/volume_rendering/volume.ispc), [BSD3C](https://github.com/ispc/ispc?tab=BSD-3-Clause-1-ov-file)
         - [samples/ISPC/program_city.ispc](https://github.com/re-esper/CPUShadertoy/blob/master/program_city.ispc), [MIT](https://github.com/re-esper/CPUShadertoy?tab=MIT-1-ov-file)

  - [x] I have included a syntax highlighting grammar: [[ispc.syntax]](https://github.com/ispc/ispc.syntax)
  - [x] I have added a color
    - Hex value: `#2D68B1`
    - Rationale: it is used in a header on official website: https://ispc.github.io/ispc.html
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension. N/A. There are no languages with the same extension.

