### PR TITLE
Add Teal language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1470,6 +1470,9 @@
 [submodule "vendor/grammars/vscode-slice"]
 	path = vendor/grammars/vscode-slice
 	url = https://github.com/zeroc-ice/vscode-slice
+[submodule "vendor/grammars/vscode-teal"]
+	path = vendor/grammars/vscode-teal
+	url = https://github.com/teal-language/vscode-teal.git
 [submodule "vendor/grammars/vscode-tree-sitter-query"]
 	path = vendor/grammars/vscode-tree-sitter-query
 	url = https://github.com/jrieken/vscode-tree-sitter-query.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1315,6 +1315,8 @@ vendor/grammars/vscode-singularity:
 vendor/grammars/vscode-slice:
 - source.ice
 - source.slice
+vendor/grammars/vscode-teal:
+- source.teal
 vendor/grammars/vscode-tree-sitter-query:
 - source.scm
 vendor/grammars/vscode-vba:

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -853,6 +853,13 @@ disambiguations:
   rules:
   - language: Java Server Pages
     pattern: '<%[@!=\s]?\s*(taglib|tag|include|attribute|variable)\s'
+- extensions: ['.tl']
+  rules:
+  - language: Teal
+    and:
+    - pattern: '--.*'
+    - pattern: '\b(local|function|end|record|interface|enum)\b'
+  - language: Type Language
 - extensions: ['.tlv']
   rules:
   - language: TL-Verilog

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7654,6 +7654,18 @@ Tea:
   tm_scope: source.tea
   ace_mode: text
   language_id: 370
+Teal:
+  type: programming
+  extensions:
+  - ".tl"
+  color: "#00B1BC"
+  tm_scope: source.teal
+  ace_mode: lua
+  codemirror_mode: lua
+  codemirror_mime_type: text/x-lua
+  interpreters:
+  - tl
+  language_id: 719038619
 Terra:
   type: programming
   extensions:

