### PR TITLE
add missing extension for C3 language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -886,6 +886,7 @@ C3:
   color: "#2563eb"
   extensions:
   - ".c3"
+  - ".c3i"
   tm_scope: source.c3
   ace_mode: c_cpp
   codemirror_mode: clike


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.c3i
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [webview-c3](https://github.com/thechampagne/webview-c3/)
    - Sample license(s):
      - MIT  
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.