### PR TITLE
Add XVBA dependencies as vendored

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -391,3 +391,6 @@
 
 # teamcity CI configuration
 - (^|/)\.teamcity/
+
+# VBAX dependencies
+- (^|/)xvba_modules/


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

At the moment, [XVBA](https://marketplace.visualstudio.com/items?itemName=local-smart.excel-live-server) is the most popular VS Code extension for VBA. One feature it offers is the inclusion of VBA "modules" and other dependencies inside the `xvba_modules` directory. The files included there should be considered vendored files in the same way we do for `node_modules`.

Example repo that has this directory: https://github.com/jimbrig/VBASuite
Example of a "module" included in the xvba_modules folder: https://github.com/Aeraphe/excel-types

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->

  ~~- [ ] I have added or updated the tests for the new or changed functionality.~~ (There's no tests to update for vendored files at the moment it seems)