### PR TITLE
Fix Assembly heuristics to remove char class duplication 

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -368,7 +368,7 @@ disambiguations:
   - language: Assembly
     pattern:
     - '(?i)mov\s+[^\s]+,'
-    - '^\s+(i?)db\s+[\d\w]'
+    - '^\s+(i?)db\s+[a-z\d]'
 - extensions: ['.ice']
   rules:
   - language: JSON
@@ -403,7 +403,7 @@ disambiguations:
   - language: Assembly
     pattern:
     - '^(?i)[^"m]*mov\s+[^\s]+,'
-    - '^\s+(?i)db\s+[\d\w]'
+    - '^\s+(?i)db\s+[a-z\d]'
 - extensions: ['.json']
   rules:
   - language: OASv2-json


### PR DESCRIPTION
https://github.com/github-linguist/linguist/pull/7229 introduced changes to the Assembly heuristics that included character class duplication which were reported as warnings in CI but missed at the time:

```
/home/runner/work/linguist/linguist/lib/linguist/heuristics.rb:91: warning: character class has duplicated range: /^\s+(i?)db\s+[\d\w]/
/home/runner/work/linguist/linguist/lib/linguist/heuristics.rb:91: warning: character class has duplicated range: /(?i-mx:mov\s+[^\s]+,)|(?-mix:^\s+(i?)db\s+[\d\w])/
/home/runner/work/linguist/linguist/lib/linguist/heuristics.rb:91: warning: character class has duplicated range: /^\s+(?i)db\s+[\d\w]/
/home/runner/work/linguist/linguist/lib/linguist/heuristics.rb:91: warning: character class has duplicated range
/home/runner/work/linguist/linguist/lib/linguist/heuristics.rb:129: warning: character class has duplicated range
```

For future reference, @donno2048, useful PR bodies like this are preferred over simple pings as context is needed for reviewing by those unfamiliar at the time or who question the change in future.