### PR TITLE
Add ROS Interface language grammar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1073,6 +1073,9 @@
 [submodule "vendor/grammars/roc-vscode-unofficial"]
 	path = vendor/grammars/roc-vscode-unofficial
 	url = https://github.com/ivan-demchenko/roc-vscode-unofficial.git
+[submodule "vendor/grammars/ros-tmlanguage"]
+	path = vendor/grammars/ros-tmlanguage
+	url = https://github.com/jtbandes/ros-tmlanguage.git
 [submodule "vendor/grammars/rust-syntax"]
 	path = vendor/grammars/rust-syntax
 	url = https://github.com/dustypomerleau/rust-syntax.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -978,6 +978,8 @@ vendor/grammars/riot-syntax-highlight:
 - text.html.riot
 vendor/grammars/roc-vscode-unofficial:
 - source.roc
+vendor/grammars/ros-tmlanguage:
+- source.rosmsg
 vendor/grammars/rust-syntax:
 - source.rust
 vendor/grammars/sail_vscode:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6165,6 +6165,17 @@ RON:
   ace_mode: rust
   tm_scope: source.ron
   language_id: 587855233
+ROS Interface:
+  type: data
+  color: "#22314e"
+  aliases:
+  - rosmsg
+  extensions:
+  - ".msg"
+  - ".action"
+  - ".srv"
+  tm_scope: source.rosmsg
+  language_id: 809230569
 RPC:
   type: programming
   aliases:

--- a/samples/ROS Interface/AboutROSInterfaces.msg
+++ b/samples/ROS Interface/AboutROSInterfaces.msg
@@ -1,0 +1,36 @@
+# From https://docs.ros.org/en/kilted/Concepts/Basic/About-Interfaces.html#interfaces
+
+int32[] unbounded_integer_array
+int32[5] five_integers_array
+int32[<=5] up_to_five_integers_array
+
+string string_of_unbounded_size
+string<=10 up_to_ten_characters_string
+
+string[<=5] up_to_five_unbounded_strings
+string<=10[] unbounded_array_of_strings_up_to_ten_characters_each
+string<=10[<=5] up_to_five_strings_up_to_ten_characters_each
+
+uint8 x 42
+int16 y -2000
+string full_name "John Doe"
+int32[] samples [-200, -100, 0, 100, 200]
+
+int32 X=123
+int32 Y=-123
+string FOO="foo"
+string EXAMPLE='bar'
+
+# request constants
+int8 FOO=1
+int8 BAR=2
+# request fields
+int8 foobar
+another_pkg/AnotherMessage msg
+---
+# response constants
+uint32 SECRET=123456
+# response fields
+another_pkg/YetAnotherMessage val
+CustomMessageDefinedInThisPackage value
+uint32 an_integer

--- a/samples/ROS Interface/LoadMap.srv
+++ b/samples/ROS Interface/LoadMap.srv
@@ -1,0 +1,17 @@
+# From https://github.com/ros-navigation/navigation2/blob/f7b665406c46494b0f6fbfe80bd16d4f0d85e1df/nav2_msgs/srv/LoadMap.srv
+
+# URL of map resource
+# Can be an absolute path to a file: file:///path/to/maps/floor1.yaml
+# Or, relative to a ROS package: package://my_ros_package/maps/floor2.yaml
+string map_url
+---
+# Result code definitions
+uint8 RESULT_SUCCESS=0
+uint8 RESULT_MAP_DOES_NOT_EXIST=1
+uint8 RESULT_INVALID_MAP_DATA=2
+uint8 RESULT_INVALID_MAP_METADATA=3
+uint8 RESULT_UNDEFINED_FAILURE=255
+
+# Returned map is only valid if result equals RESULT_SUCCESS
+nav_msgs/OccupancyGrid map
+uint8 result