--- a/samples/Teal/Emitter.tl
+++ b/samples/Teal/Emitter.tl
@@ -1,0 +1,239 @@
+-- emitter.tl
+--
+-- Copyright (c) 2024, Michael Dowling
+--
+-- This module is free software; you can redistribute it and/or modify it under
+-- the terms of the MIT license. See LICENSE for details.
+
+--- Signal slot event dispatcher.
+local record Emitter
+    --- An event that can be emitted.
+    ---
+    --- Events are registered with an emitter by their type, and the type is defined using a sentinel value of the
+    --- same type as the event. This is typically done using a record for the event, and each instance of the event
+    --- sets its type to the record.
+    interface Event
+        --- The type of event used to lookup the event by type.
+        type: self
+    end
+
+    --- Receives a specific type of emitted events.
+    type Listener = function<E is Event>(event: E)
+
+    --- Optional configuration used to configure a listener.
+    record ListenerConfig
+        id: string
+        position: ListenerPosition
+    end
+
+    --- The position to insert a listener.
+    enum ListenerPosition
+        --- Insert the listener at the beginning of the list of listeners.
+        "first"
+        --- Insert the listener at the end of the list of listeners.
+        "last"
+    end
+
+    --- Create a new Emitter.
+    --- @return the created Emitter
+    new: function(): Emitter
+
+    --- Add an event listener to the object.
+    --- @param event    The event type to subscribe to.
+    --- @param listener Listener to invoke.
+    --- @param config?  Optional listener configuration.
+    on: function<E is Event>(self: Emitter, event: E, listener: Listener<E>, config?: ListenerConfig)
+
+    --- Unsubscribes a listener from an event.
+    --- @param event    Event to unsubscribe from.
+    --- @param listener Listener function or ID to unsubscribe.
+    off: function<E is Event>(self: Emitter, event: E, listener: Listener<E> | string)
+
+    --- Add an event listener that is unsubscribed after receiving an event.
+    --- @param event    The event type to subscribe to.
+    --- @param listener Listener to invoke.
+    --- @param config?  Optional listener configuration.
+    once: function<E is Event>(self: Emitter, event: E, listener: Listener<E>, config?: ListenerConfig)
+
+    --- Emit an event to all listners.
+    --- @param event Event to emit.
+    emit: function(self: Emitter, event: Event)
+
+    --- Forwards all events of this Emitter to the provided `emitter`.
+    --- @param emitter Emitter that receives all events of the this emitter.
+    startForwarding: function(self: Emitter, emitter: Emitter)
+
+    --- Stops forwarding events of this Emitter to the provided `emitter`.
+    --- @param emitter the emitter to remove.
+    stopForwarding: function(self: Emitter, emitter: Emitter)
+
+    --- Resets the state of the emitter by removing all listeners and stops all forwarding.
+    reset: function(self: Emitter)
+
+    --- Unsubscribes all listeners for a specific event type.
+    --- @param name Event to unsubscribe.
+    removeAllListeners: function(self: Emitter, event: Event)
+
+    _forwarding: LinkedList<EmitterNode>
+    _listeners: {any:LinkedList<ListenerNode>}
+end
+
+-----------------------------------------------------------------------------
+
+--- A doubly linked list is used for event listeners and forwarding emitters so they can be removed during traversal.
+local interface ListNode<N is ListNode>
+    next: N
+    prev: N
+end
+
+local record LinkedList<N is ListNode<any>>
+    head: N
+    tail: N
+end
+
+function LinkedList.append<N is ListNode<any>, L is LinkedList<N>>(list: L, node: N)
+    if list.head == nil then
+        list.head = node
+        list.tail = node
+    else
+        list.tail.next = node
+        node.prev = list.tail
+        list.tail = node
+    end
+end
+
+function LinkedList.prepend<N is ListNode<any>, L is LinkedList<N>>(list: L, node: N)
+    if list.head == nil then
+        list.head = node
+        list.tail = node
+    else
+        list.head.prev = node
+        node.next = list.head
+        list.head = node
+    end
+end
+
+function LinkedList.remove<N is ListNode<any>, L is LinkedList<N>>(list: L, node: N)
+    if node.prev then
+        (node.prev as N).next = node.next
+    else
+        list.head = node.next as ListNode<any>
+    end
+    if node.next then
+        (node.next as N).prev = node.prev
+    else
+        list.tail = node.prev as ListNode<any>
+    end
+end
+
+local record ListenerNode is ListNode<ListenerNode>
+    id: string
+    listener: Emitter.Listener<any>
+end
+
+local record EmitterNode is ListNode<EmitterNode>
+    emitter: Emitter
+end
+
+-----------------------------------------------------------------------------
+
+local DEFAULT_CONFIG <const>: Emitter.ListenerConfig = { id = "", position = "last" }
+local EMITTER_MT <const>: metatable<Emitter> = { __index = Emitter }
+
+function Emitter.new(): Emitter
+    return setmetatable({
+        _listeners = {},
+        _forwarding = {}
+    }, EMITTER_MT)
+end
+
+function Emitter:reset()
+    self._listeners = {}
+    self._forwarding = {}
+end
+
+function Emitter:on<E is Emitter.Event>(event: E, listener: Emitter.Listener<E>, config?: Emitter.ListenerConfig)
+    local list = self._listeners[event]
+    if not list then
+        list = {}
+        self._listeners[event] = list
+    end
+    config = config or DEFAULT_CONFIG
+    local node <const>: ListenerNode = { id = config.id or "", listener = listener as Emitter.Listener<any> }
+    if config.position == "last" then
+        LinkedList.append(list, node as ListNode<any>)
+    else
+        LinkedList.prepend(list, node as ListNode<any>)
+    end
+end
+
+function Emitter:off<E is Emitter.Event>(event: E, listener: Emitter.Listener<E> | string)
+    local listeners <const> = self._listeners[event]
+    if not listeners then
+        return
+    elseif listener is string then
+        local node = listeners.head
+        while node do
+            if node.id == listener then
+                LinkedList.remove(listeners, node as ListNode<any>)
+            end
+            node = node.next
+        end
+    else
+        local node = listeners.head
+        while node do
+            if node.listener == listener as Emitter.Listener<any> then
+                LinkedList.remove(listeners, node as ListNode<any>)
+            end
+            node = node.next
+        end
+    end
+end
+
+function Emitter:once<E is Emitter.Event>(event: E, listener: Emitter.Listener<E>, config?: Emitter.ListenerConfig)
+    local wrappedFunction: Emitter.Listener<E>
+    wrappedFunction = function(e: E)
+        self:off(event, wrappedFunction)
+        listener(e)
+    end
+    self:on(event, wrappedFunction, config)
+end
+
+function Emitter:emit(event: Emitter.Event)
+    local listeners <const> = self._listeners[event.type]
+    if listeners then
+        local node = listeners.head
+        while node do
+            node.listener(event)
+            node = node.next
+        end
+    end
+
+    local node = self._forwarding.head
+    while node do
+        node.emitter:emit(event)
+        node = node.next
+    end
+end
+
+function Emitter:removeAllListeners(event: Emitter.Event)
+    self._listeners[event] = nil
+end
+
+function Emitter:startForwarding(emitter: Emitter)
+    local node <const>: EmitterNode = { emitter = emitter }
+    LinkedList.append(self._forwarding, node as ListNode<any>)
+end
+
+function Emitter:stopForwarding(emitter: Emitter)
+    local node = self._forwarding.head
+    while node do
+        if node.emitter == emitter then
+            LinkedList.remove(self._forwarding, node as ListNode<any>)
+            return
+        end
+        node = node.next
+    end
+end
+
+return Emitter

