### PR TITLE
Added NUM 

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8995,3 +8995,15 @@ xBase:
   tm_scope: source.harbour
   ace_mode: text
   language_id: 421
+
+NUM:
+  type:
+  - markup
+  - programming
+  color: "#a010c0"
+  extensions:
+  - ".num"
+  - ".html"
+  tm_scope: source.num
+  ace_mode: xml
+  language_id: 99999


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
This pull request adds support for the NUM language.  
NUM is a markup-based domain-specific language originally developed as part of the closed-source ISE Project and used in production by internal enterprise tools. It uses `.num` files with HTML-like syntax and logic elements (e.g., `<print>`, `<if>`, `<calc>`). The language has now been open-sourced at https://github.com/iselang/num.

## Checklist:

- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.num+%3Cprint%3E
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/iselang/num/blob/main/examples/hello.num
    - Sample license(s):
      - MIT (https://github.com/iselang/num/blob/main/LICENSE)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.num+%3Cprint%3E
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/iselang/num/blob/main/examples/hello.num
    - Sample license(s):
      - MIT (https://github.com/iselang/num/blob/main/LICENSE)
  - [ ] I have included a syntax highlighting grammar: *(not yet available)*
  - [x] I have added a color
    - Hex value: `#a010c0`
    - Rationale: A unique purple tone chosen to reflect NUM’s distinct hybrid nature between markup and logic. Random but consistent with markup languages.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

