### PR TITLE
Add Git Commit language

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -88,6 +88,7 @@ vendor/grammars/NovaGrammars:
 - source.solution
 - source.win32-messages
 - source.ws
+- text.git-commit
 - text.hash-commented
 - text.robots-txt
 vendor/grammars/ObjectScript.tmBundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2588,7 +2588,8 @@ Git Commit:
   filenames:
   - COMMIT_EDITMSG
   ace_mode: text
-  tm_scope: text.hash-commented
+  tm_scope: text.git-commit
+  wrap: true
   language_id: 131750475
 Git Config:
   type: data

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2580,6 +2580,16 @@ Git Attributes:
   codemirror_mode: shell
   codemirror_mime_type: text/x-sh
   language_id: 956324166
+Git Commit:
+  type: data
+  color: "#F44D27"
+  aliases:
+  - commit
+  filenames:
+  - COMMIT_EDITMSG
+  ace_mode: text
+  tm_scope: text.hash-commented
+  language_id: 131750475
 Git Config:
   type: data
   color: "#F44D27"

--- a/samples/Git Commit/filenames/COMMIT_EDITMSG
+++ b/samples/Git Commit/filenames/COMMIT_EDITMSG
@@ -1,0 +1,15 @@
+updated css for all pages 
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch master
+# Changes to be committed:
+#	new file:   cv.css
+#	modified:   cv.html
+#	new file:   cvdraft.html
+#	modified:   index.css
+#	modified:   index.html
+#
+# Changes not staged for commit:
+#	deleted:    home.css
+#

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -220,6 +220,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Gettext Catalog:** [textmate/gettext.tmbundle](https://github.com/textmate/gettext.tmbundle)
 - **Gherkin:** [cucumber/cucumber-tmbundle](https://github.com/cucumber/cucumber-tmbundle)
 - **Git Attributes:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
+- **Git Commit:** [Nixinova/NovaGrammars](https://github.com/Nixinova/NovaGrammars)
 - **Git Config:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **Git Revision List:** [Nixinova/NovaGrammars](https://github.com/Nixinova/NovaGrammars)
 - **Gleam:** [gleam-lang/tree-sitter-gleam](https://github.com/gleam-lang/tree-sitter-gleam) 🐌

--- a/vendor/licenses/git_submodule/NovaGrammars.dep.yml
+++ b/vendor/licenses/git_submodule/NovaGrammars.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: NovaGrammars
-version: b675183505ba8e8931a31351bf62954a18c1a14a
+version: c6dfb955f070c5aaf3ca7f6ee8d0b1802c6aed95
 type: git_submodule
 homepage: https://github.com/Nixinova/NovaGrammars
 license: isc


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
- Implements half of #5598

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Adds the git commit file as its own language. This shouldnt be committed, but is found on github.
Name: "Git Commit", with alias "Commit" (for usage like ````` ```commit `````)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - [COMMIT_EDITMSG](https://github.com/search?q=path%3ACOMMIT_EDITMSG+-path%3A*.*&type=code&p=2) 4.9K+ files
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - [Sample](https://github.com/JazzDev26/JazzDev26.github.io/blob/a65f0b815271a59073d43b32e518bab5c0304db0/COMMIT_EDITMSG#L4), under [MIT](https://github.com/JazzDev26/JazzDev26.github.io/blob/main/LICENSE)
  - [x] I have included a syntax highlighting grammar
    - Using `text.git-commit` from my NovaGrammars repo. [NovaLightshow preview](https://nixinova.github.io/NovaLightshow/?grammar-type=url&grammar=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/grammars/git-commit.yaml-tmLanguage&sample-type=url&sample=https://raw.githubusercontent.com/Nixinova/NovaGrammars/main/samples/COMMIT_EDITMSG)
  - [x] I have added a color
    - Hex value: `#F44D27`
    - Rationale: From the other Git languages
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
