### PR TITLE
Update languages.yml -- Add support for the Alice programming language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8987,3 +8987,9 @@ xBase:
   tm_scope: source.harbour
   ace_mode: text
   language_id: 421
+  Alice:
+  type: programming
+  extensions:
+    - ".alice"
+  color: "#FF69B4"
+  language_id: 2311


### PR DESCRIPTION
## Add support for the Alice programming language

Alice is a minimalist, single-line programming language. Lightweight, concise, and experimental, it is a DSL designed to explore the essence of code.

This addition includes:
- File extension `.alice`
- Unique hot pink color `#FF69B4` (distinct from C++)
- Basic metadata for recognition by GitHub Linguist

Language repository: [https://github.com/isqs504/Alice](https://github.com/isqs504/Alice)

Thank you for reviewing!