### PR TITLE
Add support for Sail

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1064,6 +1064,9 @@
 [submodule "vendor/grammars/rust-syntax"]
 	path = vendor/grammars/rust-syntax
 	url = https://github.com/dustypomerleau/rust-syntax.git
+[submodule "vendor/grammars/sail_vscode"]
+	path = vendor/grammars/sail_vscode
+	url = https://github.com/Timmmm/sail_vscode.git
 [submodule "vendor/grammars/sas.tmbundle"]
 	path = vendor/grammars/sas.tmbundle
 	url = https://github.com/rpardee/sas.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -969,6 +969,8 @@ vendor/grammars/ruby-slim.tmbundle:
 - text.slim
 vendor/grammars/rust-syntax:
 - source.rust
+vendor/grammars/sail_vscode:
+- source.sail
 vendor/grammars/sas.tmbundle:
 - source.sas
 vendor/grammars/scheme.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6732,6 +6732,14 @@ Sage:
   codemirror_mode: python
   codemirror_mime_type: text/x-python
   language_id: 338
+Sail:
+  type: programming
+  color: "#259dd5"
+  ace_mode: text
+  extensions:
+  - ".sail"
+  tm_scope: source.sail
+  language_id: 1029438153
 SaltStack:
   type: programming
   color: "#646464"

--- a/samples/Sail/basics.sail
+++ b/samples/Sail/basics.sail
@@ -1,0 +1,113 @@
+// This example introduces most basic features of Sail.
+/* Comments are C-style. /* Blocks comments can be nested. */ */
+
+// Sail supports configurable indexing endianness. Dec is the most common
+// option. It must be declared globally.
+default Order dec
+
+// C-style includes are supported. `prelude.sail` is from the Sail standard
+// library and includes some common things.
+$include <prelude.sail>
+
+// Global mutable variables are introduced with `register`.
+// They must include a type (int) and can include an initialiser (= 0).
+// `int` is the type for all integers (any size, like in Python).
+// Try changing this to 10000000000000000000000000000000000000000000000000.
+register my_global_int : int = 0
+
+// `nat` is the type for natural numbers (>= 0). Try changing the 3 to -3.
+register not_negative : nat = 3
+
+// There's also a `range(M, N)` type for integers in [M, N] (inclusive).
+// Try changing this to 0
+register month : range(1, 12) = 1
+
+// Immutable globals variables are declared with let.
+// Real numbers are supported, using libgmp (which represents them as
+// arbitrary length integer fractions). Although supported, they are very
+// rarely used in Sail code.
+let pi : real = 3.141
+
+// This is a simple function. Sail is expression-based like Rust, OCaml,
+// Haskell, etc. Braces are not required for function bodies if they are
+// a single expression.
+function add_ints(a : int, b : int) -> int = a + b
+
+// As usual in expression-based languages, if and match are also expressions.
+function max1(a : int, b : int) -> int = if a > b then a else b
+
+// You can use traditional imperative forms too but it isn't recommended.
+function max2(a : int, b : int) -> int = {
+    if a > b then {
+        return a;
+    } else {
+        return b;
+    }
+}
+
+// It has standard ML/Rust style `match`.
+function month_name(month : range(1, 12)) -> string =
+    match month {
+        1 => "Jan",
+        2 => "Feb",
+        // Alternate patterns are not yet supported.
+        // 3 | 4 => "March or April",
+        // _ is a wildcard.
+        _ => "Whatever",
+    }
+
+// You can define a `main()` function which will be compiled to `zmain()` in C.
+// The name mangling system for C is Z-encoding which basically double all
+// z's and prepends a z. E.g. size -> zsizze
+//
+// Main returns `unit` which is like a 0-length tuple. It's used in places you
+// might use `void` in C. Unlike `void` you can make a value of `unit` by writing
+// `()`.
+//
+// Sail will optionally generate a C `main()` function that calls `zmain()`
+// (this code).
+function main() -> unit = {
+    // The standard print function.
+    print_endline("Hello world");
+
+    // `let` introduces immutable variables.
+    let a : int = 5;
+    // They can be shadowed with the same name.
+    let a : string = "5";
+    // Type annotations are not always required - often they can be inferred.
+    let a = 5;
+    // Because they are immutable you cannot do this:
+    a = 6;
+
+    // Mutable variables use `var`.
+    var a : int = 5;
+    // This is now ok.
+    a = 6;
+
+    // One small gotcha is that the inferred type for 5 is int(5). So this
+    var a = 5;
+    // is equivalent to this
+    var a : int(5) = 5;
+    // And because its type is literally the number 5, you can't assign
+    // any other numbers to it.
+    // a = 6; // compile error
+}
+
+// Being aimed at ISA specifications, Sail has very good support for bit vectors.
+function reverse_endianness(word : bits(16)) -> bits(16) =
+    // @ means concatenation. Since we declared `default Order dec` all
+    // of these indices and concatenations happen in Little Endian notational
+    // order. This doesn't mean that the underlying data is Little Endian though.
+    //
+    // .. selects a bit range. This is inclusive. Currently there is no
+    // half-open syntax (8 >.. 0) but this is planned.
+    word[7 .. 0] @ word[15 .. 8]
+
+// Sail has an advanced type system for bit vectors and integers which means
+// they can almost always be checked at compile time.
+//
+// Try changing 7 to 8 here.
+function lowest_byte(word : bits(16)) -> bits(8) = word[7 .. 0]
+
+// Check the other examples for more features. Or see the Sail manual here:
+// https://alasdair.github.io/manual.html

