### PR TITLE
Update licensed dependency version

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry', '~> 0.14'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'yajl-ruby', '~> 1.4'
-  s.add_development_dependency 'licensed', '~> 4.0'
+  s.add_development_dependency 'licensed', '~> 5.0'
   s.add_development_dependency 'licensee', '~> 9.15'
   s.add_development_dependency 'bundler', '~> 2.0'
 end


### PR DESCRIPTION
Updated the `licensed` gem dependency version to ~> 5.0 to pull in the fix for https://github.com/licensee/licensed/issues/752

Closes https://github.com/github-linguist/linguist/issues/7318.