--- a/samples/Teal/teal-cyan-example.tl
+++ b/samples/Teal/teal-cyan-example.tl
@@ -1,0 +1,355 @@
+--[[
+Copied from: https://raw.githubusercontent.com/teal-language/cyan/refs/heads/main/src/cyan/commands/build.tl
+--]]
+
+---@nodoc
+
+local argparse <const> = require("argparse")
+local tl <const> = require("tl")
+
+local command <const> = require("cyan.command")
+local common <const> = require("cyan.tlcommon")
+local config <const> = require("cyan.config")
+local decoration <const> = require("cyan.decoration")
+local fs <const> = require("cyan.fs")
+local graph <const> = require("cyan.graph")
+local invocation_context <const> = require("cyan.invocation-context")
+local lexical_path <const> = require("lexical-path")
+local log <const> = require("cyan.log")
+local script <const> = require("cyan.script")
+local util <const> = require("cyan.util")
+
+local ivalues <const> = util.tab.ivalues
+
+local function exists_and_is_dir(prefix: string, p: lexical_path.Path): boolean
+   if not fs.exists(p) then
+      log.err(prefix, " \"", decoration.file_name(p), "\" does not exist")
+      return false
+   end
+   if not fs.is_directory(p) then
+      log.err(prefix, " \"", decoration.file_name(p), "\" is not a directory")
+      return false
+   end
+   return true
+end
+
+-- in the event that an out of project dependency has a type error, we should report it
+local function report_dep_errors(env: tl.Env, source_dir: lexical_path.Path): boolean
+   local ok = true
+   for name in ivalues(env.loaded_order) do
+      local res <const> = env.loaded[name]
+      if not lexical_path.from_os(res.filename):is_in(source_dir) then
+         if (res.syntax_errors and #res.syntax_errors > 0) or #res.type_errors > 0 then
+            if (res.syntax_errors and #res.syntax_errors > 0) then
+               common.report_errors(log.err, res.syntax_errors, res.filename, "(Out of project) syntax error")
+            end
+            if #res.type_errors > 0 then
+               common.report_errors(log.err, res.type_errors, res.filename, "(Out of project) type error")
+            end
+            ok = false
+         end
+      end
+   end
+   return ok
+end
+
+local function build(args: command.Args, loaded_config: config.Config, context: invocation_context.InvocationContext): integer
+   if not loaded_config.loaded_from then
+      log.err(config.filename, " not found")
+      return 1
+   end
+
+   local source_dir <const> = loaded_config.source_dir and loaded_config.source_dir:copy() or lexical_path.from_unix(".")
+   if not exists_and_is_dir("Source dir", source_dir) then
+      return 1
+   end
+
+   local build_dir <const> = loaded_config.build_dir and loaded_config.build_dir:copy() or lexical_path.from_unix(".")
+   if not fs.exists(build_dir) then
+      local succ <const>, err <const> = fs.make_directory(build_dir)
+      if not succ then
+         log.err("Failed to create build dir ", decoration.file_name(build_dir), ": ", err)
+         return 1
+      end
+   elseif not fs.is_directory(build_dir) then
+      log.err("Build dir \"", decoration.file_name(build_dir), "\" is not a directory")
+      return 1
+   end
+
+   local current_dir <const> = fs.current_directory()
+   local function ensure_abs_path(p: lexical_path.Path): lexical_path.Path
+      if p.is_absolute then return p end
+      return current_dir .. p
+   end
+
+   local abs_build_dir <const> = ensure_abs_path(build_dir)
+   local abs_source_dir <const> = ensure_abs_path(source_dir)
+
+   local env <const>, env_err <const> = common.init_env_from_config(loaded_config)
+   if not env then
+      log.err("Could not initialize Teal environment:\n", env_err)
+      return 1
+   end
+
+   if not script.emit_hook(context, "pre") then
+      return 1
+   end
+
+   local include <const> = loaded_config.include or {}
+   local exclude <const> = loaded_config.exclude and { table.unpack(loaded_config.exclude) } or {}
+   if abs_source_dir == context.initial_directory then
+      table.insert(exclude, lexical_path.parse_pattern "tlconfig.lua")
+   end
+   local dont_write_lua_files <const> = source_dir == build_dir
+
+   local dag <const>, cycles <const> = graph.scan_directory(source_dir, include, exclude)
+   if not dag then
+      log.err(
+         "Circular dependency detected in the following files:\n   ",
+         table.unpack(util.tab.intersperse(cycles, "\n   "))
+      )
+      return 1
+   end
+   local exit = 0
+
+   if log.debug:should_log() then
+      log.debug("Built dependency graph")
+      for k, v in pairs(dag._nodes_by_filename) do
+         if not next(v.dependents) then
+            log.debug:cont("   ", k, " has no dependents")
+         else
+            log.debug:cont("   ", k, " has dependents:")
+            for dependent in pairs(v.dependents) do
+               log.debug:cont("      ", dependent.input:to_string())
+            end
+         end
+      end
+   end
+
+   local function display_filename(f: lexical_path.Path, trailing_slash?: boolean): decoration.Decorated
+      return decoration.file_name(assert(ensure_abs_path(f):relative_to(context.initial_directory)):to_string() .. (trailing_slash and fs.path_separator or ""))
+   end
+
+   local function get_output_name(src: lexical_path.Path): lexical_path.Path
+      local out <const> = build_dir .. assert(src:relative_to(source_dir))
+      local ext <const> = out:extension():lower()
+      if ext:lower() == "tl" then
+         out[#out] = out[#out]:sub(1, -#ext - 2) .. ".lua"
+      end
+      return out
+   end
+
+   local function source_is_newer(src: lexical_path.Path): boolean
+      local target <const> = get_output_name(src)
+      local newer: boolean
+      if args.update_all then
+         newer = true
+      else
+         local in_t <const>, out_t <const> = fs.mod_time(src), fs.mod_time(target) or -1
+         newer = in_t > out_t
+      end
+      if newer then
+         log.extra("Source ", display_filename(src), " is newer than target (", display_filename(target), ")")
+         if not script.emit_hook(context, "file_updated", src:copy()) then
+            exit = 1
+            coroutine.yield()
+         end
+      end
+      return newer
+   end
+
+   if not coroutine.wrap(function(): boolean
+      dag:mark_each(source_is_newer)
+      return true
+   end)() then
+      return exit
+   end
+
+   local type_check_options <const> = {
+      feat_lax = "off",
+      feat_arity = loaded_config.feat_arity,
+
+      gen_compat = loaded_config.gen_compat,
+      gen_target = loaded_config.gen_target,
+   }
+
+   local to_write <const> = {}
+   local function process_node(n: graph.Node, compile: boolean)
+      local path <const> = n.input:to_string()
+      local disp_path <const> = display_filename(n.input)
+      log.debug("processing node of ", disp_path, " for ", compile and "compilation" or "type check")
+      local out <const> = get_output_name(n.input)
+      n.output = out
+      local parsed <const>, parse_err <const> = common.parse_file(path)
+      if not parsed then
+         log.err("Could not parse ", disp_path, ":\n   ", parse_err)
+         exit = 1
+         return
+      end
+      if #parsed.errs > 0 then
+         common.report_errors(log.err, parsed.errs, path, "syntax error")
+         exit = 1
+         return
+      end
+
+      local result <const>, check_ast_err <const> = tl.check(parsed.ast, path, type_check_options, env)
+      if not result then
+         log.err("Could not type check ", disp_path, ":\n   ", check_ast_err)
+         exit = 1
+         return
+      end
+
+      if not common.report_result(result, loaded_config) then
+         exit = 1
+         return
+      end
+
+      log.info("Type checked ", disp_path)
+      if args.check_only then
+         return
+      end
+
+      local is_lua <const> = n.input:extension():lower() == "lua"
+      if compile and not (is_lua and dont_write_lua_files) then
+         local ok <const>, err <const> = fs.make_parent_directories(n.output)
+         if ok then
+            table.insert(to_write, {n, parsed.ast})
+         else
+            log.err("Unable to create parent dirs to ", display_filename(n.output), ":", err)
+            exit = 1
+         end
+      end
+   end
+
+   for n in dag:marked_nodes() do
+      process_node(n, n.mark == "compile")
+   end
+
+   if exit ~= 0 then
+      report_dep_errors(env, source_dir)
+      return exit
+   end
+
+   if args.check_only then
+      return exit
+   end
+
+   for node_ast in ivalues(to_write) do
+      local n <const>, ast <const> = node_ast[1], node_ast[2]
+      local fh <const>, err <const> = io.open(n.output:to_string(), "w")
+      if not fh then
+         log.err("Error opening file ", display_filename(n.output), ": ", err)
+         exit = 1
+      else
+         local generated <const>, gen_err <const> = tl.generate(ast, loaded_config.gen_target) -- TODO: gen_options
+         if generated then
+            fh:write(generated, "\n")
+            fh:close()
+            log.info("Wrote ", display_filename(n.output))
+         else
+            log.err("Error when generating lua for ", display_filename(n.output), "\n", gen_err)
+            exit = 1
+         end
+      end
+   end
+
+   if #to_write > 0 then
+      if not script.emit_hook(context, "post") then
+         return 1
+      end
+   end
+
+   if build_dir ~= source_dir then
+      local expected_files <const> = {}
+      for n in dag:nodes() do
+         log.debug(display_filename(n.input), " -> ", display_filename(get_output_name(n.input)))
+         local p <const> = assert(get_output_name(n.input):remove_leading(build_dir))
+         expected_files[p:to_string()] = true
+         for ancestor in p:ancestors() do
+            expected_files[ancestor:to_string()] = true
+         end
+      end
+
+      local unexpected_files <const>: {lexical_path.Path} = {}
+      local unexpected_directories <const>: {lexical_path.Path} = {}
+      local dont_prune <const> = util.tab.map(loaded_config.dont_prune or {}, lexical_path.parse_pattern)
+      for p in fs.scan_directory(build_dir, nil, nil, true) do
+         log.debug("checking if ", p:to_string(), " is expected...")
+         local full <const> = build_dir .. p
+         local pattern_index <const> = fs.match_any(full, dont_prune)
+         if pattern_index then
+            log.debug("   yes (ignored by pattern ", dont_prune[pattern_index], ")")
+         elseif expected_files[p:to_string()] then
+            log.debug("   yes")
+         else
+            log.debug("   no")
+            table.insert(fs.is_directory(full) and unexpected_directories or unexpected_files, p)
+         end
+      end
+
+      -- sort directory names by length so that more nested directories are removed first
+      table.sort(unexpected_directories, function(a: lexical_path.Path, b: lexical_path.Path): boolean
+         local a_str <const> = a:to_string()
+         local b_str <const> = b:to_string()
+         local a_len <const> = #a_str
+         local b_len <const> = #b_str
+         if a_len ~= b_len then
+            return a_len > b_len
+         end
+         return a_str > b_str
+      end)
+
+      if #unexpected_files > 0 or #unexpected_directories > 0 then
+         if args.prune then
+            local cwd <const> = fs.current_directory()
+            local function prune(p: lexical_path.Path, kind: string)
+               local file <const> = abs_build_dir .. p
+               local disp <const> = display_filename(file)
+               local real <const> = assert(file:relative_to(cwd))
+               local ok <const>, err <const> = os.remove(real:to_string())
+               if ok then
+                  log.info("Pruned ", kind, " ", disp)
+               else
+                  log.err("Unable to prune ", kind, " '", disp, "': ", err)
+               end
+            end
+            for p in ivalues(unexpected_files) do
+               prune(p, "file")
+            end
+            for p in ivalues(unexpected_directories) do
+               prune(p, "directory")
+            end
+         else
+            local strs <const>: {any} = {}
+            for p in ivalues(unexpected_files) do
+               table.insert(strs, "\n   ")
+               table.insert(strs, display_filename(p))
+            end
+            for p in ivalues(unexpected_directories) do
+               table.insert(strs, "\n   ")
+               table.insert(strs, display_filename(p, true))
+            end
+            table.insert(strs, "\nhint: use `cyan build --prune` to automatically delete these files")
+            log.warn("Unexpected files in build directory:", table.unpack(strs))
+         end
+      end
+   end
+
+   if not report_dep_errors(env, source_dir) then
+      log.warn("There were errors in out of project files. Your project may not work as expected.")
+   end
+
+   return exit
+end
+
+command.new{
+   name = "build",
+   description = [[Build a project based on tlconfig.lua.]],
+   exec = build,
+   argparse = function(cmd: argparse.Command)
+      cmd:flag("-u --update-all", "Force recompilation of every file in your project.")
+      cmd:flag("-c --check-only", "Only type check files.")
+      cmd:flag("-p --prune", "Remove any unexpected files in the build directory.")
+   end,
+   script_hooks = { "pre", "post", "file_updated" },
+}

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -1058,6 +1058,13 @@ class TestHeuristics < Minitest::Test
     })
   end
 
+  def test_tl_by_heuristics
+    assert_heuristics({
+      "Teal" => all_fixtures("Teal", "*.tl"),
+      "Type Language" => all_fixtures("Type Language", "*.tl")
+    })
+  end
+
   def test_tlv_by_heuristics
     assert_heuristics({
       "TL-Verilog" => all_fixtures("TL-Verilog", "*.tlv"),

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -611,6 +611,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Tcsh:** [atom/language-shellscript](https://github.com/atom/language-shellscript)
 - **TeX:** [textmate/latex.tmbundle](https://github.com/textmate/latex.tmbundle)
 - **Tea:** [pferruggiaro/sublime-tea](https://github.com/pferruggiaro/sublime-tea)
+- **Teal:** [teal-language/vscode-teal](https://github.com/teal-language/vscode-teal)
 - **Terra:** [pyk/sublime-terra](https://github.com/pyk/sublime-terra)
 - **Terraform Template:** [hashicorp/syntax](https://github.com/hashicorp/syntax)
 - **Texinfo:** [Alhadis/language-texinfo](https://github.com/Alhadis/language-texinfo)

--- a/vendor/licenses/git_submodule/vscode-teal.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-teal.dep.yml
@@ -3,7 +3,7 @@ name: vscode-teal
 version: f4b0541c42a548ab82e34a2bab2dc5fa2cc9454b
 type: git_submodule
 homepage: https://github.com/teal-language/vscode-teal.git
-license: other
+license: mit
 licenses:
 - sources: LICENSE
   text: |-

--- a/vendor/licenses/git_submodule/vscode-teal.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-teal.dep.yml
@@ -1,0 +1,46 @@
+---
+name: vscode-teal
+version: f4b0541c42a548ab82e34a2bab2dc5fa2cc9454b
+type: git_submodule
+homepage: https://github.com/teal-language/vscode-teal.git
+license: other
+licenses:
+- sources: LICENSE
+  text: |-
+    MIT License
+
+    Copyright (c) 2020 Patrick Desaulniers
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+- sources: LICENSE-vscode-extension-samples
+  text: "Copyright (c) Microsoft Corporation\n\nAll rights reserved. \n\nMIT License\n\nPermission
+    is hereby granted, free of charge, to any person obtaining a copy of this software
+    and associated documentation \nfiles (the \"Software\"), to deal in the Software
+    without restriction, including without limitation the rights to use, copy,\nmodify,
+    merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+    to permit persons to whom the Software \nis furnished to do so, subject to the
+    following conditions:\n\nThe above copyright notice and this permission notice
+    shall be included in all copies or substantial portions of the Software.\n\nTHE
+    SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+    INCLUDING BUT NOT LIMITED TO THE WARRANTIES\nOF MERCHANTABILITY, FITNESS FOR A
+    PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS \nBE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT \nOF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+notices: []


### PR DESCRIPTION
See https://teal-language.org

## Description
This PR adds support for the Teal, a statically-typed dialect of Lua.

## Checklist:
- [X] **I am adding a new language.**
  - [X] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  https://github.com/search?q=%22--+%22+%28path%3A*.tl+OR+path%3A*..d.tl%29&type=code&ref=advsearch&p=1 (2.8K files)
  - [X] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/teal-language/cyan/blob/main/src/cyan/commands/build.tl
      - https://github.com/mtdowling/emitter.tl/blob/main/src/emitter.tl
    - Sample license(s): MIT
  - [X] I have included a syntax highlighting grammar: https://github.com/teal-language/vscode-teal
  - [X] I have added a color
    - Hex value: `#00B1BC`
    - Rationale: Teal is teal
  - [X] I have updated the heuristics to distinguish my language from others using the same extension.