--- a/samples/Sail/bitfields.sail
+++ b/samples/Sail/bitfields.sail
@@ -1,0 +1,35 @@
+default Order dec
+
+$include <prelude.sail>
+$include <vector.sail>
+
+// Bitfields are useful for registers. You can take an underlying bitvector
+// and allow naming bits in them.
+
+bitfield Status : bits(32) = {
+    U : 31,
+    // Not all bits need to have a corresponding field, and fields can overlap.
+    A : 0,
+    lowest_byte : 7 .. 0,
+    upper_byte : 31 .. 24,
+}
+
+function main() -> unit = {
+    // To create a new bitfield, use Mk_<name>.
+    var status = Mk_Status(0x00000000);
+
+    // You can update mutable variables (including `register`s) imperatively:
+    status[lowest_byte] = status[upper_byte];
+
+    // You can access the underlying bitvector via the special field `bits`.
+    status.bits = 0x11223344;
+
+    // You can also do functional-style immutable updates.
+    let status = [
+        status with
+        U = 0b1,
+        lowest_byte = 0xFF,
+    ];
+
+    print_endline(bits_str(status.bits));
+}

--- a/samples/Sail/bitvectors.sail
+++ b/samples/Sail/bitvectors.sail
@@ -1,0 +1,48 @@
+default Order dec
+
+$include <prelude.sail>
+$include <vector.sail>
+
+// Sail has excellent support for bit vectors. These have the type `bits(N)`.
+let status : bits(32) = 0x11223344
+
+// Bit vector literals are written 0x.. or 0b...
+// Leading zeros are significant - the affect the size of the literal.
+// This is ok:
+register byte0 : bits(8) = 0x01
+// This is an error:
+// register byte1 : bits(8) = 0x1
+
+function main() -> unit = {
+    // @ means concatenation. With 'default Order dec' concatenation is written
+    // in Big Endian order.
+    assert(0x12 @ 0x34 == 0x1234);
+
+    // Individual bits or ranges of bits can be accessed like this.
+    // Note that the range is inclusive.
+    assert(status[0] == bitzero);
+    assert(status[7 .. 0] == 0x44);
+
+    // You can update mutable bit vectors like this:
+    byte0[3 .. 0] = 0b1100;
+    // Or in immutable function style:
+    let byte2 = [
+        byte0 with
+        3 .. 0 = 0xA,
+    ];
+
+    // You can convert a bit vector to a string with `bits_str()`. If it is
+    // a multiple of 4 bits it will be printed in hex, otherwise binary.
+    print_endline(bits_str(byte2[2 .. 0]));
+
+    // Pattern matching also supports bit vectors.
+    match byte2 {
+        upper @ 0b010 => {
+            print_endline(bits_str(upper));
+        },
+        0b10 @ lower => {
+            print_endline(bits_str(lower));
+        },
+        _ => (),
+    };
+}

