### PR TITLE
Add `.swig` and `.swg` extension to SWIG

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6814,6 +6814,8 @@ SWIG:
   type: programming
   extensions:
   - ".i"
+  - ".swg"
+  - ".swig"
   tm_scope: source.c++
   ace_mode: c_cpp
   codemirror_mode: clike

--- a/samples/SWIG/constraint_solver.swig
+++ b/samples/SWIG/constraint_solver.swig
@@ -1,0 +1,539 @@
+// Copyright 2010-2025 Google LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This .swig file exposes the code declared in ../constraint_solver.h and
+// ../constraint_solveri.h.
+//
+// USAGE EXAMPLES (most of which are also unit tests):
+// - ./pywrapcp_test.py
+
+%include "ortools/base/base.swig"
+%include "ortools/util/python/proto.swig"
+
+// PY_CONVERT_HELPER_* macros.
+%include "ortools/constraint_solver/python/constraint_solver_helpers.swig"
+
+%include "ortools/util/python/functions.swig"
+%include "ortools/util/python/vector.swig"
+
+%include "ortools/constraint_solver/python/pywrapcp_util.swig"
+
+// We *do* need to use SWIGTYPE_... type names directly, because the
+// (recommended replacement) $descriptor macro fails, as of 2019-07, with
+// types such as operations_research::Solver.
+// The absence of whitespace before 'swiglint' is mandatory.
+//swiglint: disable swigtype-name
+
+// We need to forward-declare the proto here, so that PROTO_INPUT involving it
+// works correctly. The order matters very much: this declaration needs to be
+// before the %{ #include ".../constraint_solver.h" %}.
+namespace operations_research {
+class AssignmentProto;
+class ConstraintSolverParameters;
+}  // namespace operations_research
+
+%{
+#include <setjmp.h>  // For FailureProtect. See below.
+
+// Used in the PROTECT_FROM_FAILURE macro. See below.
+struct FailureProtect {
+  jmp_buf exception_buffer;
+  void JumpBack() { longjmp(exception_buffer, 1); }
+};
+
+// This #includes constraint_solver.h, and inlines some C++ helpers.
+#include "ortools/constraint_solver/assignment.pb.h"
+#include "ortools/constraint_solver/search_limit.pb.h"
+#include "ortools/constraint_solver/solver_parameters.pb.h"
+%}
+
+// We need to fully support C++ inheritance, because it is heavily used by the
+// exposed C++ classes. Eg:
+// class BaseClass {
+//   virtual void Foo() { ... }
+//   virtual void Bar() { Foo(); ... }
+// };
+// ...
+// class SubClass {
+//   // Overrides Foo; and expects the inherited Bar() to use
+//   // the overriden Foo().
+//   virtual void Foo() { ... }
+// };
+//
+// See the occurrences of "director" in this file.
+%module(directors="1") operations_research
+// The %feature and %exception below let python exceptions that occur within
+// director method propagate to the user as they were originally. See
+// http://www.swig.org/Doc1.3/Python.html#Python_nn36 for example.
+%feature("director:except") {
+    if ($error != NULL) {
+        throw Swig::DirectorMethodException();
+    }
+}
+%exception {
+  try { $action }
+  catch (Swig::DirectorException &e) { SWIG_fail; }
+}
+
+// ============= Type conversions ==============
+
+// See ./constraint_solver_helpers.swig
+PY_CONVERT_HELPER_PTR(Constraint);
+PY_CONVERT_HELPER_PTR(Decision);
+PY_CONVERT_HELPER_PTR(IntervalVar);
+PY_CONVERT_HELPER_PTR(SequenceVar);
+PY_CONVERT_HELPER_INTEXPR_AND_INTVAR();
+
+// Actual conversions. This also includes the conversion to std::vector<Class>.
+PY_CONVERT(IntVar);
+PY_CONVERT(IntExpr);
+PY_CONVERT(Constraint);
+PY_CONVERT(Decision);
+PY_CONVERT(IntervalVar);
+PY_CONVERT(SequenceVar);
+
+// Support passing std::function<void(Solver*)> as argument.
+// See ../utils/python/functions.swig, from which this was copied and adapted.
+
+%{
+static void PyFunctionSolverToVoid(PyObject* pyfunc,
+                                   operations_research::Solver* s) {
+  // () needed to force creation of one-element tuple
+  PyObject* const pysolver =
+      SWIG_NewPointerObj(s, SWIGTYPE_p_operations_research__Solver,
+                         SWIG_POINTER_EXCEPTION);
+  PyObject* const pyresult = PyObject_CallFunction(pyfunc, "(O)", pysolver);
+  if (!pyresult) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "std::function<void(Solver*)> invocation failed.");
+  } else {
+    Py_DECREF(pyresult);
+  }
+}
+%}
+
+%typecheck(SWIG_TYPECHECK_POINTER) std::function<void(
+    operations_research::Solver*)> {
+  $1 = PyCallable_Check($input);
+}
+
+%typemap(in) std::function<void(operations_research::Solver*)> {
+  $1 = [$input](operations_research::Solver* s) {
+    return PyFunctionSolverToVoid($input, s);
+  };
+}
+
+// ============= Extensions ==============
+
+// Add display methods on BaseObject and Solver.
+%extend operations_research::BaseObject {
+  std::string __str__() {
+    return $self->DebugString();
+  }
+}
+%extend operations_research::Solver {
+  std::string __str__() {
+    return $self->DebugString();
+  }
+%pythoncode {
+  def Add(self, ct):
+    if isinstance(ct, PyConstraint):
+      self.__python_constraints.append(ct)
+    self.AddConstraint(ct)
+  }  // %pythoncode
+}
+%feature("pythonappend") operations_research::Solver::Solver %{
+  self.__python_constraints = []
+%}
+
+// Extend IntervalVar to provide a nicer pythonic API for precedence
+// and scheduling constraints. The macros below help do that concisely.
+%define PRECEDENCE_CONSTRAINT(PythonMethodName, CppEnumName)
+Constraint* PythonMethodName(IntervalVar* other) {
+  return $self->solver()->MakeIntervalVarRelation(
+      $self, operations_research::Solver::CppEnumName, other);
+}
+
+Constraint* PythonMethodName##WithDelay(IntervalVar* other, int64_t delay) {
+  return $self->solver()->MakeIntervalVarRelationWithDelay(
+      $self, operations_research::Solver::CppEnumName, other, delay);
+}
+%enddef
+%define SCHEDULING_CONSTRAINT(PythonMethodName, CppEnumName)
+Constraint* PythonMethodName(int64_t date) {
+  return $self->solver()->MakeIntervalVarRelation(
+      $self, operations_research::Solver::CppEnumName, date);
+}
+%enddef
+%extend operations_research::IntervalVar {
+  PRECEDENCE_CONSTRAINT(EndsAfterEnd, ENDS_AFTER_END)
+  PRECEDENCE_CONSTRAINT(EndsAfterStart, ENDS_AFTER_START)
+  PRECEDENCE_CONSTRAINT(EndsAtEnd, ENDS_AT_END)
+  PRECEDENCE_CONSTRAINT(EndsAtStart, ENDS_AT_START)
+  PRECEDENCE_CONSTRAINT(StartsAfterEnd, STARTS_AFTER_END)
+  PRECEDENCE_CONSTRAINT(StartsAfterStart, STARTS_AFTER_START)
+  PRECEDENCE_CONSTRAINT(StartsAtEnd, STARTS_AT_END)
+  PRECEDENCE_CONSTRAINT(StartsAtStart, STARTS_AT_START)
+}
+#undef PRECEDENCE_CONSTRAINT
+#undef SCHEDULING_CONSTRAINT
+
+// Use DebugString() for the native string conversion in python, for objects
+// that support it.
+%define PY_STRINGIFY_DEBUGSTRING(Class)
+%extend operations_research::Class {
+  std::string __repr__() {
+    return $self->DebugString();
+  }
+
+  std::string __str__() {
+    return $self->DebugString();
+  }
+}
+%enddef
+PY_STRINGIFY_DEBUGSTRING(BaseObject);
+PY_STRINGIFY_DEBUGSTRING(IntervalVar);
+PY_STRINGIFY_DEBUGSTRING(SequenceVar);
+PY_STRINGIFY_DEBUGSTRING(IntVar);
+PY_STRINGIFY_DEBUGSTRING(IntExpr);
+PY_STRINGIFY_DEBUGSTRING(Constraint);
+#undef PY_STRINGIFY_DEBUGSTRING
+
+// Extend the solver with a few nicer pythonic methods.
+%extend operations_research::Solver {
+  Constraint* TreeNoCycle(const std::vector<IntVar*>& nexts,
+                          const std::vector<IntVar*>& active,
+                          Solver::IndexFilter1 callback = nullptr) {
+    return $self->MakeNoCycle(nexts, active, callback, false);
+  }
+
+  SearchMonitor* SearchLogWithCallback(int period,
+                                       std::function<std::string()> callback) {
+    return $self->MakeSearchLog(period, callback);
+  }
+
+  IntExpr* ElementFunction(std::function<int64_t(int64_t)> values,
+                           IntVar* const index) {
+    return $self->MakeElement(values, index);
+  }
+}
+
+// Add arithmetic operators to integer expressions.
+%extend operations_research::IntExpr {
+  IntExpr* __add__(IntExpr* other) {
+    return $self->solver()->MakeSum($self, other);
+  }
+  IntExpr* __add__(Constraint* other) {
+    return $self->solver()->MakeSum($self, other->Var());
+  }
+  IntExpr* __add__(int64_t v) {
+    return $self->solver()->MakeSum($self, v);
+  }
+  IntExpr* __radd__(int64_t v) {
+    return $self->solver()->MakeSum($self, v);
+  }
+  IntExpr* __sub__(IntExpr* other) {
+    return $self->solver()->MakeDifference($self, other);
+  }
+  IntExpr* __sub__(Constraint* other) {
+    return $self->solver()->MakeDifference($self, other->Var());
+  }
+  IntExpr* __sub__(int64_t v) {
+    return $self->solver()->MakeSum($self, -v);
+  }
+  IntExpr* __rsub__(int64_t v) {
+    return $self->solver()->MakeDifference(v, $self);
+  }
+  IntExpr* __mul__(IntExpr* other) {
+    return $self->solver()->MakeProd($self, other);
+  }
+  IntExpr* __mul__(Constraint* other) {
+    return $self->solver()->MakeProd($self, other->Var());
+  }
+  IntExpr* __mul__(int64_t v) {
+    return $self->solver()->MakeProd($self, v);
+  }
+  IntExpr* __rmul__(int64_t v) {
+    return $self->solver()->MakeProd($self, v);
+  }
+  IntExpr* __floordiv__(int64_t v) {
+    return $self->solver()->MakeDiv($self, v);
+  }
+  IntExpr* __floordiv__(IntExpr* e) {
+    return $self->solver()->MakeDiv($self, e);
+  }
+  IntExpr* __mod__(int64_t v) {
+    return $self->solver()->MakeModulo($self, v);
+  }
+  IntExpr* __mod__(IntExpr* e) {
+    return $self->solver()->MakeModulo($self, e);
+  }
+  IntExpr* __neg__() {
+    return $self->solver()->MakeOpposite($self);
+  }
+  IntExpr* __abs__() {
+    return $self->solver()->MakeAbs($self);
+  }
+  IntExpr* Square() {
+    return $self->solver()->MakeSquare($self);
+  }
+
+  Constraint* __eq__(int64_t v) {
+    return $self->solver()->MakeEquality($self, v);
+  }
+  Constraint* __ne__(int64_t v) {
+    return $self->solver()->MakeNonEquality($self->Var(), v);
+  }
+  Constraint* __ge__(int64_t v) {
+    return $self->solver()->MakeGreaterOrEqual($self, v);
+  }
+  Constraint* __gt__(int64_t v) {
+    return $self->solver()->MakeGreater($self, v);
+  }
+  Constraint* __le__(int64_t v) {
+    return $self->solver()->MakeLessOrEqual($self, v);
+  }
+  Constraint* __lt__(int64_t v) {
+    return $self->solver()->MakeLess($self, v);
+  }
+  Constraint* __eq__(IntExpr* other) {
+    return $self->solver()->MakeEquality($self->Var(), other->Var());
+  }
+  Constraint* __ne__(IntExpr* other) {
+    return $self->solver()->MakeNonEquality($self->Var(), other->Var());
+  }
+  Constraint* __ge__(IntExpr* other) {
+    return $self->solver()->MakeGreaterOrEqual($self->Var(), other->Var());
+  }
+  Constraint* __gt__(IntExpr* other) {
+    return $self->solver()->MakeGreater($self->Var(), other->Var());
+  }
+  Constraint* __le__(IntExpr* other) {
+    return $self->solver()->MakeLessOrEqual($self->Var(), other->Var());
+  }
+  Constraint* __lt__(IntExpr* other) {
+    return $self->solver()->MakeLess($self->Var(), other->Var());
+  }
+  Constraint* __eq__(Constraint* other) {
+    return $self->solver()->MakeEquality($self->Var(), other->Var());
+  }
+  Constraint* __ne__(Constraint* other) {
+    return $self->solver()->MakeNonEquality($self->Var(), other->Var());
+  }
+  Constraint* __ge__(Constraint* other) {
+    return $self->solver()->MakeGreaterOrEqual($self->Var(), other->Var());
+  }
+  Constraint* __gt__(Constraint* other) {
+    return $self->solver()->MakeGreater($self->Var(), other->Var());
+  }
+  Constraint* __le__(Constraint* other) {
+    return $self->solver()->MakeLessOrEqual($self->Var(), other->Var());
+  }
+  Constraint* __lt__(Constraint* other) {
+    return $self->solver()->MakeLess($self->Var(), other->Var());
+  }
+  Constraint* MapTo(const std::vector<IntVar*>& vars) {
+    return $self->solver()->MakeMapDomain($self->Var(), vars);
+  }
+  IntExpr* IndexOf(const std::vector<int64_t>& vars) {
+    return $self->solver()->MakeElement(vars, $self->Var());
+  }
+  IntExpr* IndexOf(const std::vector<IntVar*>& vars) {
+    return $self->solver()->MakeElement(vars, $self->Var());
+  }
+  IntVar* IsMember(const std::vector<int64_t>& values) {
+    return $self->solver()->MakeIsMemberVar($self->Var(), values);
+  }
+  Constraint* Member(const std::vector<int64_t>& values) {
+    return $self->solver()->MakeMemberCt($self->Var(), values);
+  }
+  Constraint* NotMember(const std::vector<int64_t>& starts,
+                        const std::vector<int64_t>& ends) {
+    return $self->solver()->MakeNotMemberCt($self, starts, ends);
+  }
+}
+
+// Extend IntVar to provide natural iteration over its domains.
+%extend operations_research::IntVar {
+  %pythoncode {
+  def DomainIterator(self):
+    return iter(self.DomainIteratorAux(False))
+
+  def HoleIterator(self):
+    return iter(self.HoleIteratorAux(False))
+  }  // %pythoncode
+}
+
+// Extend IntVarIterator to make it iterable in python.
+%extend operations_research::IntVarIterator {
+  %pythoncode {
+  def __iter__(self):
+    self.Init()
+    return self
+
+  def next(self):
+    if self.Ok():
+      result = self.Value()
+      self.Next()
+      return result
+    else:
+      raise StopIteration()
+
+  def __next__(self):
+    return self.next()
+  }  // %pythoncode
+}
+
+// ============= Exposed C++ API : Solver class ==============
+
+%ignoreall
+
+%unignore operations_research;
+
+namespace operations_research {
+
+// Solver: Basic API.
+%unignore Solver;
+%unignore Solver::Solver;
+%unignore Solver::~Solver;
+%unignore Solver::AddConstraint;
+%unignore Solver::Solve;
+
+// Solver: Debug and performance counters.
+%rename (WallTime) Solver::wall_time;
+%rename (Solutions) Solver::solutions;
+%rename (Failures) Solver::failures;
+%rename (Constraints) Solver::constraints;
+
+// Solver: IntVar creation. We always strip the "Make" prefix in python.
+%rename (IntVar) Solver::MakeIntVar;
+%rename (BoolVar) Solver::MakeBoolVar;
+%rename (IntConst) Solver::MakeIntConst;
+
+// Constraint
+// Ignored:
+// - Accept()
+// - IsCastConstraint()
+// Note(user): we prefer setting the 'director' feature on the individual
+// methods of a class that require it, but sometimes we must actually set
+// 'director' on the class itself, because it is a C++ abstract class and
+// the client needs to construct it. In these cases, we don't bother
+// setting the 'director' feature on individual methods, since it is done
+// automatically when setting it on the class.
+%feature("director") Constraint;
+%unignore Constraint;
+%unignore Constraint::Constraint;
+%unignore Constraint::~Constraint;
+%unignore Constraint::Post;
+%rename (InitialPropagateWrapper) Constraint::InitialPropagate;
+%unignore Constraint::Var;
+%unignore Constraint::DebugString;
+
+}  // namespace operations_research
+
+PY_PROTO_TYPEMAP(ortools.constraint_solver.assignment_pb2,
+                 AssignmentProto,
+                 operations_research::AssignmentProto)
+PY_PROTO_TYPEMAP(ortools.constraint_solver.solver_parameters_pb2,
+                 ConstraintSolverParameters,
+                 operations_research::ConstraintSolverParameters)
+
+%include "ortools/constraint_solver/constraint_solver.h"
+
+// Define templates instantiation after wrapping.
+namespace operations_research {
+%rename (RevInteger) Rev<int64_t>;
+%rename (RevInteger) Rev<int64_t>::Rev;
+%unignore Rev<int64_t>::Value;
+%unignore Rev<int64_t>::SetValue;
+%template(RevInteger) Rev<int64_t>;
+
+#define PARENTHIZE(X...) X
+%define RENAME_ASSIGNMENT_CONTAINER(TYPE, NEW_NAME)
+%rename (NEW_NAME) TYPE;
+%unignore TYPE::Contains;
+%rename (Element) TYPE::MutableElement(int);
+%unignore TYPE::Size;
+%unignore TYPE::Store;
+%unignore TYPE::Restore;
+%template (NEW_NAME) TYPE;
+%enddef
+
+RENAME_ASSIGNMENT_CONTAINER(
+    PARENTHIZE(AssignmentContainer<IntVar, IntVarElement>),
+    IntVarContainer)
+
+#undef RENAME_ASSIGNMENT_CONTAINER
+#undef PARENTHIZE
+
+}  // namespace operations_research
+
+// ============= Custom python wrappers around C++ objects ==============
+// (this section must be after the constraint_solver*.h %includes)
+
+%pythoncode {
+class PyDecision(Decision):
+  def ApplyWrapper(self, solver):
+    try:
+       self.Apply(solver)
+    except Exception as e:
+      if 'CP Solver fail' in str(e):
+        solver.ShouldFail()
+      else:
+        raise
+
+  def RefuteWrapper(self, solver):
+    try:
+       self.Refute(solver)
+    except Exception as e:
+      if 'CP Solver fail' in str(e):
+        solver.ShouldFail()
+      else:
+        raise
+
+  def DebugString(self):
+    return "PyDecision"
+
+class PyConstraint(Constraint):
+  def __init__(self, solver):
+    super().__init__(solver)
+    self.__demons = []
+
+  def Demon(self, method, *args):
+    demon = PyConstraintDemon(self, method, False, *args)
+    self.__demons.append(demon)
+    return demon
+
+  def DelayedDemon(self, method, *args):
+    demon = PyConstraintDemon(self, method, True, *args)
+    self.__demons.append(demon)
+    return demon
+
+  def InitialPropagateDemon(self):
+    return self.solver().ConstraintInitialPropagateCallback(self)
+
+  def DelayedInitialPropagateDemon(self):
+    return self.solver().DelayedConstraintInitialPropagateCallback(self)
+
+  def InitialPropagateWrapper(self):
+    try:
+      self.InitialPropagate()
+    except Exception as e:
+      if 'CP Solver fail' in str(e):
+        self.solver().ShouldFail()
+      else:
+        raise
+
+  def DebugString(self):
+    return "PyConstraint"
+}  // %pythoncode

