### PR TITLE
chore: add .oxlintrc.json to json with comments

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3467,6 +3467,7 @@ JSON with Comments:
   - ".jscsrc"
   - ".jshintrc"
   - ".jslintrc"
+  - ".oxlintrc.json"
   - ".swcrc"
   - api-extractor.json
   - devcontainer.json


### PR DESCRIPTION
Adds `.oxlintrc.json`, [Oxlints config file](https://oxc.rs/docs/guide/usage/linter/) to JSON with comments entry.

## Checklist:
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.oxlintrc.json
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.