### PR TITLE
Use proper JSONC grammar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1347,6 +1347,9 @@
 [submodule "vendor/grammars/vscode-jest"]
 	path = vendor/grammars/vscode-jest
 	url = https://github.com/jest-community/vscode-jest
+[submodule "vendor/grammars/vscode-jsonc-syntax-highlighting"]
+	path = vendor/grammars/vscode-jsonc-syntax-highlighting
+	url = https://github.com/DecimalTurn/vscode-jsonc-syntax-highlighting.git
 [submodule "vendor/grammars/vscode-just"]
 	path = vendor/grammars/vscode-just
 	url = https://github.com/nefrob/vscode-just.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1206,6 +1206,8 @@ vendor/grammars/vscode-janet:
 - source.janet
 vendor/grammars/vscode-jest:
 - source.jest.snap
+vendor/grammars/vscode-jsonc-syntax-highlighting:
+- source.json.comments
 vendor/grammars/vscode-just:
 - source.just
 vendor/grammars/vscode-kdl:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3328,7 +3328,7 @@ JSON with Comments:
   type: data
   color: "#292929"
   group: JSON
-  tm_scope: source.js
+  tm_scope: source.json.comments
   ace_mode: javascript
   codemirror_mode: javascript
   codemirror_mime_type: text/javascript

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -274,7 +274,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **JCL:** [spgennard/vscode_cobol](https://github.com/spgennard/vscode_cobol)
 - **JFlex:** [jflex-de/jflex.tmbundle](https://github.com/jflex-de/jflex.tmbundle)
 - **JSON:** [Nixinova/NovaGrammars](https://github.com/Nixinova/NovaGrammars)
-- **JSON with Comments:** [atom/language-javascript](https://github.com/atom/language-javascript)
+- **JSON with Comments:** [DecimalTurn/vscode-jsonc-syntax-highlighting](https://github.com/DecimalTurn/vscode-jsonc-syntax-highlighting)
 - **JSON5:** [atom/language-javascript](https://github.com/atom/language-javascript)
 - **JSONLD:** [atom/language-javascript](https://github.com/atom/language-javascript)
 - **JSONiq:** [wcandillon/language-jsoniq](https://github.com/wcandillon/language-jsoniq)

--- a/vendor/licenses/git_submodule/vscode-jsonc-syntax-highlighting.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-jsonc-syntax-highlighting.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: vscode-jsonc-syntax-highlighting
-version: 548eaefd23585e1a58bede7544d25e293511aea2
+version: b3a09c98467d73620b3e92d08d1d1eec3146f6bf
 type: git_submodule
 homepage: https://github.com/DecimalTurn/vscode-jsonc-syntax-highlighting.git
 license: mit
@@ -9,7 +9,8 @@ licenses:
   text: |
     MIT License
 
-    Copyright (c) 2015 - present Microsoft Corporation
+    Copyright (c) 2015 - present Microsoft Corporation for JSONC.tmLanguage.json
+    Copyright (c) 2025 - present DecimalTurn for everything else
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/vendor/licenses/git_submodule/vscode-jsonc-syntax-highlighting.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-jsonc-syntax-highlighting.dep.yml
@@ -1,0 +1,31 @@
+---
+name: vscode-jsonc-syntax-highlighting
+version: 548eaefd23585e1a58bede7544d25e293511aea2
+type: git_submodule
+homepage: https://github.com/DecimalTurn/vscode-jsonc-syntax-highlighting.git
+license: mit
+licenses:
+- sources: LICENSE.txt
+  text: |
+    MIT License
+
+    Copyright (c) 2015 - present Microsoft Corporation
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

At the moment, the Javascript grammar is used for JSONC (JSON with comments). This is not ideal since it makes the keys have the same highlighting as strings making it less pleasant to read:

![image](https://github.com/user-attachments/assets/7453f626-1c8c-4c10-8657-5e05054c30c5)

Looking at the official grammar used by VS Code, we get a nicer experience:

![image](https://github.com/user-attachments/assets/52be9713-15ee-4941-a2f7-99b977541d5d)

This PR changes the grammar to use the official VS Code grammar for JSONC. However, to avoid adding the whole VS Code repos as a submodule, I've used a "mirror" repo that remains synced with the official version.

## Checklist:

- [x] **I am changing the source of a syntax highlighting grammar**
  - Old: https://github.com/atom/language-javascript
  - New: https://github.com/DecimalTurn/vscode-jsonc-syntax-highlighting
