### PR TITLE
Remove possessive qualifier for NASL

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -388,7 +388,7 @@ disambiguations:
   - language: NASL
     pattern:
     - '^\s*include\s*\(\s*(?:"|'')[\\/\w\-\.:\s]+\.(?:nasl|inc)\s*(?:"|'')\s*\)\s*;'
-    - '^\s*(?:global|local)_var\s+(?:\w+(?:\s*=\s*[\w\-"'']+)?\s*)(?:,\s*\w+(?:\s*=\s*[\w\-"'']+)?\s*)*+\s*;'
+    - '^\s*(?:global|local)_var\s+(?:\w+(?:\s*=\s*[\w\-"'']+)?\s*)(?:,\s*\w+(?:\s*=\s*[\w\-"'']+)?\s*)*\s*;'
     - '^\s*namespace\s+\w+\s*\{'
     - '^\s*object\s+\w+\s*(?:extends\s+\w+(?:::\w+)?)?\s*\{'
     - '^\s*(?:public\s+|private\s+|\s*)function\s+\w+\s*\([\w\s,]*\)\s*\{'


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

Similarly to https://github.com/github-linguist/linguist/pull/7240, this PR removes an instance of a possessive qualifier. Possessive qualifiers aren't supported in re2, hence this PR increases portability of Linguist's heuristics.

Removing this from the NASL heuristic could theoretically reduce performance, but due to the fact that the possessive qualifier is close to the end of the regex and that the structure of the regex prevents multple branching while backtracking, this change should be unnoticable in practice.

Note that with this PR and https://github.com/github-linguist/linguist/pull/7242, Linguist's heuristics should now be fully compatible with RE2's syntax except for `Vim Help File`, `Hosts File` and `Adblock Filter List`. 🎉

## Checklist:
NA