### PR TITLE
Add Lean4 alias

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3989,6 +3989,8 @@ Lean:
 Lean 4:
   type: programming
   group: Lean
+  aliases:
+  - lean4
   extensions:
   - ".lean"
   tm_scope: source.lean4


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
- Proper implementation of #7434

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
> This makes lean4 work as a markdown block language instead of lean-4.
> https://github.com/github-linguist/linguist/pull/7434#issue-3127094852
> https://github.com/github-linguist/linguist/pull/7434#issuecomment-2953313613

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - Adding alias "lean4" for Lean 4 language 
  - [ ] I have added or updated the tests for the new or changed functionality.
<!--
- [ ] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR ->
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [URL to public discussion]
    - [Optional: URL to official branding guidelines for the language]
-->