### PR TITLE
Update Vyper's color

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8016,7 +8016,7 @@ Vyper:
   type: programming
   extensions:
   - ".vy"
-  color: "#2980b9"
+  color: "#9F4CF2"
   ace_mode: text
   tm_scope: source.vyper
   language_id: 1055641948


### PR DESCRIPTION
## Description
Changes the color of Vyper from `#2980b9` to `#9F4CF2`

## Checklist:
- [x] **I am changing the color associated with a language**
  - [x] I have obtained agreement from the wider language community on this color change. 
   - community discussion:
       - https://t.me/vyperlang/5062
       - https://t.me/vyperlang/5063
       - https://t.me/vyperlang/5072
  - Vyper has changed its logo and brand color since it was added 3 years ago, see:
  	- https://vyperlang.org/ 
  	- https://docs.vyperlang.org/en/latest/index.html
  	- https://github.com/vyperlang/