### PR TITLE
Add sample for `*.toml` extension

### DIFF
--- a/samples/TOML/Cargo.toml
+++ b/samples/TOML/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sample-project"
+description = "A sample project manifest for Linguist"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+categories = ["command-line-utilities"]
+keywords = ["cli", "terminal"]
+
+[dependencies.clap]
+version = "4"
+features = ["derive"]
+
+[dev-dependencies]
+rstest = "0.26"


### PR DESCRIPTION
## Description

PR made in response to https://github.com/github-linguist/linguist/pull/7478#issuecomment-3266427861. This adds a sample for the `*.toml` extension. When that comment was made, the only samples were for filenames.

The sample was generated by me, via running `cargo new ...` and then manually filling in a few fields. This should be enough to be a minimalistic but close to real-world example. I'm happy to fetch a larger sample from a real-world project if that's preferred.

## Checklist:

None that apply.