--- a/samples/SWIG/linear_solver.swg
+++ b/samples/SWIG/linear_solver.swg
@@ -1,0 +1,319 @@
+// Copyright 2010-2025 Google LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This .swg file is only used in the open-source export of
+// util/operations_research (github or-tools)
+//
+// It exposes the linear programming and integer programming solver.
+//
+// The C# API is quite different from the C++ API; mostly because it
+// supports the same "Natural language" API as the python wrapper. See the
+// usage examples.
+//
+// This .swg file is complemented by C# extensions (using partial classes)
+// of some wrapped C++ classes, like Solver or Variable. There are also
+// other C# helper classes. See src/com/google/ortools/linearsolver.
+//
+// USAGE EXAMPLES:
+// - examples/csharp/cslinearprogramming.cs
+// - examples/csharp/csintegerprogramming.cs
+
+%include "ortools/base/base.swg"
+%include "enums.swg"
+%import "ortools/util/csharp/vector.swg"
+
+%{
+#include "ortools/linear_solver/linear_solver.h"
+#include "ortools/linear_solver/linear_solver.pb.h"
+#include "ortools/linear_solver/model_exporter.h"
+%}
+
+%template(DoubleVector) std::vector<double>;
+VECTOR_AS_CSHARP_ARRAY(double, double, double, DoubleVector);
+
+// We need to forward-declare the proto here, so that the PROTO_* macros
+// involving them work correctly. The order matters very much: this declaration
+// needs to be before the %{ #include ".../linear_solver.h" %}.
+namespace operations_research {
+class MPModelProto;
+class MPModelRequest;
+class MPSolutionResponse;
+}  // namespace operations_research
+
+// Allow partial C# classes. That way, we can put our C# code extension in C#
+// files instead of using typemap(cscode).
+/* allow partial c# classes */
+%typemap(csclassmodifiers) SWIGTYPE "public partial class"
+
+%typemap(csclassmodifiers) operations_research::MPVariable "public partial class"
+%typemap(csclassmodifiers) operations_research::MPSolver "public partial class"
+
+%define CONVERT_VECTOR(CTYPE, TYPE)
+SWIG_STD_VECTOR_ENHANCED(CTYPE*);
+%template(TYPE ## Vector) std::vector<CTYPE*>;
+%enddef  // CONVERT_VECTOR
+
+CONVERT_VECTOR(operations_research::MPConstraint, MPConstraint)
+CONVERT_VECTOR(operations_research::MPVariable, MPVariable)
+
+#undef CONVERT_VECTOR
+
+%ignoreall
+
+%unignore operations_research;
+
+// Rename all the exposed classes, by removing the "MP" prefix.
+%rename (Solver) operations_research::MPSolver;
+%rename (Variable) operations_research::MPVariable;
+%rename (Constraint) operations_research::MPConstraint;
+%rename (Objective) operations_research::MPObjective;
+%rename (SolverParameters) operations_research::MPSolverParameters;
+%unignore operations_research::MPSolver::SolverVersion;
+
+// Expose the MPSolver::OptimizationProblemType enum.
+%unignore operations_research::MPSolver::OptimizationProblemType;
+%unignore operations_research::MPSolver::CLP_LINEAR_PROGRAMMING;
+%unignore operations_research::MPSolver::GLOP_LINEAR_PROGRAMMING;
+%unignore operations_research::MPSolver::GLPK_LINEAR_PROGRAMMING;
+%unignore operations_research::MPSolver::PDLP_LINEAR_PROGRAMMING;
+%unignore operations_research::MPSolver::SCIP_MIXED_INTEGER_PROGRAMMING;
+%unignore operations_research::MPSolver::CBC_MIXED_INTEGER_PROGRAMMING;
+%unignore operations_research::MPSolver::GLPK_MIXED_INTEGER_PROGRAMMING;
+%unignore operations_research::MPSolver::GUROBI_LINEAR_PROGRAMMING;
+%unignore operations_research::MPSolver::GUROBI_MIXED_INTEGER_PROGRAMMING;
+%unignore operations_research::MPSolver::CPLEX_LINEAR_PROGRAMMING;
+%unignore operations_research::MPSolver::CPLEX_MIXED_INTEGER_PROGRAMMING;
+%unignore operations_research::MPSolver::XPRESS_LINEAR_PROGRAMMING;
+%unignore operations_research::MPSolver::XPRESS_MIXED_INTEGER_PROGRAMMING;
+%unignore operations_research::MPSolver::BOP_INTEGER_PROGRAMMING;
+%unignore operations_research::MPSolver::SAT_INTEGER_PROGRAMMING;
+
+// Expose the MPSolver::ResultStatus enum.
+%unignore operations_research::MPSolver::ResultStatus;
+%unignore operations_research::MPSolver::OPTIMAL;
+%unignore operations_research::MPSolver::FEASIBLE;
+%unignore operations_research::MPSolver::INFEASIBLE;
+%unignore operations_research::MPSolver::UNBOUNDED;
+%unignore operations_research::MPSolver::ABNORMAL;
+%unignore operations_research::MPSolver::MODEL_INVALID;
+%unignore operations_research::MPSolver::NOT_SOLVED;
+
+// Expose the MPSolver's basic API, with some non-trivial renames.
+// We intentionally don't expose MakeRowConstraint(LinearExpr), because this
+// "natural language" API is specific to C++: other languages may add their own
+// syntactic sugar on top of MPSolver instead of this.
+%rename (MakeConstraint) operations_research::MPSolver::MakeRowConstraint(double, double);
+%rename (MakeConstraint) operations_research::MPSolver::MakeRowConstraint();
+%rename (MakeConstraint) operations_research::MPSolver::MakeRowConstraint(double, double, const std::string&);
+%rename (MakeConstraint) operations_research::MPSolver::MakeRowConstraint(const std::string&);
+
+%rename (Objective) operations_research::MPSolver::MutableObjective;
+
+// Expose the MPSolver's basic API, with trivial renames when needed.
+%unignore operations_research::MPSolver::MPSolver;
+%unignore operations_research::MPSolver::~MPSolver;
+%newobject operations_research::MPSolver::CreateSolver;
+%unignore operations_research::MPSolver::CreateSolver;
+%unignore operations_research::MPSolver::MakeBoolVar;
+%unignore operations_research::MPSolver::MakeIntVar;
+%unignore operations_research::MPSolver::MakeNumVar;
+%unignore operations_research::MPSolver::MakeVar;
+%unignore operations_research::MPSolver::Solve;
+%unignore operations_research::MPSolver::VerifySolution;
+%unignore operations_research::MPSolver::Reset;
+%rename (SetTimeLimit) operations_research::MPSolver::set_time_limit;
+
+// Expose some of the more advanced MPSolver API.
+%unignore operations_research::MPSolver::InterruptSolve;
+%unignore operations_research::MPSolver::SupportsProblemType;
+%unignore operations_research::MPSolver::SetSolverSpecificParametersAsString;
+%rename (WallTime) operations_research::MPSolver::wall_time;
+%unignore operations_research::MPSolver::Clear;
+%rename (Constraint) operations_research::MPSolver::constraint;
+%unignore operations_research::MPSolver::constraints;
+%unignore operations_research::MPSolver::NumConstraints;
+%unignore operations_research::MPSolver::NumVariables;
+%rename (Variable) operations_research::MPSolver::variable;
+%unignore operations_research::MPSolver::variables;
+%unignore operations_research::MPSolver::EnableOutput;
+%unignore operations_research::MPSolver::SuppressOutput;
+%rename (IsMip) operations_research::MPSolver::IsMIP;
+%unignore operations_research::MPSolver::LookupConstraintOrNull;
+%unignore operations_research::MPSolver::LookupVariableOrNull;
+
+// Expose very advanced parts of the MPSolver API. For expert users only.
+%unignore operations_research::MPSolver::ComputeConstraintActivities;
+%unignore operations_research::MPSolver::ComputeExactConditionNumber;
+%rename (Nodes) operations_research::MPSolver::nodes;
+%rename (Iterations) operations_research::MPSolver::iterations;
+%unignore operations_research::MPSolver::BasisStatus;
+%unignore operations_research::MPSolver::FREE;
+%unignore operations_research::MPSolver::AT_LOWER_BOUND;
+%unignore operations_research::MPSolver::AT_UPPER_BOUND;
+%unignore operations_research::MPSolver::FIXED_VALUE;
+%unignore operations_research::MPSolver::BASIC;
+
+// Extend code.
+%unignore operations_research::MPSolver::ExportModelAsLpFormat(bool);
+%unignore operations_research::MPSolver::ExportModelAsMpsFormat(bool, bool);
+%unignore operations_research::MPSolver::WriteModelToMpsFile(
+  const std::string& filename, bool, bool);
+%unignore operations_research::MPSolver::SetHint(
+    const std::vector<operations_research::MPVariable*>&,
+    const std::vector<double>&);
+%unignore operations_research::MPSolver::SetNumThreads;
+%extend operations_research::MPSolver {
+  std::string ExportModelAsLpFormat(bool obfuscated) {
+    operations_research::MPModelExportOptions options;
+    options.obfuscate = obfuscated;
+    operations_research::MPModelProto model;
+    $self->ExportModelToProto(&model);
+    return ExportModelAsLpFormat(model, options).value_or("");
+  }
+
+  std::string ExportModelAsMpsFormat(bool fixed_format, bool obfuscated) {
+    operations_research::MPModelExportOptions options;
+    options.obfuscate = obfuscated;
+    operations_research::MPModelProto model;
+    $self->ExportModelToProto(&model);
+    return ExportModelAsMpsFormat(model, options).value_or("");
+  }
+
+  bool WriteModelToMpsFile(const std::string& filename, bool fixed_format,
+                           bool obfuscated) {
+    operations_research::MPModelExportOptions options;
+    options.obfuscate = obfuscated;
+    operations_research::MPModelProto model;
+    $self->ExportModelToProto(&model);
+    return WriteModelToMpsFile(filename, model, options).ok();
+  }
+
+  void SetHint(const std::vector<operations_research::MPVariable*>& variables,
+               const std::vector<double>& values) {
+    if (variables.size() != values.size()) {
+      LOG(FATAL) << "Different number of variables and values when setting "
+                 << "hint.";
+    }
+    std::vector<std::pair<const operations_research::MPVariable*, double> >
+        hint(variables.size());
+    for (int i = 0; i < variables.size(); ++i) {
+      hint[i] = std::make_pair(variables[i], values[i]);
+    }
+    $self->SetHint(hint);
+  }
+
+  bool SetNumThreads(int num_theads) {
+    return $self->SetNumThreads(num_theads).ok();
+  }
+}
+
+// MPVariable: writer API.
+%unignore operations_research::MPVariable::SetInteger;
+%rename (SetLb) operations_research::MPVariable::SetLB;
+%rename (SetUb) operations_research::MPVariable::SetUB;
+%unignore operations_research::MPVariable::SetBounds;
+
+// MPVariable: reader API.
+%rename (SolutionValue) operations_research::MPVariable::solution_value;
+%rename (Lb) operations_research::MPVariable::lb;
+%rename (Ub) operations_research::MPVariable::ub;
+%rename (Name) operations_research::MPVariable::name;
+%rename (BasisStatus) operations_research::MPVariable::basis_status;
+%rename (ReducedCost) operations_research::MPVariable::reduced_cost;  // expert
+
+// MPConstraint: writer API.
+%unignore operations_research::MPConstraint::SetCoefficient;
+%rename (SetLb) operations_research::MPConstraint::SetLB;
+%rename (SetUb) operations_research::MPConstraint::SetUB;
+%unignore operations_research::MPConstraint::SetBounds;
+%rename (Index) operations_research::MPConstraint::index;
+%rename (SetIsLazy) operations_research::MPConstraint::set_is_lazy;
+
+// MPConstraint: reader API.
+%unignore operations_research::MPConstraint::GetCoefficient;
+%rename (Lb) operations_research::MPConstraint::lb;
+%rename (Ub) operations_research::MPConstraint::ub;
+%rename (Name) operations_research::MPConstraint::name;
+%rename (BasisStatus) operations_research::MPConstraint::basis_status;
+%rename (DualValue) operations_research::MPConstraint::dual_value;  // expert
+%rename (IsLazy) operations_research::MPConstraint::is_lazy;  // expert
+
+// MPObjective: writer API.
+%unignore operations_research::MPObjective::SetCoefficient;
+%unignore operations_research::MPObjective::SetMinimization;
+%unignore operations_research::MPObjective::SetMaximization;
+%unignore operations_research::MPObjective::SetOptimizationDirection;
+%unignore operations_research::MPObjective::Clear;
+%unignore operations_research::MPObjective::SetOffset;
+
+// MPObjective: reader API.
+%unignore operations_research::MPObjective::Value;
+%unignore operations_research::MPObjective::GetCoefficient;
+%rename (Minimization) operations_research::MPObjective::minimization;
+%rename (Maximization) operations_research::MPObjective::maximization;
+%rename (Offset) operations_research::MPObjective::offset;
+%unignore operations_research::MPObjective::BestBound;
+
+// MPSolverParameters API. For expert users only.
+// TODO(user): unit test all of it.
+
+%unignore operations_research::MPSolverParameters;  // no test
+%unignore operations_research::MPSolverParameters::MPSolverParameters;  // no test
+
+// Expose the MPSolverParameters::DoubleParam enum.
+%unignore operations_research::MPSolverParameters::DoubleParam;  // no test
+%unignore operations_research::MPSolverParameters::RELATIVE_MIP_GAP;  // no test
+%unignore operations_research::MPSolverParameters::PRIMAL_TOLERANCE;  // no test
+%unignore operations_research::MPSolverParameters::DUAL_TOLERANCE;  // no test
+%unignore operations_research::MPSolverParameters::GetDoubleParam;  // no test
+%unignore operations_research::MPSolverParameters::SetDoubleParam;  // no test
+%unignore operations_research::MPSolverParameters::kDefaultRelativeMipGap;  // no test
+%unignore operations_research::MPSolverParameters::kDefaultPrimalTolerance;  // no test
+%unignore operations_research::MPSolverParameters::kDefaultDualTolerance;  // no test
+
+// Expose the MPSolverParameters::IntegerParam enum.
+%unignore operations_research::MPSolverParameters::IntegerParam;  // no test
+%unignore operations_research::MPSolverParameters::PRESOLVE;  // no test
+%unignore operations_research::MPSolverParameters::LP_ALGORITHM;  // no test
+%unignore operations_research::MPSolverParameters::INCREMENTALITY;  // no test
+%unignore operations_research::MPSolverParameters::SCALING;  // no test
+%unignore operations_research::MPSolverParameters::GetIntegerParam;  // no test
+%unignore operations_research::MPSolverParameters::SetIntegerParam;  // no test
+
+// Expose the MPSolverParameters::PresolveValues enum.
+%unignore operations_research::MPSolverParameters::PresolveValues;  // no test
+%unignore operations_research::MPSolverParameters::PRESOLVE_OFF;  // no test
+%unignore operations_research::MPSolverParameters::PRESOLVE_ON;  // no test
+%unignore operations_research::MPSolverParameters::kDefaultPresolve;  // no test
+
+// Expose the MPSolverParameters::LpAlgorithmValues enum.
+%unignore operations_research::MPSolverParameters::LpAlgorithmValues;  // no test
+%unignore operations_research::MPSolverParameters::DUAL;  // no test
+%unignore operations_research::MPSolverParameters::PRIMAL;  // no test
+%unignore operations_research::MPSolverParameters::BARRIER;  // no test
+
+// Expose the MPSolverParameters::IncrementalityValues enum.
+%unignore operations_research::MPSolverParameters::IncrementalityValues;  // no test
+%unignore operations_research::MPSolverParameters::INCREMENTALITY_OFF;  // no test
+%unignore operations_research::MPSolverParameters::INCREMENTALITY_ON;  // no test
+%unignore operations_research::MPSolverParameters::kDefaultIncrementality;  // no test
+
+// Expose the MPSolverParameters::ScalingValues enum.
+%unignore operations_research::MPSolverParameters::ScalingValues;  // no test
+%unignore operations_research::MPSolverParameters::SCALING_OFF;  // no test
+%unignore operations_research::MPSolverParameters::SCALING_ON;  // no test
+
+%include "ortools/linear_solver/linear_solver.h"
+%include "ortools/linear_solver/model_exporter.h"
+
+%unignoreall


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
Add `.swig` and `.swg` extension to SWIG, as used by Google and already supported/used by severals projects...

## Description

`.swg` already specified in the SWIG documentation
>  More often than not, this is a special SWIG interface file which is usually denoted with a special .i or .swg suffix

ref: https://www.swig.org/Doc4.3/SWIG.html#SWIG_nn3

Both extensions are already supported by vim: https://github.com/vim/vim/blob/20eb68a8f29008fe9041e60b920246f64ee29335/runtime/filetype.vim#L2573-L2574

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - `.swig`: https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.swig+include
      - `.swg`: https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.swg+include
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s): https://github.com/google/or-tools/tree/main
      * https://github.com/google/or-tools/blob/main/ortools/constraint_solver/python/constraint_solver.swig
      * https://github.com/google/or-tools/blob/main/ortools/linear_solver/csharp/linear_solver.i
    - Sample license(s): apache2