--- a/samples/ROS Interface/Marker.msg
+++ b/samples/ROS Interface/Marker.msg
@@ -1,0 +1,81 @@
+# See:
+#  - http://www.ros.org/wiki/rviz/DisplayTypes/Marker
+#  - http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes
+#
+# for more information on using this message with rviz.
+
+int32 ARROW=0
+int32 CUBE=1
+int32 SPHERE=2
+int32 CYLINDER=3
+int32 LINE_STRIP=4
+int32 LINE_LIST=5
+int32 CUBE_LIST=6
+int32 SPHERE_LIST=7
+int32 POINTS=8
+int32 TEXT_VIEW_FACING=9
+int32 MESH_RESOURCE=10
+int32 TRIANGLE_LIST=11
+int32 ARROW_STRIP=12
+
+int32 ADD=0
+int32 MODIFY=0
+int32 DELETE=2
+int32 DELETEALL=3
+
+# Header for timestamp and frame id.
+std_msgs/Header header
+# Namespace in which to place the object.
+# Used in conjunction with id to create a unique name for the object.
+string ns
+# Object ID used in conjunction with the namespace for manipulating and deleting the object later.
+int32 id
+# Type of object.
+int32 type
+# Action to take; one of:
+#  - 0 add/modify an object
+#  - 1 (deprecated)
+#  - 2 deletes an object (with the given ns and id)
+#  - 3 deletes all objects (or those with the given ns if any)
+int32 action
+# Pose of the object with respect the frame_id specified in the header.
+geometry_msgs/Pose pose
+# Scale of the object; 1,1,1 means default (usually 1 meter square).
+geometry_msgs/Vector3 scale
+# Color of the object; in the range: [0.0-1.0]
+std_msgs/ColorRGBA color
+# How long the object should last before being automatically deleted.
+# 0 indicates forever.
+builtin_interfaces/Duration lifetime
+# If this marker should be frame-locked, i.e. retransformed into its frame every timestep.
+bool frame_locked
+
+# Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ARROW_STRIP, etc.)
+geometry_msgs/Point[] points
+# Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, etc.)
+# The number of colors provided must either be 0 or equal to the number of points provided.
+# NOTE: alpha is not yet used
+std_msgs/ColorRGBA[] colors
+
+# Texture resource is a special URI that can either reference a texture file in
+# a format acceptable to (resource retriever)[https://docs.ros.org/en/rolling/p/resource_retriever/]
+# or an embedded texture via a string matching the format:
+#   "embedded://texture_name"
+string texture_resource
+# An image to be loaded into the rendering engine as the texture for this marker.
+# This will be used iff texture_resource is set to embedded.
+sensor_msgs/CompressedImage texture
+# Location of each vertex within the texture; in the range: [0.0-1.0]
+UVCoordinate[] uv_coordinates
+
+# Only used for text markers
+string text
+
+# Only used for MESH_RESOURCE markers.
+# Similar to texture_resource, mesh_resource uses resource retriever to load a mesh.
+# Optionally, a mesh file can be sent in-message via the mesh_file field. If doing so,
+# use the following format for mesh_resource:
+#   "embedded://mesh_name"
+string mesh_resource
+MeshFile mesh_file
+bool mesh_use_embedded_materials

