### PR TITLE
Add `.toml.example` extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7424,6 +7424,7 @@ TOML:
   color: "#9c4221"
   extensions:
   - ".toml"
+  - ".toml.example"
   filenames:
   - Cargo.lock
   - Cargo.toml.orig

--- a/samples/TOML/audit.toml.example
+++ b/samples/TOML/audit.toml.example
@@ -1,0 +1,35 @@
+# Example audit config file
+#
+# It may be located in the user home (`~/.cargo/audit.toml`) or in the project
+# root (`.cargo/audit.toml`).
+#
+# All of the options which can be passed via CLI arguments can also be
+# permanently specified in this file.
+
+[advisories]
+ignore = [] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
+informational_warnings = ["unmaintained"] # warn for categories of informational advisories
+severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")
+
+# Advisory Database Configuration
+[database]
+path = "~/.cargo/advisory-db" # Path where advisory git repo will be cloned
+url = "https://github.com/RustSec/advisory-db.git" # URL to git repo
+fetch = true # Perform a `git fetch` before auditing (default: true)
+stale = false # Allow stale advisory DB (i.e. no commits for 90 days, default: false)
+
+# Output Configuration
+[output]
+deny = ["unmaintained"] # exit on error if unmaintained dependencies are found
+format = "terminal" # "terminal" (human readable report) or "json"
+quiet = false # Only print information on error
+show_tree = true # Show inverse dependency trees along with advisories (default: true)
+
+# Target Configuration
+[target]
+arch = ["x86_64"] # Ignore advisories for CPU architectures other than these
+os = ["linux", "windows"] # Ignore advisories for operating systems other than these
+
+[yanked]
+enabled = true # Warn for yanked crates in Cargo.lock (default: true)
+update_index = true # Auto-update the crates.io index (default: true)


### PR DESCRIPTION
## Checklist:
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.toml.example
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [`audit.toml.example`](https://github.com/rustsec/rustsec/blob/13604e1909456e25752784681f0367b13a21e47b/cargo-audit/audit.toml.example)
    - Sample license(s):
      - Dual-licensed as [MIT or Apache](https://github.com/rustsec/rustsec/blob/13604e1909456e25752784681f0367b13a21e47b/cargo-audit/Cargo.toml#L6)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.