### PR TITLE
Update search example link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,6 +241,6 @@ As Linguist is a production dependency for GitHub we have a couple of workflow r
 [languages]: /lib/linguist/languages.yml
 [licenses]: https://github.com/github/linguist/blob/9b1023ed5d308cb3363a882531dea1e272b59977/vendor/licenses/config.yml#L4-L15
 [samples]: /samples
-[search-example]: https://github.com/search?utf8=%E2%9C%93&q=extension%3Aboot+NOT+nothack&type=Code&ref=searchresults
+[search-example]: https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.boot
 [#5756]: https://github.com/github/linguist/issues/5756
 [merged-pr]: /docs/troubleshooting.md#my-linguist-pr-has-been-merged-but-gitHub-doesnt-reflect-my-changes


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
The documented search example syntax (`extension:<ext>`[^1]) is legacy and should be updated to the currently available one (`path:*.<ext>`[^2]).

[^1]: https://docs.github.com/en/search-github/searching-on-github/searching-code#search-by-file-extension
[^2]: https://docs.github.com/en/search-github/github-code-search/understanding-github-code-search-syntax#path-qualifier

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
N/A
