### PR TITLE
Add Aly programming language support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8995,3 +8995,11 @@ xBase:
   tm_scope: source.harbour
   ace_mode: text
   language_id: 421
+Aly:
+  type: programming
+  color: "#5e5ce6"
+  extensions:
+    - ".aly"
+  tm_scope: source.aly
+  ace_mode: text
+  filenames: []


### PR DESCRIPTION
This PR adds support for the Aly programming language to GitHub Linguist.

- Adds `.aly` file extension for Aly source files
- Sets the language color to indigo (#5e5ce6)
- Marks Aly as a programming language

Aly is a new language created by me (link to your Aly repo). This will allow GitHub to correctly detect and display Aly code in repositories.

Thank you for considering this addition!
