### PR TITLE
Add Strace log highlighting (reuse C grammar)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7343,6 +7343,17 @@ Stata:
   tm_scope: source.stata
   ace_mode: text
   language_id: 358
+Strace:
+  type: data
+  aliases:
+  - strace-log
+  filenames:
+  - strace.log
+  extensions:
+  - ".strace"
+  tm_scope: source.c
+  ace_mode: text
+  language_id: 820187979
 StringTemplate:
   type: markup
   color: "#3fb34f"

--- a/samples/Strace/basic.strace
+++ b/samples/Strace/basic.strace
@@ -1,0 +1,7 @@
+execve("/bin/echo", ["echo", "hello"], 0x7ffcb1d558e0 /* 20 vars */) = 0
+brk(NULL)                               = 0x55e7c5f2d000
+arch_prctl(ARCH_SET_FS, 0x7f9d74b89540) = 0
+mmap(NULL, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f9d74f40000
+write(1, "hello\n", 6)                  = 6
+exit_group(0)                           = ?
++++ exited with 0 +++

--- a/samples/Strace/open-close.strace
+++ b/samples/Strace/open-close.strace
@@ -1,0 +1,10 @@
+openat(AT_FDCWD, "/etc/hosts", O_RDONLY|O_CLOEXEC) = 3
+fstat(3, {st_mode=S_IFREG|0644, st_size=309, ...}) = 0
+read(3, "# Hosts file\n127.0.0.1 localhost\n", 4096) = 31
+close(3)                                = 0
+openat(AT_FDCWD, "/etc/resolv.conf", O_RDONLY|O_CLOEXEC) = 3
+fstat(3, {st_mode=S_IFREG|0644, st_size=86, ...}) = 0
+read(3, "nameserver 8.8.8.8\n", 4096)   = 19
+close(3)                                = 0
+exit_group(0)                           = ?
++++ exited with 0 +++

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -584,6 +584,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Standard ML:** [textmate/standard-ml.tmbundle](https://github.com/textmate/standard-ml.tmbundle)
 - **Starlark:** [MagicStack/MagicPython](https://github.com/MagicStack/MagicPython)
 - **Stata:** [pschumm/Stata.tmbundle](https://github.com/pschumm/Stata.tmbundle)
+- **Strace:** [mikomikotaishi/c.tmbundle](https://github.com/mikomikotaishi/c.tmbundle)
 - **StringTemplate:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **Stylus:** [billymoon/Stylus](https://github.com/billymoon/Stylus)
 - **SubRip Text:** [Alhadis/language-subtitles](https://github.com/Alhadis/language-subtitles)


### PR DESCRIPTION
### Summary
Adds syntax highlighting support for `strace` command output by reusing the existing C TextMate grammar.

### Changes
- Add "Strace" entry to `languages.yml` as a data language
- **Detection**: `extensions: .strace`, `filenames: strace.log` 
- **Grammar**: `tm_scope: source.c` (reuses existing C grammar from mikomikotaishi/c.tmbundle)
- **Editor**: `ace_mode: text` (consistent with other data-type languages)
- **Type**: `data` (diagnostic output, not source code)
- **Language ID**: Generated automatically by `script/update-ids`

### Implementation Details  
* No new grammar submodule required - leverages C grammar already shipped with Linguist
* Conservative detection pattern (specific extension/filename) to avoid false positives on generic `.log/.txt` files
* Vendor/README.md updated automatically during regeneration

### Samples  
Two realistic sample files added under `samples/Strace/`:
- `basic.strace` - simple system call trace
- `open-close.strace` - file operation trace

Both samples authored for this PR and released under MIT license.

### Validation  
```bash
script/bootstrap
script/update-ids  
bundle exec rake samples
bundle exec rake test
```

Closes #7575
