### PR TITLE
ci(docker-release): Build & push docker on release

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,72 @@
+name: Package
+on:
+  push:
+    tags:
+      - "*"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up tags & labels
+        run: |
+          GIT_TAG=$(git describe --tags --abbrev=0 | sed 's/^v//')
+          echo "Git tag: $GIT_TAG"
+          echo "GIT_TAG=$GIT_TAG" >> $GITHUB_ENV
+
+          if [[ "$GIT_TAG" == *"-"* ]]; then
+            echo "is pre-release"
+            echo "DOCKER_TAG=prerelease" >> $GITHUB_ENV
+          else
+            echo "is stable release"
+            echo "DOCKER_TAG=latest" >> $GITHUB_ENV
+          fi
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ env.DOCKER_TAG }}
+            ghcr.io/${{ github.repository }}:${{ env.GIT_TAG }}
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -184,7 +184,20 @@ grammars.yml: 884 lines (884 sloc)
 
 #### Docker
 
-If you have Docker installed you can build an image and run Linguist within a container:
+If you have Docker installed you can either build or use
+our pre-built images and run Linguist within a container:
+
+```console
+$ docker run --rm -v $(pwd):$(pwd):Z -w $(pwd) -t ghcr.io/github-linguist/linguist:latest
+66.84%  264519     Ruby
+24.68%  97685      C
+6.57%   25999      Go
+1.29%   5098       Lex
+0.32%   1257       Shell
+0.31%   1212       Dockerfile
+```
+
+##### Building the image
 
 ```console
 $ docker build -t linguist .


### PR DESCRIPTION
So I noticed that the instructions for running github-linguist as a docker image requires the end-user to build it locally. Thus for the sake of convenience, I made CI that runs against new tags and pushes to GitHub's `ghcr.io` docker repository. I have tested these changes on this fork of mine.

Tags:

- `buildcache` - for build caching (on the max setting)
- `latest` or `prerelease` - based on the release tag (should be fine as long as we stick to semver)
- `commit SHA`

I've also updated README to include pulling images down from `ghcr.io`.

Cheers,
-Alex Ng J. X.