### PR TITLE
Add KiCAD symbols

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3764,6 +3764,7 @@ KiCad Schematic:
   - eeschema schematic
   extensions:
   - ".kicad_sch"
+  - ".kicad_sym"
   - ".sch"
   tm_scope: source.pcb.schematic
   ace_mode: text


### PR DESCRIPTION
Adds KiCAD symbols to the schematic language, the symbols are just mini schematics for one part.
Similiar how the footprint .kicad_mod files are listed as mini PCB layouts.

## Checklist:
- [X] **I am adding a new extension to a language.**
  - [X] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?q=kicad_symbol_editor&type=code
  - [X] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/espressif/kicad-libraries/blob/main/symbols/Espressif.kicad_sym
