### PR TITLE
Add language QuakeC

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1052,6 +1052,9 @@
 [submodule "vendor/grammars/quake"]
 	path = vendor/grammars/quake
 	url = https://github.com/newgrammars/quake
+[submodule "vendor/grammars/quakec-syntax"]
+	path = vendor/grammars/quakec-syntax
+	url = https://github.com/4LT/quakec-syntax.git
 [submodule "vendor/grammars/r.tmbundle"]
 	path = vendor/grammars/r.tmbundle
 	url = https://github.com/textmate/r.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -962,6 +962,8 @@ vendor/grammars/qsharp:
 - source.qsharp
 vendor/grammars/quake:
 - source.quake
+vendor/grammars/quakec-syntax:
+- source.quakec
 vendor/grammars/r.tmbundle:
 - source.r
 - text.tex.latex.rd

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -864,7 +864,7 @@ C3:
   type: programming
   color: "#2563eb"
   extensions:
-    - ".c3"
+  - ".c3"
   tm_scope: source.c3
   ace_mode: c_cpp
   codemirror_mode: clike
@@ -6062,6 +6062,14 @@ Quake:
   ace_mode: text
   tm_scope: source.quake
   language_id: 375265331
+QuakeC:
+  type: programming
+  extensions:
+  - ".qc"
+  color: "#975777"
+  ace_mode: text
+  tm_scope: source.quakec
+  language_id: 472308069
 QuickBASIC:
   type: programming
   color: "#008080"

