### PR TITLE
Added SQL files to vendors

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -391,3 +391,6 @@
 
 # teamcity CI configuration
 - (^|/)\.teamcity/
+
+# SQL files
+- (^|/).*\.sql$

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -594,6 +594,9 @@ class TestFileBlob < Minitest::Test
     assert sample_blob(".teamcity/Project_Name_CI/Project.kt").vendored?
     assert sample_blob(".teamcity/Project_Name_CI/settings.kts").vendored?
     assert sample_blob(".teamcity/Project_Name_CI/patches/projects/3b71d400-c5d6-4628-8164-c50b1254cf1d.kts").vendored?
+
+    # SQL files
+    assert sample_blob("sample.sql").vendored?
   end
 
   def test_documentation


### PR DESCRIPTION
Added SQL files to vendors

## Description
`.sql` files may take up most of the Language stats, hiding the rest of the languages used.

![imagen](https://github.com/user-attachments/assets/e850783c-819e-4be1-8701-97ed884c7868)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am adding a new extension to a language.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.FOOBAR+KEYWORDS
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.FOOBAR+KEYWORDS
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a syntax highlighting grammar: [URL to grammar repo]
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [ ] I have added a color
    - Hex value: `#RRGGBB`
    - Rationale: <!-- Please specify why you chose this color (if it was randomly selected, please say so); it helps arbitrate future requests to change a language's color -->
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  - Old: [URL to grammar repo]
  - New: [URL to grammar repo]

- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.

- [ ] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [URL to public discussion]
    - [Optional: URL to official branding guidelines for the language]
