### PR TITLE
Add linker script grammar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1464,3 +1464,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/Linker.tmLanguage"]
+	path = vendor/grammars/Linker.tmLanguage
+	url = https://github.com/donno2048/Linker.tmLanguage

--- a/.gitmodules
+++ b/.gitmodules
@@ -67,6 +67,9 @@
 [submodule "vendor/grammars/Ligo-grammar"]
 	path = vendor/grammars/Ligo-grammar
 	url = https://github.com/pewulfman/Ligo-grammar.git
+[submodule "vendor/grammars/Linker.tmLanguage"]
+	path = vendor/grammars/Linker.tmLanguage
+	url = https://github.com/donno2048/Linker.tmLanguage
 [submodule "vendor/grammars/LiveScript.tmbundle"]
 	path = vendor/grammars/LiveScript.tmbundle
 	url = https://github.com/paulmillr/LiveScript.tmbundle
@@ -1464,6 +1467,3 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
-[submodule "vendor/grammars/Linker.tmLanguage"]
-	path = vendor/grammars/Linker.tmLanguage
-	url = https://github.com/donno2048/Linker.tmLanguage

--- a/grammars.yml
+++ b/grammars.yml
@@ -55,6 +55,8 @@ vendor/grammars/Ligo-grammar:
 - source.ligo
 - source.mligo
 - source.religo
+vendor/grammars/Linker.tmLanguage:
+- source.c.linker
 vendor/grammars/LiveScript.tmbundle:
 - source.livescript
 vendor/grammars/Luau.tmLanguage:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3953,14 +3953,14 @@ Linear Programming:
   ace_mode: text
   language_id: 377204539
 Linker Script:
-  type: data
+  type: programming
   extensions:
   - ".ld"
   - ".lds"
   - ".x"
   filenames:
   - ld.script
-  tm_scope: none
+  tm_scope: source.c.linker
   ace_mode: text
   language_id: 202
 Linux Kernel Module:

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -323,6 +323,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Lex:** [Alhadis/language-grammars](https://github.com/Alhadis/language-grammars)
 - **LigoLANG:** [pewulfman/Ligo-grammar](https://github.com/pewulfman/Ligo-grammar)
 - **LilyPond:** [nwhetsell/linter-lilypond](https://github.com/nwhetsell/linter-lilypond)
+- **Linker Script:** [donno2048/Linker.tmLanguage](https://github.com/donno2048/Linker.tmLanguage)
 - **Liquid:** [Shopify/liquid-tm-grammar](https://github.com/Shopify/liquid-tm-grammar)
 - **Literate CoffeeScript:** [atom/language-coffee-script](https://github.com/atom/language-coffee-script)
 - **Literate Haskell:** [atom-haskell/language-haskell](https://github.com/atom-haskell/language-haskell)

--- a/vendor/licenses/git_submodule/Linker.tmLanguage.dep.yml
+++ b/vendor/licenses/git_submodule/Linker.tmLanguage.dep.yml
@@ -1,0 +1,31 @@
+---
+name: Linker.tmLanguage
+version: 9c1b6b8320c21dda0e65aa8bac117d17df34aa16
+type: git_submodule
+homepage: https://github.com/donno2048/Linker.tmLanguage
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+    
+    Copyright (c) 2025 Elisha Hollander
+    
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
I've noticed there's no linker script grammar so I made one.

## Description

Add new linker script grammar

## Checklist:


- [x] **I am changing the source of a syntax highlighting grammar**
  - Old: NONE
  - New: https://github.com/donno2048/Linker.tmLanguage
