### PR TITLE
Add language support for Tor configuration files

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -558,6 +558,7 @@ vendor/grammars/language-etc:
 - injections.etc
 - source.2da
 - source.bc
+- source.c.calendar
 - source.c.nwscript
 - source.curlrc
 - source.dc
@@ -595,6 +596,7 @@ vendor/grammars/language-etc:
 - source.stl
 - source.string-template
 - source.tags
+- source.torrc
 - source.ucd.nameslist
 - source.ucd.unidata
 - source.wgetrc

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7635,6 +7635,16 @@ Toit:
   tm_scope: source.toit
   ace_mode: text
   language_id: 356554395
+Tor Config:
+  type: data
+  color: "#59316b"
+  filenames:
+  - torrc
+  tm_scope: source.torrc
+  ace_mode: apache_conf
+  aliases:
+  - torrc
+  language_id: 1016912802
 Tree-sitter Query:
   type: programming
   color: "#8ea64c"

--- a/samples/Tor Config/filenames/torrc
+++ b/samples/Tor Config/filenames/torrc
@@ -1,0 +1,12 @@
+ControlSocket /run/tor/control
+ControlSocketsGroupWritable 1
+CookieAuthentication 1
+CookieAuthFileGroupReadable 1
+CookieAuthFile /run/tor/control.authcookie
+DataDirectory /var/lib/tor
+ExitPolicy reject6 *:*, reject *:*
+ExitRelay 0
+IPv6Exit 0
+Log notice stdout
+PublishServerDescriptor 0
+SOCKSPort 0.0.0.0:9050

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -604,6 +604,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **TextMate Properties:** [textmate/textmate.tmbundle](https://github.com/textmate/textmate.tmbundle)
 - **Thrift:** [textmate/thrift.tmbundle](https://github.com/textmate/thrift.tmbundle)
 - **Toit:** [toitware/ide-tools](https://github.com/toitware/ide-tools)
+- **Tor Config:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **Tree-sitter Query:** [jrieken/vscode-tree-sitter-query](https://github.com/jrieken/vscode-tree-sitter-query)
 - **Turing:** [Alhadis/language-turing](https://github.com/Alhadis/language-turing)
 - **Turtle:** [peta/turtle.tmbundle](https://github.com/peta/turtle.tmbundle)

--- a/vendor/licenses/git_submodule/language-etc.dep.yml
+++ b/vendor/licenses/git_submodule/language-etc.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: language-etc
-version: d149d79c5a0efb8fec013f079e027fe9b1bea530
+version: ed1933244c7b82e2ddeca5474fc7436866301a5e
 type: git_submodule
 homepage: https://github.com/Alhadis/language-etc
 license: isc


### PR DESCRIPTION
## Description
This PR adds language support for [`torrc`](https://gitlab.torproject.org/tpo/core/tor/-/blob/main/doc/torrc_format.txt?ref_type=heads), a configuration file used by [`tor(1)`](https://www.mankier.com/1/tor#The_Configuration_File_Format) (and by extension, software that makes use of it, like the graphical Tor Browser).

## Checklist
-	[x] **I am adding a new language.**
	-	[x] **The extension of the new language is used in hundreds of repositories.**  
		*	[~1,500 results](https://github.com/search?q=path%3A**%2Ftorrc&type=code) for files named `torrc`
	-	[*] **I have included a real-world usage sample:** 
		*	`torrc` From [`lalanza808/monero.fail`](https://github.com/lalanza808/monero.fail/blob/38c77eeb909d77942c8d3a7d5bfbb928d2d53527/conf/torrc), [MIT license](https://github.com/lalanza808/monero.fail/blob/main/LICENSE)
	-	[x] **I have** ~~included~~ **_written_ a [syntax highlighting grammar](https://github.com/Alhadis/language-etc/commit/ed1933244c7b82e2ddeca5474fc7436866301a5e)** (as usual)
	-	[x] **I have added a colour:**
		*	**Hex value:** `#59316b`
		*	**Rationale:** The colour features prominently on the [project's homepage](https://www.torproject.org/) and throughout its branding.
	-	[ ] ~~I have updated the heuristics to distinguish my language from others.~~
