### PR TITLE
Add CSSlite language and grammar

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1500,6 +1500,13 @@ Cython:
   codemirror_mode: python
   codemirror_mime_type: text/x-cython
   language_id: 79
+CSSlite:
+  type: programming
+  color: "#1e90ff"
+  tm_scope: source.csslite
+  ace_mode: text
+  extensions:
+    - .cssl
 D:
   type: programming
   color: "#ba595e"

--- a/vendor/language-csslite/grammars/CSSlite.tmLanguage.json
+++ b/vendor/language-csslite/grammars/CSSlite.tmLanguage.json
@@ -1,0 +1,27 @@
+{
+    "name": "CSSlite",
+    "scopeName": "source.csslite",
+    "patterns": [
+        {
+            "name": "entity.name.selector.csslite",
+            "match": "^[a-zA-Z0-9_-]+:"
+        },
+        {
+            "name": "keyword.operator.assignment.csslite",
+            "match": "="
+        },
+        {
+            "name": "support.type.property-name.csslite",
+            "match": "\\b(color|size|weight|bg|margin|padding)\\b"
+        },
+        {
+            "name": "constant.language.value.csslite",
+            "match": "[#a-zA-Z0-9%]+"
+        }
+    ],
+    "repository": {},
+    "scopeName": "source.csslite",
+    "fileTypes": [
+        "cssl"
+    ]
+}


### PR DESCRIPTION
Description
Adds support for the CSSlite language to GitHub Linguist.
CSSlite is a simplified CSS-like language using .cssl file extension.
This PR adds a TextMate grammar for syntax highlighting and registers .cssl as the file extension.

Checklist:
 I am adding a new language.

Search: https://github.com/Ivannnnnnnnnnnn/CSSlite

 I have included a real-world usage sample for all extensions added in this PR:

Sample source: https://github.com/Ivannnnnnnnnnnn/CSSlite/blob/main/examples/example.cssl

Sample license: MIT

 I have included a syntax highlighting grammar:

https://github.com/Ivannnnnnnnnnnn/CSSlite/blob/main/CSSlite.tmLanguage.json

 I have added a color

Hex value: #1e90ff

Rationale: A bright blue color fitting the language’s CSS inspiration
