### PR TITLE
Add Haki language support to Linguist

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -68,6 +68,16 @@ ABAP:
   tm_scope: source.abap
   ace_mode: abap
   language_id: 1
+Haki:
+  type: programming
+  color: "#ff69b4" 
+  extensions:
+    - ".haki"
+  tm_scope: source.js
+  ace_mode: javascript
+  aliases:
+    - haki
+  group: JavaScript
 ABAP CDS:
   type: programming
   color: "#555e25"


### PR DESCRIPTION
This PR adds support for the `.haki` extension, used for modular bot plugin development in Node.js.

A sample file is included under the MIT license.

Currently in use within the open-source wisteria-md project  
🔗 https://github.com/hakisolos/wisteria-md/tree/master/plugins

Thank you for reviewing ❤️