### PR TITLE
Add huff language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1521,3 +1521,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/huff-treesitter"]
+	path = vendor/grammars/huff-treesitter
+	url = https://github.com/mmsaki/huff-treesitter.git

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -376,7 +376,7 @@ disambiguations:
 - extensions: [".huff"]
   rules:
   - language: Huff
-    named_pattern: huff
+    pattern: '#define\\s+macro'
 - extensions: ['.i']
   rules:
   - language: Motorola 68K Assembly

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -373,6 +373,10 @@ disambiguations:
   - language: Ecmarkup
     pattern: '<emu-(?:alg|annex|biblio|clause|eqn|example|figure|gann|gmod|gprose|grammar|intro|not-ref|note|nt|prodref|production|rhs|table|t|xref)(?:$|\s|>)'
   - language: HTML
+- extensions: [".huff"]
+  rules:
+  - language: Huff
+    named_pattern: huff
 - extensions: ['.i']
   rules:
   - language: Motorola 68K Assembly

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3102,6 +3102,14 @@ Hosts File:
   tm_scope: source.hosts
   ace_mode: text
   language_id: 231021894
+Huff:
+  type: programming
+  color: "#4242C7"
+  ace_mode: c_cpp
+  tm_scope: source.huff
+  extensions:
+  - ".huff"
+  language_id: 405540950
 Hy:
   type: programming
   ace_mode: text

--- a/samples/huff/add.huff
+++ b/samples/huff/add.huff
@@ -1,0 +1,19 @@
+// Entry point.
+#define function add(uint256, uint256) view returns (uint256)
+#define function sub(uint256, uint256) view returns (uint256)
+
+#define macro MAIN() = takes (0) returns (0) {
+    // Grab the function selector from the calldata
+    0x00 calldataload 0xE0 shr                 // [selector]
+
+    dup1 __FUNC_SIG(add) eq add_func jumpi     // [selector]
+    dup1 __FUNC_SIG(sub) eq sub_func jumpi     // [selector]
+
+    // Revert if no functions match
+    0x00 0x00 revert
+
+    add_func:
+        ADD()
+    sub_func:
+        SUB()
+}

--- a/samples/huff/non-reentrant.huff
+++ b/samples/huff/non-reentrant.huff
@@ -1,0 +1,63 @@
+#define function doAction() view returns (uint256)
+#define function otherAction() view returns (uint256)
+
+#define constant LOCK_SLOT = FREE_STORAGE_POINTER()
+
+#define macro NON_REENTRANT() = takes (0) returns (0) {
+    [LOCK_SLOT]  // [lock_slot]
+    sload        // [lock]
+    iszero       // [is_unlocked]
+    unlocked     // [unlocked_jumpdest]
+    jumpi        // []
+    0x00         // [size]
+    0x00         // [offset, size]
+    revert       // []
+    unlocked:    // []
+    0x01         // [lock_value]
+    [LOCK_SLOT]  // [lock_slot, lock_value]
+    sstore       // []
+}
+
+#define macro UNLOCK() = takes (0) returns (0) {
+    0x00         // [lock_value]
+    [LOCK_SLOT]  // [lock_slot, lock_value]
+    sstore       // []
+}
+
+#define macro DO_ACTION() = takes (0) returns (2) {
+    0x45    // [value]
+    0x00    // [offset, value]
+    mstore  // []
+    0x20    // [size]
+    0x00    // [offset, size]
+}
+
+#define macro OTHER_ACTION() = takes (0) returns (2) {
+    0x00    // [size]
+    0x00    // [offset, size]
+}
+
+#define macro MAIN() = takes (0) returns (0) {
+    // Grab the function selector from the calldata
+    0x00 calldataload 0xE0 shr                          // [selector]
+    dup1 __FUNC_SIG(doAction) eq do_action jumpi        // [selector]
+    dup1 __FUNC_SIG(otherAction) eq other_action jumpi  // [selector]
+
+    // Revert if no functions match
+    0x00 0x00 revert
+
+
+    do_action:
+        NON_REENTRANT()
+        DO_ACTION()
+        finish jump
+
+    other_action:
+        OTHER_ACTION()
+        finish jump
+
+    finish:
+        // stack: [offset, size]
+        UNLOCK()
+        return
+}

--- a/samples/huff/style-guide.huff
+++ b/samples/huff/style-guide.huff
@@ -1,0 +1,31 @@
+/* Imports */
+#include "./contracts/utils/ExampleImport1.huff"
+#include "./contracts/utils/ExampleImport2.huff"
+
+/* Function Interfaces */
+#define function exampleFunction1(address,uint256) nonpayable returns ()
+#define function exampleFunction2(address,uint256) nonpayable returns ()
+
+#define function exampleFunction3(address,address,uint256) nonpayable returns ()
+#define function exampleFunction4(address,uint256) nonpayable returns ()
+
+#define event ExampleEvent1(address indexed example)
+#define event ExampleEvent2(address indexed example)
+
+/* Events Signatures */
+#define constant EXAMPLE_EVENT_SIGNATURE1 = 0xDDF252AD1BE2C89B69C2B068FC378DAA952BA7F163C4A11628F55A4DF523B3EF
+#define constant EXAMPLE_EVENT_SIGNATURE2 = 0x8C5BE1E5EBEC7D5BD14F71427D1E84F3DD0314C0F7B2291E5B200AC8C7C3B925
+
+/* Storage Slots */
+#define constant EXAMPLE_SLOT1 = FREE_STORAGE_POINTER()
+#define constant EXAMPLE_SLOT2 = FREE_STORAGE_POINTER()
+#define constant EXAMPLE_SLOT3 = FREE_STORAGE_POINTER()
+
+/* Constructor */
+#define macro CONSTRUCTOR() = takes(0) returns (0) {}
+
+/* Macros */
+#define macro MYMAC() = takes (0) returns (0) {}
+
+/* Entry Point */
+#define macro MAIN() = takes (0) returns (0) {}


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.huff+#define
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [huff-language/huff-docs](https://github.com/huff-language/huff-docs/tree/main/src/style-guide/overview)
    - Sample license(s): MIT
  - [x] I have included a syntax highlighting grammar: [mmsaki/huff-treesitter](https://github.com/mmsaki/huff-treesitter)
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#4242C7`
    - Rationale: This color hex code is used as the icon color for huff file extensions in dev-icons repo [nvim-web-devicons/lua/nvim-web-devicons/light/icons_by_file_extension.lua](https://github.com/nvim-tree/nvim-web-devicons/blob/6e51ca170563330e063720449c21f43e27ca0bc1/lua/nvim-web-devicons/light/icons_by_file_extension.lua#L186)
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.