### PR TITLE
Update heuristics for ROS Interface

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -57,7 +57,7 @@ disambiguations:
   rules:
   - language: ROS Interface
     and:
-      - pattern: '^[a-z][a-z0-9_]*(?:\/[a-zA-Z]\w*)?(?:<=\d+)?(?:\[(?:<=\d+)?\])?\s+\w+\b'
+      - pattern: '(?i)^[a-z]\w*(?:\/[a-z]\w*)?(?:<=\d+)?(?:\[(?:<=\d+)?\])?\s+\w+\b'
       - pattern: '^---\s*$'
       - negative_pattern: '^\s*[^\s@#\w-]'
 - extensions: ['.al']
@@ -539,7 +539,7 @@ disambiguations:
     pattern: '^cplusplus\(?[\S]*\)?[\s]*\{?\{?|^namespace[\s]+([^.\s]*\.)*[^.\s]*;|^struct[\s]+[\S]+|^message[\s]+[\S]+(extends )?[\S]*[\s]*|^packet[\s]+[\S]+|^class[\s]+[\S]+(extends )?[\S]*[\s]*|^enum[\s]+[\S]+|^import ([^.\s]*\.)*[^.\s]*;'
   - language: ROS Interface
     and:
-      - pattern: '^[a-z][a-z0-9_]*(?:\/[a-zA-Z]\w*)?(?:<=\d+)?(?:\[(?:<=\d+)?\])?\s+\w+\b'
+      - pattern: '(?i)^[a-z]\w*(?:\/[a-z]\w*)?(?:<=\d+)?(?:\[(?:<=\d+)?\])?\s+\w+\b'
       - negative_pattern: '^\s*[^\s@#\w-]'
 - extensions: ['.n']
   rules:
@@ -805,7 +805,7 @@ disambiguations:
   rules:
   - language: ROS Interface
     and:
-      - pattern: '^[a-z][a-z0-9_]*(?:\/[a-zA-Z]\w*)?(?:<=\d+)?(?:\[(?:<=\d+)?\])?\s+\w+\b'
+      - pattern: '(?i)^[a-z]\w*(?:\/[a-z]\w*)?(?:<=\d+)?(?:\[(?:<=\d+)?\])?\s+\w+\b'
       - pattern: '^---\s*$'
       - negative_pattern: '^\s*[^\s@#\w-]'
 - extensions: ['.st']

--- a/samples/ROS Interface/ParameterEventDescriptors.msg
+++ b/samples/ROS Interface/ParameterEventDescriptors.msg
@@ -1,0 +1,9 @@
+# From https://github.com/ros2/rcl_interfaces/blob/1bd7d0b36c79e9e6db6980301f3732fff51ddc50/rcl_interfaces/msg/ParameterEventDescriptors.msg
+
+# This message contains descriptors of a parameter event.
+# It was an atomic update.
+# A specific parameter name can only be in one of the three sets.
+
+ParameterDescriptor[] new_parameters
+ParameterDescriptor[] changed_parameters
+ParameterDescriptor[] deleted_parameters


### PR DESCRIPTION
## Description
Follow-up from https://github.com/github-linguist/linguist/pull/7523. Now that this is deployed I noticed a couple of files that were not properly detected (https://github.com/ros2/rcl_interfaces/blob/rolling/action_msgs/msg/GoalStatusArray.msg, https://github.com/ros2/rcl_interfaces/blob/rolling/rcl_interfaces/msg/ParameterEventDescriptors.msg). This was due to unnecessary case-sensitivity in the herustics.

## Checklist:
- [x] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language:
    - Sample source(s):
      - https://github.com/ros2/rcl_interfaces/blob/1bd7d0b36c79e9e6db6980301f3732fff51ddc50/rcl_interfaces/msg/ParameterEventDescriptors.msg
    - Sample license(s): Apache-2.0
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
