### PR TITLE
Zumbra lang

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -233,6 +233,9 @@
 [submodule "vendor/grammars/ZenScript-tmLanguage"]
 	path = vendor/grammars/ZenScript-tmLanguage
 	url = https://github.com/CraftTweaker/ZenScript-tmLanguage
+[submodule "vendor/grammars/Zumbra-lang"]
+	path = vendor/grammars/Zumbra-lang
+	url = https://github.com/Zumbra-lang/Zumbra-lang.git
 [submodule "vendor/grammars/abap-cds-grammar"]
 	path = vendor/grammars/abap-cds-grammar
 	url = https://github.com/FreHu/abap-cds-grammar
@@ -1488,6 +1491,3 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
-[submodule "vendor/grammars/Zumbra-lang"]
-	path = vendor/grammars/Zumbra-lang
-	url = https://github.com/Zumbra-lang/Zumbra-lang.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1488,3 +1488,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/Zumbra-lang"]
+	path = vendor/grammars/Zumbra-lang
+	url = https://github.com/Zumbra-lang/Zumbra-lang.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -191,6 +191,8 @@ vendor/grammars/XojoSyntaxTM:
 - source.xojo
 vendor/grammars/ZenScript-tmLanguage:
 - source.zenscript
+vendor/grammars/Zumbra-lang:
+- source.zum
 vendor/grammars/abap-cds-grammar:
 - source.abapcds
 vendor/grammars/abap.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2786,7 +2786,7 @@ HIP:
   type: programming
   color: "#4F3A4F"
   extensions:
-    - ".hip"
+  - ".hip"
   tm_scope: source.c++
   ace_mode: c_cpp
   codemirror_mode: clike
@@ -8615,6 +8615,14 @@ Zimpl:
   tm_scope: none
   ace_mode: text
   language_id: 411
+Zumbra:
+  type: programming
+  color: "#FFFFFF"
+  extensions:
+  - ".zum"
+  tm_scope: source.zum
+  ace_mode: text
+  language_id: 356996075
 cURL Config:
   type: data
   group: INI

--- a/samples/Zumbra/calculator.zum
+++ b/samples/Zumbra/calculator.zum
@@ -1,0 +1,5 @@
+var sum << fct(a,b){
+    return a + b;
+};
+
+show(sum(1,2));

--- a/samples/Zumbra/hello.zum
+++ b/samples/Zumbra/hello.zum
@@ -1,0 +1,4 @@
+var hello << "Hello";
+var world << "World";
+
+show(hello + " " + world);

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -681,6 +681,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **ZenScript:** [CraftTweaker/ZenScript-tmLanguage](https://github.com/CraftTweaker/ZenScript-tmLanguage)
 - **Zephir:** [phalcon/zephir-sublime](https://github.com/phalcon/zephir-sublime)
 - **Zig:** [ziglang/sublime-zig-language](https://github.com/ziglang/sublime-zig-language)
+- **Zumbra:** [Zumbra-lang/Zumbra-lang](https://github.com/Zumbra-lang/Zumbra-lang)
 - **cURL Config:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **crontab:** [textmate/cron.tmbundle](https://github.com/textmate/cron.tmbundle)
 - **desktop:** [Mailaender/desktop.tmbundle](https://github.com/Mailaender/desktop.tmbundle)


### PR DESCRIPTION
## Description

This pull request adds **Zumbra**, a custom programming language, to GitHub's language recognition system. Zumbra uses the `.zum` file extension, and this change includes the necessary configurations for GitHub to correctly identify and highlight Zumbra files in repositories.

## Checklist:

- [x] **I am adding a new language to GitHub.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for the `.zum` extension:
      - [https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.zum+keywords](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.zum+keywords)
  - [x] I have included a real-world usage sample for Zumbra:
    - Sample source(s):
      - [https://github.com/Zumbra-lang/Zumbra-lang](https://github.com/Zumbra-lang/Zumbra-lang)
    - Sample license(s): MIT License
     - [https://github.com/Zumbra-lang/Zumbra-lang/blob/main/LICENSE](https://github.com/Zumbra-lang/Zumbra-lang/blob/main/LICENSE)
  - [x] I have included a syntax highlighting grammar for Zumbra: [https://github.com/Zumbra-lang/Zumbra-lang](https://github.com/Zumbra-lang/Zumbra-lang)
  - [x] I have added a color for Zumbra language files
    - Hex value: `#ffffff`
    - Rationale: This color was chosen to match the project's theme and mascot, and provide a clear visual identity for Zumbra in the editor.
  - [] I have updated the heuristics to distinguish Zumbra from other languages using the `.zum` extension. N/A, there are no other languages with the same extensions