--- a/samples/ROS Interface/Marker_ROS1.msg
+++ b/samples/ROS Interface/Marker_ROS1.msg
@@ -1,0 +1,46 @@
+# From https://github.com/ros/common_msgs/blob/092bc230c8153dd4cfee0c84c9796cc7e6b09fdb/visualization_msgs/msg/Marker.msg
+
+# See http://www.ros.org/wiki/rviz/DisplayTypes/Marker and http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes for more information on using this message with rviz
+
+uint8 ARROW=0
+uint8 CUBE=1
+uint8 SPHERE=2
+uint8 CYLINDER=3
+uint8 LINE_STRIP=4
+uint8 LINE_LIST=5
+uint8 CUBE_LIST=6
+uint8 SPHERE_LIST=7
+uint8 POINTS=8
+uint8 TEXT_VIEW_FACING=9
+uint8 MESH_RESOURCE=10
+uint8 TRIANGLE_LIST=11
+
+uint8 ADD=0
+uint8 MODIFY=0
+uint8 DELETE=2
+uint8 DELETEALL=3
+
+Header header                        # header for time/frame information
+string ns                            # Namespace to place this object in... used in conjunction with id to create a unique name for the object
+int32 id 		                         # object ID useful in conjunction with the namespace for manipulating and deleting the object later
+int32 type 		                       # Type of object
+int32 action 	                       # 0 add/modify an object, 1 (deprecated), 2 deletes an object, 3 deletes all objects
+geometry_msgs/Pose pose                 # Pose of the object
+geometry_msgs/Vector3 scale             # Scale of the object 1,1,1 means default (usually 1 meter square)
+std_msgs/ColorRGBA color             # Color [0.0-1.0]
+duration lifetime                    # How long the object should last before being automatically deleted.  0 means forever
+bool frame_locked                    # If this marker should be frame-locked, i.e. retransformed into its frame every timestep
+
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)
+geometry_msgs/Point[] points
+#Only used if the type specified has some use for them (eg. POINTS, LINE_STRIP, ...)
+#number of colors must either be 0 or equal to the number of points
+#NOTE: alpha is not yet used
+std_msgs/ColorRGBA[] colors
+
+# NOTE: only used for text markers
+string text
+
+# NOTE: only used for MESH_RESOURCE markers
+string mesh_resource
+bool mesh_use_embedded_materials

--- a/samples/ROS Interface/NavigateThroughPoses.action
+++ b/samples/ROS Interface/NavigateThroughPoses.action
@@ -1,0 +1,28 @@
+# From https://github.com/ros-navigation/navigation2/blob/f7b665406c46494b0f6fbfe80bd16d4f0d85e1df/nav2_msgs/action/NavigateThroughPoses.action
+
+#goal definition
+nav_msgs/Goals poses
+string behavior_tree
+---
+#result definition
+
+# Error codes
+# Note: The expected priority order of the errors should match the message order
+uint16 NONE=0
+uint16 UNKNOWN=9100
+uint16 FAILED_TO_LOAD_BEHAVIOR_TREE=9101
+uint16 TF_ERROR=9102
+uint16 TIMEOUT=9103
+
+uint16 error_code
+string error_msg
+WaypointStatus[] waypoint_statuses
+---
+#feedback definition
+geometry_msgs/PoseStamped current_pose
+builtin_interfaces/Duration navigation_time
+builtin_interfaces/Duration estimated_time_remaining
+int16 number_of_recoveries
+float32 distance_remaining
+int16 number_of_poses_remaining
+WaypointStatus[] waypoint_statuses

--- a/samples/ROS Interface/ParameterDescriptor.msg
+++ b/samples/ROS Interface/ParameterDescriptor.msg
@@ -1,0 +1,38 @@
+# From https://github.com/ros2/rcl_interfaces/blob/1bd7d0b36c79e9e6db6980301f3732fff51ddc50/rcl_interfaces/msg/ParameterDescriptor.msg
+
+# This is the message to communicate a parameter's descriptor.
+
+# The name of the parameter.
+string name
+
+# Enum values are defined in the `ParameterType.msg` message.
+uint8 type
+
+# Description of the parameter, visible from introspection tools.
+string description
+
+# Parameter constraints
+
+# Plain English description of additional constraints which cannot be expressed
+# with the available constraints, e.g. "only prime numbers".
+#
+# By convention, this should only be used to clarify constraints which cannot
+# be completely expressed with the parameter constraints below.
+string additional_constraints
+
+# If 'true' then the value cannot change after it has been initialized.
+bool read_only false
+
+# If true, the parameter is allowed to change type.
+bool dynamic_typing false
+
+# If any of the following sequences are not empty, then the constraint inside of
+# them apply to this parameter.
+#
+# FloatingPointRange and IntegerRange are mutually exclusive.
+
+# FloatingPointRange consists of a from_value, a to_value, and a step.
+FloatingPointRange[<=1] floating_point_range
+
+# IntegerRange consists of a from_value, a to_value, and a step.
+IntegerRange[<=1] integer_range