--- a/samples/QuakeC/slider.qc
+++ b/samples/QuakeC/slider.qc
@@ -1,0 +1,282 @@
+float SLIDER_SPAWNFLAG_SOLID = 1;
+
+float SLIDER_STATE_STOPPED = 0;
+float SLIDER_STATE_FORWARD = 1;
+float SLIDER_STATE_REVERSE = 2;
+
+float SLIDER_BLOCKCHECK_DTIME = 0.02;
+float SLIDER_DMG_DTIME = 0.3;
+
+// float SLIDER_DMGSTYLE_GROW = 0; (DEFAULT)
+float SLIDER_DMGSTYLE_CONST = 1;
+float SLIDER_DMGSTYLE_CRUSH = 2;
+
+void() SliderStop = {
+    self.state = SLIDER_STATE_STOPPED;
+    self.velocity = '0 0 0';
+    self.cnt = self.ltime;
+
+    sound(self, CHAN_VOICE, self.noise1, 1, ATTN_NORM);
+};
+
+void() SliderStopAtLanding = {
+    self.io_send = self.io_received;
+
+    // Restore cached activator if possible; otherwise self
+    if (self.enemy) {
+        activator = self.enemy;
+        self.enemy = world;
+    } else {
+        activator = self;
+    }
+
+    SUB_UseTargets();
+    SliderStop();
+};
+
+void() SliderMove = {
+    if (self.height < self.io_received) {
+        self.state = SLIDER_STATE_FORWARD;
+    } else {
+        self.state = SLIDER_STATE_REVERSE;
+    }
+
+    vector next_dest = self.pos2 * self.io_received + self.pos1;
+
+    if (next_dest != self.origin) {
+        SUB_CalcMove(next_dest, self.speed, SliderStopAtLanding);
+        sound(self, CHAN_VOICE, self.noise2, 1, ATTN_NORM);
+    }
+};
+
+void() CalcScalarPos = {
+    float sign = (self.origin - self.pos1) * self.pos2 < 0 ? -1 : 1;
+    self.height = vlen(self.origin - self.pos1) / self.t_length * sign;
+};
+
+void() SliderRecalcAndMove = {
+    CalcScalarPos();
+    SliderMove();
+};
+
+void() SliderUse = {
+    // Cache activator for later use
+    self.enemy = activator;
+
+    CalcScalarPos();
+
+    // Fix bug related to triggering with 0 movement
+    if (self.height == self.io_received) {
+        SliderStop();
+        return;
+    }
+
+    float behind = self.height < self.io_received;
+    float ahead = self.height > self.io_received;
+    float nextmove = self.cnt + self.wait;
+
+    if (self.state == SLIDER_STATE_STOPPED) {
+        // Start moving eventually
+        if (nextmove <= self.ltime) {
+            SliderMove();
+        } else {
+            self.think = SliderRecalcAndMove;
+            self.nextthink = nextmove;
+        }
+    } else if ((self.state == SLIDER_STATE_FORWARD && behind)
+            || (self.state == SLIDER_STATE_REVERSE && ahead)) {
+        // Keep moving
+        // Call again to update destination
+        SliderMove();
+    } else {
+        if (self.wait <= 0) {
+            SliderRecalcAndMove();
+        } else {
+            // Stop & reverse direction
+            SliderStop();
+            self.think = SliderRecalcAndMove;
+            self.nextthink = self.cnt + self.wait;
+        }
+    }
+};
+
+void() SliderInit = {
+    entity dest_ent = find(world, targetname, self.target);
+    if (!dest_ent) {
+        //error("func_slider requires a target!");
+        dprint("func_slider ");
+        if (self.targetname != "") {
+            dprint3("\"", self.targetname, "\" ");
+        }
+        dprint("requires a target\n");
+        return;
+    }
+    
+    // displacement from start to target dest
+    self.pos2 = dest_ent.origin - self.pos1;
+
+    // distance from position start to target dest
+    self.t_length = vlen(self.pos2);
+
+    self.use = SliderUse;
+};
+
+void() SliderObserverThink = {
+    // if slider is still blocked
+    if (self.owner.ltime == self.pausetime) {
+        self.nextthink = time + SLIDER_BLOCKCHECK_DTIME;
+        self.think = SliderObserverThink;
+    } else {
+        self.owner.count = 0;
+        remove(self);
+    }
+};
+
+void() SliderBlocked = {
+    if (self.style == SLIDER_DMGSTYLE_CRUSH) {
+        T_Damage(other, self, self, self.dmg);
+    } else if (self.style == SLIDER_DMGSTYLE_CONST) {
+        if (time > self.pausetime) {
+            T_Damage(other, self, self, self.dmg);
+            other.velocity = '0 0 0';
+            
+            // next time to inflict damage
+            self.pausetime = time + SLIDER_DMG_DTIME;
+        }
+    } else {
+        if (self.count == 0) {
+            entity observer = spawn();
+            observer.nextthink = time + SLIDER_BLOCKCHECK_DTIME;
+            observer.think = SliderObserverThink;
+
+            // slider's ltime when first blocked
+            observer.pausetime = self.ltime;
+            observer.owner = self;
+        }
+
+        if (self.count == 0 || time > self.pausetime) {
+            // damage rises quadratically
+            float damage = self.dmg * (0.5 * (self.count * self.count) + 1);
+            T_Damage(other, self, self, damage);
+            other.velocity = '0 0 0';
+
+            // next time to inflict damage
+            self.pausetime = time + SLIDER_DMG_DTIME;
+
+            self.count+= 1;
+        }
+    }
+};
+
+void() MoverInitSounds = {
+    string stop_snd;
+    string move_snd;
+    
+    switch(self.sounds) {
+        case 1: // DOOR Stone
+            stop_snd = "doors/drclos4.wav";
+            move_snd = "doors/doormv1.wav";
+            break;
+
+        case 2: // DOOR Machine
+            stop_snd = "doors/hydro2.wav";
+            move_snd = "doors/hydro1.wav";
+            break;
+
+        case 3: // DOOR Chain
+            stop_snd = "doors/stndr2.wav";
+            move_snd = "doors/stndr1.wav";
+            break;
+
+        case 4: // DOOR Metal
+            stop_snd = "doors/ddoor2.wav";
+            move_snd = "doors/ddoor1.wav";
+            break;
+
+        case 5: // DOOR SEC Medieval
+            stop_snd = "doors/latch2.wav";
+            move_snd = "doors/winch2.wav";
+            break;
+
+        case 6: // DOOR SEC Metal
+            stop_snd = "doors/airdoor2.wav";
+            move_snd = "doors/airdoor1.wav";
+            break;
+
+        case 7: // DOOR SEC Base
+            stop_snd = "doors/basesec2.wav";
+            move_snd = "doors/basesec1.wav";
+            break;
+
+        case 8: // PLAT Base
+            stop_snd = "plats/plat2.wav";
+            move_snd = "plats/plat1.wav";
+            break;
+
+        case 9: // PLAT Chain
+            stop_snd = "plats/medplat2.wav";
+            move_snd = "plats/medplat1.wav";
+            break;
+
+        case 10: // TRAIN Ratchet
+            stop_snd = "plats/train2.wav";
+            move_snd = "plats/train1.wav";
+            break;
+
+        default: // Silent
+            stop_snd = "misc/null.wav";
+            move_snd = "misc/null.wav";
+    }
+
+    if ((!self.noise1) || self.noise1 == "") {
+        self.noise1 = stop_snd;
+    }
+
+    if ((!self.noise2) || self.noise2 == "") {
+        self.noise2 = move_snd;
+    }
+
+    precache_sound(self.noise1);
+    precache_sound(self.noise2);
+};
+
+void() func_slider = {
+    self.movetype = MOVETYPE_PUSH;
+    self.state = SLIDER_STATE_STOPPED;
+
+    // time since stopping
+    self.cnt = -self.wait;
+
+    // current position as scalar
+    self.height = 0;
+
+    if (self.speed <= 0) {
+        self.speed = 40;
+    }
+
+    if (self.dmg <= 0) {
+        self.dmg = 2;
+    }
+
+    if (self.spawnflags & SLIDER_SPAWNFLAG_SOLID) {
+        self.solid = SOLID_BSP;
+    } else {
+        self.solid = SOLID_NOT;
+    }
+
+    // starting point
+    self.pos1 = self.origin;
+
+    // number of frames entity is blocked
+    self.count = 0;
+
+    setorigin(self, self.origin);
+    setmodel(self, self.model);
+
+    self.blocked = SliderBlocked;
+
+    self.think = SliderInit;
+    self.nextthink = 0.01;
+
+    MoverInitSounds();
+};