--- a/samples/Sail/match.sail
+++ b/samples/Sail/match.sail
@@ -1,0 +1,52 @@
+default Order dec
+
+$include <option.sail>
+$include <string.sail>
+
+// Sail has pattern matching similar to Rust, OCaml and other functional languages.
+// A notable difference is that it doesn't support combining identical branches.
+
+function suit_name(suit : range(0, 3)) -> string =
+    match suit {
+        0 => "hearts",
+        1 => "diamonds",
+        2 => "clubs",
+        3 => "spaces",
+    }
+
+// _ is a wildcard
+
+function map_add(a : option(int), b : option(int)) -> option(int) =
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a + b),
+        _ => None(),
+    }
+
+// Sail copies a minor footgun from other functional languages.
+
+function ordinal(x : nat) -> string =
+    match x {
+        0 => "zeroth",
+        1 => "first",
+        2 => "second",
+        3 => "third",
+        other => concat_str(dec_str(other), "th"),
+    }
+
+// Here `other` creates a new variable bound to `x`.
+// Unfortunately it can catch you out. The following code appears correct and
+// will compile (with warnings), but actually the function always returns 2.
+// Rust and OCaml also suffer from this flaw.
+
+let ONE = 1
+let TWO = 2
+let THREE = 3
+
+function add_one(x : range(1, 3)) -> range(2, 4) =
+    match x {
+        ONE => 2,
+        TWO => 3,
+        THREE => 4,
+    }
+
+function main() -> unit = ()

