### PR TITLE
Rename JavaScript to WebScript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3535,7 +3535,7 @@ Java Template Engine:
   ace_mode: text
   tm_scope: text.html.jte
   language_id: 599494012
-JavaScript:
+WebScript:
   type: programming
   tm_scope: source.js
   ace_mode: javascript
@@ -3545,6 +3545,7 @@ JavaScript:
   aliases:
   - js
   - node
+  - javascript
   extensions:
   - ".js"
   - "._js"


### PR DESCRIPTION
Renames `JavaScript` to `WebScript` because Oracle won't release the trademark on `JavaScript`.
Reference: https://news.ycombinator.com/item?id=44412408