--- a/samples/QuakeC/spawner.qc
+++ b/samples/QuakeC/spawner.qc
@@ -1,0 +1,184 @@
+#define TRY_SET_CLASSNAME(ent, spawn_fn, spawn_fn_sym)\
+    do {\
+        if (spawn_fn == spawn_fn_sym) {\
+            ent.classname = #spawn_fn_sym;\
+        }\
+    } while (FALSE)
+    
+void() monster_army, monster_boss, monster_demon1, monster_dog,
+    monster_enforcer, monster_fish, monster_hell_knight, monster_knight,
+    monster_ogre, monster_ogre_marksman, monster_oldone, monster_shalrath,
+    monster_shambler, monster_tarbaby, monster_wizard,  monster_zombie;
+
+void(vector, entity) spawn_tdeath;
+void(vector) spawn_tfog;
+void() FoundTarget;
+float() droptofloor;
+
+const float SPAWNER_FLAG_NO_TELEFLASH = 8;
+const float SPAWNER_FLAG_ANGRY = 16;
+
+void(entity monster) SpawnerSetVelocity = {
+    // mimic behavior of monsterjump
+    makevectors(self.angles);
+    v_forward_z = 0;
+    monster.velocity = v_forward * self.speed;
+    monster.velocity_z = self.height;
+};
+
+void() SpawnerUse = {
+    vector l_mins, l_maxs;
+    entity spawner;
+
+    entity monster = self.enemy;
+    self.enemy = monster.owner;
+    monster.owner = world;
+
+    if (monster.think != monster_boss) {
+        monster.movetype = MOVETYPE_STEP;
+        monster.solid = SOLID_SLIDEBOX;
+    }
+
+    l_mins = monster.mins;
+    l_maxs = monster.maxs;
+    setmodel(monster, self.model);
+    setsize(monster, l_mins, l_maxs);
+
+    monster.health = self.max_health;
+    monster.targetname = self.netname;
+
+    spawner = self;
+    self = monster;
+
+    if (self.think) {
+        self.think();
+    } else {
+        dprint("Spawned monster has no think!\n");
+    }
+
+    self = spawner;
+
+    // un-droptofloor
+    monster.origin = self.origin + '0 0 1';
+    
+    if (monster.flags & FL_ONGROUND) {
+        monster.flags-= FL_ONGROUND;
+    }
+
+    SpawnerSetVelocity(monster);
+
+    if (!(self.spawnflags & SPAWNER_FLAG_NO_TELEFLASH)) {
+        spawn_tfog(monster.origin);
+    }
+
+    spawn_tdeath(monster.origin, monster);
+
+    if (monster.health > 0) {
+        if (self.spawnflags & SPAWNER_FLAG_ANGRY) {
+            if (activator.classname == "player") {
+                monster.enemy = activator;
+            } else {
+                self = monster;
+                monster.enemy = checkclient();
+                self = spawner;
+
+                if (!monster.enemy) {
+                    monster.enemy = find(world, classname, "player");
+                }
+            }
+
+            if (monster.enemy.flags & FL_NOTARGET) {
+                monster.enemy = world;
+            }
+
+            if (monster.enemy) {
+                monster.think = FoundTarget;
+                monster.nextthink = time + 0.01;
+            }
+        }
+    }
+
+    if (!self.enemy) {
+        self.use = SUB_Null;
+    }
+};
+
+static void(entity monster, void() spawn_fn) SpawnerSetMonsterClassname = {
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_army);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_boss);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_demon1);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_dog);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_enforcer);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_fish);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_hell_knight);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_knight);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_ogre);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_ogre_marksman);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_oldone);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_shalrath);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_shambler);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_tarbaby);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_wizard);
+    TRY_SET_CLASSNAME(monster, spawn_fn, monster_zombie);
+
+    if (monster.classname == "") {
+        dprint("Could not find classname for spawned monster\n");
+    }
+};
+
+void() monster_spawner = {
+    entity spawner;
+
+    if (deathmatch) {
+        remove(self);
+        return;
+    }
+
+    if (self.count < 1) {
+        self.count = 1;
+    }
+
+    // setup monster
+    spawner = self;
+
+    for (; spawner.count > 0; spawner.count--) {
+        self = spawn();
+
+        self.origin = spawner.origin;
+        self.angles = spawner.angles;
+        self.target = spawner.target;
+        self.target2 = spawner.target2;
+        self.squad = spawner.squad;
+        self.io_send = spawner.io_send;
+        self.delay = spawner.delay;
+        self.spawnflags = spawner.spawnflags;
+
+        if (self.spawnflags & SPAWNER_FLAG_NO_TELEFLASH) {
+            self.spawnflags-= SPAWNER_FLAG_NO_TELEFLASH;
+        }
+
+        if (self.spawnflags & SPAWNER_FLAG_ANGRY) {
+            self.spawnflags-= SPAWNER_FLAG_ANGRY;
+        }
+
+        SpawnerSetMonsterClassname(self, spawner.think);
+
+        // spawn function
+        spawner.think();
+
+        self.nextthink = 0;
+
+        // cache model (don't use setmodel)
+        spawner.model = self.model;
+        self.modelindex = 0;
+        self.solid = SOLID_NOT;
+        self.movetype = MOVETYPE_NONE;
+        spawner.max_health = self.health;
+        self.health = 0;
+        self.owner = spawner.enemy;
+        spawner.enemy = self;
+    }
+
+    self = spawner;
+    self.use = SpawnerUse;
+};

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -491,6 +491,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **QMake:** [textmate/cpp-qt.tmbundle](https://github.com/textmate/cpp-qt.tmbundle)
 - **Qt Script:** [atom/language-javascript](https://github.com/atom/language-javascript)
 - **Quake:** [newgrammars/quake](https://github.com/newgrammars/quake)
+- **QuakeC:** [4LT/quakec-syntax](https://github.com/4LT/quakec-syntax)
 - **QuickBASIC:** [QB64Official/vscode](https://github.com/QB64Official/vscode)
 - **R:** [textmate/r.tmbundle](https://github.com/textmate/r.tmbundle)
 - **RAML:** [atom/language-yaml](https://github.com/atom/language-yaml)

--- a/vendor/licenses/git_submodule/quakec-syntax.dep.yml
+++ b/vendor/licenses/git_submodule/quakec-syntax.dep.yml
@@ -1,0 +1,19 @@
+---
+name: quakec-syntax
+version: ad3089dd8220a41116b308acb2068145d3c393a7
+type: git_submodule
+homepage: https://github.com/4LT/quakec-syntax.git
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |-
+    MIT License
+
+    Copyright (c) 2025 Seth Rader
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []


### PR DESCRIPTION
Adds the language QuakeC (used in for coding games in the Quake engine) to linguist.

## Description
Adds the QuakeC language to linguist, as per the instructions in the CONTRIBUTING.md guide.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.qc+vector
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/4LT/qc-conduit/blob/master/spawner.qc
      - https://github.com/4LT/qc-conduit/blob/master/slider.qc
    - Sample license(s): MIT
  - [x] I have included a syntax highlighting grammar: [URL to grammar repo]
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#975777`
    - Rationale: This is a color sampled from the Quake palette.  It's frequently seen in the game as a sky color.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

## Additional

While the repo the sources are from is licensed under the GPL, these are my own source files written from scratch.  I am explicitly re-licensing them as MIT.  I linked the original sources, but I've copied the files to the [grammar repository](https://github.com/4LT/quakec-syntax) which has the license.

Addresses #6053 