--- a/samples/Sail/riscv_insts_zbb.sail
+++ b/samples/Sail/riscv_insts_zbb.sail
@@ -1,0 +1,363 @@
+// Example from https://github.com/riscv/sail-riscv/blob/master/model/riscv_insts_zbb.sail
+
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+function clause currentlyEnabled(Ext_Zbb) = hartSupports(Ext_Zbb) | currentlyEnabled(Ext_B)
+function clause currentlyEnabled(Ext_Zbkb) = hartSupports(Ext_Zbkb)
+
+/* ****************************************************************** */
+union clause ast = RISCV_RORIW : (bits(5), regidx, regidx)
+
+mapping clause encdec = RISCV_RORIW(shamt, rs1, rd)
+  <-> 0b0110000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0011011
+  when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
+
+mapping clause assembly = RISCV_RORIW(shamt, rs1, rd)
+  <-> "roriw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_5(shamt)
+
+function clause execute (RISCV_RORIW(shamt, rs1, rd)) = {
+  let rs1_val = (X(rs1))[31..0];
+  let result : xlenbits = sign_extend(rs1_val >>> shamt);
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+union clause ast = RISCV_RORI : (bits(6), regidx, regidx)
+
+mapping clause encdec = RISCV_RORI(shamt, rs1, rd)
+  <-> 0b011000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
+  when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & (xlen == 64 | shamt[5] == bitzero)
+
+mapping clause assembly = RISCV_RORI(shamt, rs1, rd)
+  <-> "rori" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_6(shamt)
+
+function clause execute (RISCV_RORI(shamt, rs1, rd)) = {
+  let rs1_val = X(rs1);
+  let result : xlenbits = if xlen == 32
+                          then rs1_val >>> shamt[4..0]
+                          else rs1_val >>> shamt;
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+union clause ast = ZBB_RTYPEW : (regidx, regidx, regidx, bropw_zbb)
+
+mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, RISCV_ROLW)
+  <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0111011
+  when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
+
+mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, RISCV_RORW)
+  <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0111011
+  when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
+
+mapping zbb_rtypew_mnemonic : bropw_zbb <-> string = {
+  RISCV_ROLW <-> "rolw",
+  RISCV_RORW <-> "rorw"
+}
+
+mapping clause assembly = ZBB_RTYPEW(rs2, rs1, rd, op)
+  <-> zbb_rtypew_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+
+function clause execute (ZBB_RTYPEW(rs2, rs1, rd, op)) = {
+  let rs1_val = (X(rs1))[31..0];
+  let shamt = (X(rs2))[4..0];
+  let result : bits(32) = match op {
+    RISCV_ROLW => rs1_val <<< shamt,
+    RISCV_RORW => rs1_val >>> shamt
+  };
+  X(rd) = sign_extend(result);
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+union clause ast = ZBB_RTYPE : (regidx, regidx, regidx, brop_zbb)
+
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ANDN)
+  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
+  when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
+
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ORN)
+  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
+  when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
+
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_XNOR)
+  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
+  when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
+
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MAX)
+  <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
+  when currentlyEnabled(Ext_Zbb)
+
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MAXU)
+  <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
+  when currentlyEnabled(Ext_Zbb)
+
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MIN)
+  <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
+  when currentlyEnabled(Ext_Zbb)
+
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MINU)
+  <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
+  when currentlyEnabled(Ext_Zbb)
+
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ROL)
+  <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
+  when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
+
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ROR)
+  <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
+  when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
+
+mapping zbb_rtype_mnemonic : brop_zbb <-> string = {
+  RISCV_ANDN <-> "andn",
+  RISCV_ORN  <-> "orn",
+  RISCV_XNOR <-> "xnor",
+  RISCV_MAX  <-> "max",
+  RISCV_MAXU <-> "maxu",
+  RISCV_MIN  <-> "min",
+  RISCV_MINU <-> "minu",
+  RISCV_ROL  <-> "rol",
+  RISCV_ROR  <-> "ror"
+}
+
+mapping clause assembly = ZBB_RTYPE(rs2, rs1, rd, op)
+  <-> zbb_rtype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+
+function clause execute (ZBB_RTYPE(rs2, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let result : xlenbits = match op {
+    RISCV_ANDN => rs1_val & ~(rs2_val),
+    RISCV_ORN  => rs1_val | ~(rs2_val),
+    RISCV_XNOR => ~(rs1_val ^ rs2_val),
+    RISCV_MAX  => to_bits(xlen, max(signed(rs1_val),   signed(rs2_val))),
+    RISCV_MAXU => to_bits(xlen, max(unsigned(rs1_val), unsigned(rs2_val))),
+    RISCV_MIN  => to_bits(xlen, min(signed(rs1_val),   signed(rs2_val))),
+    RISCV_MINU => to_bits(xlen, min(unsigned(rs1_val), unsigned(rs2_val))),
+    RISCV_ROL  => if xlen == 32
+                  then rs1_val <<< rs2_val[4..0]
+                  else rs1_val <<< rs2_val[5..0],
+    RISCV_ROR  => if xlen == 32
+                  then rs1_val >>> rs2_val[4..0]
+                  else rs1_val >>> rs2_val[5..0]
+  };
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+union clause ast = ZBB_EXTOP : (regidx, regidx, extop_zbb)
+
+mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_SEXTB)
+  <-> 0b0110000 @ 0b00100 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
+  when currentlyEnabled(Ext_Zbb)
+
+mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_SEXTH)
+  <-> 0b0110000 @ 0b00101 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
+  when currentlyEnabled(Ext_Zbb)
+
+mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_ZEXTH)
+  <-> 0b0000100 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
+  when currentlyEnabled(Ext_Zbb) & xlen == 32
+
+mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_ZEXTH)
+  <-> 0b0000100 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0111011
+  when currentlyEnabled(Ext_Zbb) & xlen == 64
+
+mapping zbb_extop_mnemonic : extop_zbb <-> string = {
+  RISCV_SEXTB <-> "sext.b",
+  RISCV_SEXTH <-> "sext.h",
+  RISCV_ZEXTH <-> "zext.h"
+}
+
+mapping clause assembly = ZBB_EXTOP(rs1, rd, op)
+  <-> zbb_extop_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
+
+function clause execute (ZBB_EXTOP(rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let result : xlenbits = match op {
+    RISCV_SEXTB => sign_extend(rs1_val[7..0]),
+    RISCV_SEXTH => sign_extend(rs1_val[15..0]),
+    RISCV_ZEXTH => zero_extend(rs1_val[15..0])
+  };
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+union clause ast = RISCV_REV8 : (regidx, regidx)
+
+mapping clause encdec = RISCV_REV8(rs1, rd)
+  <-> 0b011010011000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
+  when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 32
+
+mapping clause encdec = RISCV_REV8(rs1, rd)
+  <-> 0b011010111000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
+  when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
+
+mapping clause assembly = RISCV_REV8(rs1, rd)
+  <-> "rev8" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
+
+function clause execute (RISCV_REV8(rs1, rd)) = {
+  let rs1_val = X(rs1);
+  var result : xlenbits = zeros();
+  foreach (i from 0 to (xlen - 8) by 8)
+    result[(i + 7) .. i] = rs1_val[(xlen - i - 1) .. (xlen - i - 8)];
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+union clause ast = RISCV_ORCB : (regidx, regidx)
+
+mapping clause encdec = RISCV_ORCB(rs1, rd)
+  <-> 0b001010000111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
+  when currentlyEnabled(Ext_Zbb)
+
+mapping clause assembly = RISCV_ORCB(rs1, rd)
+  <-> "orc.b" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
+
+function clause execute (RISCV_ORCB(rs1, rd)) = {
+  let rs1_val = X(rs1);
+  var result : xlenbits = zeros();
+  foreach (i from 0 to (xlen - 8) by 8)
+    result[(i + 7) .. i] = if rs1_val[(i + 7) .. i] == zeros()
+                           then 0x00
+                           else 0xFF;
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+union clause ast = RISCV_CPOP : (regidx, regidx)
+
+mapping clause encdec = RISCV_CPOP(rs1, rd)
+  <-> 0b011000000010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
+  when currentlyEnabled(Ext_Zbb)
+
+mapping clause assembly = RISCV_CPOP(rs1, rd)
+  <-> "cpop" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
+
+function clause execute (RISCV_CPOP(rs1, rd)) = {
+  let rs1_val = X(rs1);
+  var result : nat = 0;
+  foreach (i from 0 to (xlen_val - 1))
+    if rs1_val[i] == bitone then result = result + 1;
+  X(rd) = to_bits(xlen, result);
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+union clause ast = RISCV_CPOPW : (regidx, regidx)
+
+mapping clause encdec = RISCV_CPOPW(rs1, rd)
+  <-> 0b011000000010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
+  when currentlyEnabled(Ext_Zbb) & xlen == 64
+
+mapping clause assembly = RISCV_CPOPW(rs1, rd)
+  <-> "cpopw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
+
+function clause execute (RISCV_CPOPW(rs1, rd)) = {
+  let rs1_val = X(rs1);
+  var result : nat = 0;
+  foreach (i from 0 to 31)
+    if rs1_val[i] == bitone then result = result + 1;
+  X(rd) = to_bits(xlen, result);
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+union clause ast = RISCV_CLZ : (regidx, regidx)
+
+mapping clause encdec = RISCV_CLZ(rs1, rd)
+  <-> 0b011000000000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
+  when currentlyEnabled(Ext_Zbb)
+
+mapping clause assembly = RISCV_CLZ(rs1, rd)
+  <-> "clz" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
+
+function clause execute (RISCV_CLZ(rs1, rd)) = {
+  let rs1_val = X(rs1);
+  var result : nat = 0;
+  var done : bool = false;
+  foreach (i from (xlen - 1) downto 0)
+    if not(done) then if rs1_val[i] == bitzero
+                    then result = result + 1
+                    else done = true;
+  X(rd) = to_bits(xlen, result);
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+union clause ast = RISCV_CLZW : (regidx, regidx)
+
+mapping clause encdec = RISCV_CLZW(rs1, rd)
+  <-> 0b011000000000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
+  when currentlyEnabled(Ext_Zbb) & xlen == 64
+
+mapping clause assembly = RISCV_CLZW(rs1, rd)
+  <-> "clzw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
+
+function clause execute (RISCV_CLZW(rs1, rd)) = {
+  let rs1_val = X(rs1);
+  var result : nat = 0;
+  var done : bool = false;
+  foreach (i from 31 downto 0)
+    if not(done) then if rs1_val[i] == bitzero
+                    then result = result + 1
+                    else done = true;
+  X(rd) = to_bits(xlen, result);
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+union clause ast = RISCV_CTZ : (regidx, regidx)
+
+mapping clause encdec = RISCV_CTZ(rs1, rd)
+  <-> 0b011000000001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
+  when currentlyEnabled(Ext_Zbb)
+
+mapping clause assembly = RISCV_CTZ(rs1, rd)
+  <-> "ctz" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
+
+function clause execute (RISCV_CTZ(rs1, rd)) = {
+  let rs1_val = X(rs1);
+  var result : nat = 0;
+  var done : bool = false;
+  foreach (i from 0 to (xlen - 1))
+    if not(done) then if rs1_val[i] == bitzero
+                    then result = result + 1
+                    else done = true;
+  X(rd) = to_bits(xlen, result);
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+union clause ast = RISCV_CTZW : (regidx, regidx)
+
+mapping clause encdec = RISCV_CTZW(rs1, rd)
+  <-> 0b011000000001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
+  when currentlyEnabled(Ext_Zbb) & xlen == 64
+
+mapping clause assembly = RISCV_CTZW(rs1, rd)
+  <-> "ctzw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
+
+function clause execute (RISCV_CTZW(rs1, rd)) = {
+  let rs1_val = X(rs1);
+  var result : nat = 0;
+  var done : bool = false;
+  foreach (i from 0 to 31)
+    if not(done) then if rs1_val[i] == bitzero
+                    then result = result + 1
+                    else done = true;
+  X(rd) = to_bits(xlen, result);
+  RETIRE_SUCCESS
+}

--- a/samples/Sail/types.sail
+++ b/samples/Sail/types.sail
@@ -1,0 +1,65 @@
+default Order dec
+
+$include <prelude.sail>
+$include <result.sail>
+$include <vector.sail>
+
+// Basic types are:
+
+// Any integer, limited only by your computer's memory!
+let a : int = 1000000000000000000000000000000000000000000000000000000000000000
+
+// Any natural number (non-negative integer).
+let b : nat = 1000000000000000000000000000000000000000000000000000000000000000
+
+// An inclusive range of integers.
+let c : range(1, 6) = 3
+
+// Strings. Sail only has very basic string support, mainly for logging and
+// assembly/disassembly support.
+let d : string = "hello"
+
+// Boolean
+let e : bool = false
+
+// Unit (like an empty tuple; roughly equivalent to 'void').
+let f : unit = ()
+
+// Bit vector. Note that bit-vector literals are written in hex or binary
+// and leading zeros are significant! 0xF is a 4-bit bitvector, but 0x0F is
+// an 8-bit bitvector. Try changing this to 0xF or 0b1010101.
+let g : bits(8) = 0x0F
+
+// More complex types are:
+
+// Standard functional option and result types.
+let h : option(int) = Some(5)
+let i : option(nat) = None()
+
+let j : result(int, unit) = Ok(5)
+let k : result(int, unit) = Err(())
+
+// Fixed-length vectors.
+let l : vector(4, int) = [1, 2, 3, 4]
+
+// Dynamically sized linked lists.
+let m : list(int) = [|1, 2, 3, 4|]
+
+// Custom enum, union and struct types are supported.
+
+// Enums are not namespaced; so you refer to `Red` directly, not `Primary::Red`.
+enum Primary = { Red, Green, Blue }
+
+// Unions are tagged (same as `enum` in Rust), and decoded using `match`.
+union Instruction = {
+    FullSize   : bits(32),
+    Compressed : bits(16),
+}
+
+struct ExecutionStep = {
+    pc          : bits(32),
+    instruction : Instruction,
+    retired     : bool,
+}
+
+function main() -> unit = ()

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -534,6 +534,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **SVG:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **SWIG:** [textmate/c.tmbundle](https://github.com/textmate/c.tmbundle)
 - **Sage:** [MagicStack/MagicPython](https://github.com/MagicStack/MagicPython)
+- **Sail:** [Timmmm/sail_vscode](https://github.com/Timmmm/sail_vscode)
 - **SaltStack:** [saltstack/atom-salt](https://github.com/saltstack/atom-salt)
 - **Sass:** [atom/language-sass](https://github.com/atom/language-sass)
 - **Scala:** [scala/vscode-scala-syntax](https://github.com/scala/vscode-scala-syntax)

--- a/vendor/licenses/git_submodule/sail_vscode.dep.yml
+++ b/vendor/licenses/git_submodule/sail_vscode.dep.yml
@@ -1,0 +1,20 @@
+---
+name: sail_vscode
+version: 3dce4a919a93eac85585ba7ef1c6f3534e8d5ebc
+type: git_submodule
+homepage: https://github.com/Timmmm/sail_vscode.git
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: All code licensed under the MIT license (see [`LICENSE.md`](https://github.com/timmmm/sail_vscode/blob/master/LICENSE.md)),
+    except `syntaxes/sail.tmLanguage.json` which was copied from the Sail project
+    [here](https://github.com/rems-project/sail/blob/f3bf59ea8f8a44089a2fb3306c75f35279e156ce/editors/vscode/sail/syntaxes/sail.tmLanguage.json)
+    and is 2-clause BSD licensed.
+notices: []


### PR DESCRIPTION
Sail is a DSL for describing ISAs. It was primarily developed by the University of Cambridge Computer Lab, and is use for the official RISC-V reference model.

It is also used a fair bit for ARM, since ARM's equivalent - ASL - has no public compiler. Instead ASL can be automatically converted to Sail.

There's some support for x86 and POWER too but I'm not sure how popular it is.

The Sail compiler can do lots of things with Sail code, including:

* Transpiling to C, for use as an emulator (Instruction Set Simulator).
* Transpiling to Lean, Coq, etc. for formal verification.
* Transpiling to SystemVerilog for formal equivalence checking against a real design.

The language itself is really neat. Inspired by OCaml but simpler and with many features that are specifically useful to ISAs. It also has a really neat liquid types system (lightweight dependent types for integers and bit vectors).

See the `basics.sail` example for an intro. I also included a random file from the RISC-V model.

Compiler: https://github.com/rems-project/sail

RISC-V model (check the `model` directory for Sail files): https://github.com/riscv/sail-riscv

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.sail
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - See samples in PR? Not sure what to put here.
    - Sample license(s):
      - All samples except RISC-V were written by me so you can use any license.
      - The RISC-V examples is BSD 2-clause as stated at the top of the file.
  - [x] I have included a syntax highlighting grammar: [URL to grammar repo](https://raw.githubusercontent.com/Timmmm/sail_vscode/refs/heads/master/syntaxes/sail.tmLanguage.json)
  - [x] I have added a color
    - Hex value: `#259dd5`
    - Rationale: Used in [the official logo](https://raw.githubusercontent.com/rems-project/sail/refs/heads/sail2/etc/logo/sail_logo.png)
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

As far as I can tell there are no other languages using `.sail`.

Fixes #7324 