### PR TITLE
Add `Package.resolved` as a JSON filename

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3329,6 +3329,7 @@ JSON:
   - ".tern-project"
   - ".watchmanconfig"
   - MODULE.bazel.lock
+  - Package.resolved
   - Pipfile.lock
   - bun.lock
   - composer.lock

--- a/samples/JSON/filenames/Package.resolved
+++ b/samples/JSON/filenames/Package.resolved
@@ -1,0 +1,59 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-driver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-driver",
+      "state" : {
+        "branch" : "main",
+        "revision" : "c647e91574122f2b104d294ab1ec5baadaa1aa95"
+      }
+    },
+    {
+      "identity" : "swift-llbuild",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-llbuild.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "e4ea3d267974bf75e637ec65c0b753558b22a451"
+      }
+    },
+    {
+      "identity" : "swift-toolchain-sqlite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-toolchain-sqlite",
+      "state" : {
+        "revision" : "9cff1f87bf66f6642ba510d42da7a3bb10006bba",
+        "version" : "0.1.1"
+      }
+    },
+    {
+      "identity" : "swift-tools-support-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-tools-support-core.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "a76104dbd3c3fff41adb70bc7e917a4b2d076cef"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
+        "version" : "5.0.6"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
This adds support for the `Package.resolved` file.

> The `Package.resolved` file records the results of the dependency resolution and lives in the top-level directory of a Swift package.
> https://developer.apple.com/documentation/packagedescription/package/dependency

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=path%3APackage.resolved+NOT+is%3Afork+%22pins%22&type=code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/swiftlang/swift/blob/c7922b29af9e8e9924da19a5b2ca4416f9cd1705/utils/swift-xcodegen/Package.resolved
    - Sample license(s): Apache-2.0 license
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