--- a/samples/ROS Interface/Test.msg
+++ b/samples/ROS Interface/Test.msg
@@ -1,0 +1,26 @@
+# From https://github.com/ros2/rosidl/blob/409437194a5c0b6a9aff9b62015342746803b5aa/rosidl_adapter/test/data/msg/Test.msg
+
+# msg level doc
+
+# field level doc
+bool bool_value
+byte byte_value  # field level doc, style 2
+# combined styles
+char char_value # combined styles, part 2
+float32 float32_value
+float64 float64_value
+int8 int8_value
+uint8 uint8_value
+int16 int16_value
+uint16 uint16_value
+int32 int32_value
+uint32 uint32_value
+int64 int64_value
+uint64 uint64_value
+
+@optional
+float32 multiline_optional
+
+@optional float32 inline_optional
+@optional float32 inline_default_optional 32.0
+@optional float32 INLINE_CONSTANT=32.0

--- a/vendor/licenses/git_submodule/ros-tmlanguage.dep.yml
+++ b/vendor/licenses/git_submodule/ros-tmlanguage.dep.yml
@@ -1,0 +1,19 @@
+---
+name: ros-tmlanguage
+version: f72c81199e1ac8532c4ef80bbc43a69f342359a3
+type: git_submodule
+homepage: https://github.com/jtbandes/ros-tmlanguage.git
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    Copyright ® Jacob Bandes-Storch
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: This project is licensed under the terms of the [MIT license](LICENSE.md).
+notices: []


### PR DESCRIPTION
Adding a language grammar for [ROS interfaces](https://docs.ros.org/en/kilted/Concepts/Basic/About-Interfaces.html) (messages, services, and actions).

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - `.msg` https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.msg+std_msgs
      - `.srv` https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.srv+std_msgs
      - `.action` https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.action+std_msgs
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - CC-BY-4.0  https://docs.ros.org/en/kilted/Concepts/Basic/About-Interfaces.html
      - Apache-2.0 https://github.com/ros-navigation/navigation2/blob/f7b665406c46494b0f6fbfe80bd16d4f0d85e1df/nav2_msgs/srv/LoadMap.srv
      - BSD https://github.com/ros/common_msgs/blob/092bc230c8153dd4cfee0c84c9796cc7e6b09fdb/visualization_msgs/msg/Marker.msg
      - Apache-2.0 From https://github.com/ros-navigation/navigation2/blob/f7b665406c46494b0f6fbfe80bd16d4f0d85e1df/nav2_msgs/action/NavigateThroughPoses.action
      - Apache-2.0 https://github.com/ros2/rcl_interfaces/blob/1bd7d0b36c79e9e6db6980301f3732fff51ddc50/rcl_interfaces/msg/ParameterDescriptor.msg
      - Apache-2.0 https://github.com/ros2/rosidl/blob/409437194a5c0b6a9aff9b62015342746803b5aa/rosidl_adapter/test/data/msg/Test.msg
    - Sample license(s): see above
  - [x] I have included a syntax highlighting grammar: https://github.com/jtbandes/ros-tmlanguage
  - [x] I have added a color
    - Hex value: `#22314e`
    - Rationale: This is the color used for the ROS logo according to the brand guidelines: https://www.ros.org/imgs/ROSBrandGuide.pdf
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
      - note: I haven't done this since the other language using `.msg` (OMNeT++ MSG) already has a disambiguation pattern. I assumed that this means I probably don't need one, but let me know. The two grammars look quite different, including different types of line comments (`#` vs `//`).