### PR TITLE
Add BuildStream Language

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -144,6 +144,11 @@ disambiguations:
     - (?i:^\s*(end\sfunction)$)
   - language: Bluespec BH
     pattern: '^package\s+[A-Za-z_][A-Za-z0-9_'']*(?:\s*\(|\s+where)'
+- extensions: ['.bst']
+  rules:
+  - language: BibTeX Style
+    pattern: 'ENTRY\s*\{'
+  - language: BuildStream
 - extensions: ['.builds']
   rules:
   - language: XML

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -760,6 +760,14 @@ Browserslist:
   tm_scope: text.browserslist
   ace_mode: text
   language_id: 153503348
+BuildStream:
+  type: data
+  color: "#006bff"
+  extensions:
+  - ".bst"
+  tm_scope: source.yaml
+  ace_mode: yaml
+  language_id: 84359046
 C:
   type: programming
   color: "#555555"

--- a/samples/BuildStream/hello.bst
+++ b/samples/BuildStream/hello.bst
@@ -1,0 +1,22 @@
+kind: manual
+description: |
+
+  Building manually
+
+# Depend on the base system
+depends:
+- base.bst
+
+# Stage the files/src directory for building
+sources:
+  - kind: local
+    path: files/src
+
+# Now configure the commands to run
+config:
+
+  build-commands:
+  - make PREFIX="%{prefix}"
+
+  install-commands:
+  - make -j1 PREFIX="%{prefix}" DESTDIR="%{install-root}" install

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -313,6 +313,13 @@ class TestHeuristics < Minitest::Test
     })
   end
 
+  def test_bst_by_heuristics
+    assert_heuristics({
+      "BibTeX Style" => all_fixtures("BibTeX Style", "*.bst"),
+      "BuildStream" => all_fixtures("BuildStream", "*.bst")
+    })
+  end
+
   def test_builds_by_heuristics
     assert_heuristics({
       nil => all_fixtures("Text"),

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -73,6 +73,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **BrighterScript:** [rokucommunity/vscode-brightscript-language](https://github.com/rokucommunity/vscode-brightscript-language)
 - **Brightscript:** [rokucommunity/vscode-brightscript-language](https://github.com/rokucommunity/vscode-brightscript-language)
 - **Browserslist:** [browserslist/browserslist-vscode](https://github.com/browserslist/browserslist-vscode)
+- **BuildStream:** [atom/language-yaml](https://github.com/atom/language-yaml)
 - **C:** [tree-sitter/tree-sitter-c](https://github.com/tree-sitter/tree-sitter-c) 🐌
 - **C#:** [tree-sitter/tree-sitter-c-sharp](https://github.com/tree-sitter/tree-sitter-c-sharp) 🐌
 - **C++:** [mikomikotaishi/c.tmbundle](https://github.com/mikomikotaishi/c.tmbundle)


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Add the BuildStream configuration language.

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.bst+kind+sources
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/apache/buildstream/blob/79ac919b5514db1fe750ef2fbc624e556570bc39/doc/examples/developing/elements/hello.bst
    - Sample license(s): Apache 2.0
  - [ ] I have included a syntax highlighting grammar: [URL to grammar repo]
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#006bff`
    - Rationale: Taken from the official logo https://buildstream.build/
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.
