### PR TITLE
Add Txtx Language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1307,6 +1307,9 @@
 [submodule "vendor/grammars/turtle.tmbundle"]
 	path = vendor/grammars/turtle.tmbundle
 	url = https://github.com/peta/turtle.tmbundle
+[submodule "vendor/grammars/txtx-grammar"]
+	path = vendor/grammars/txtx-grammar
+	url = https://github.com/txtx/txtx-grammar.git
 [submodule "vendor/grammars/typespec"]
 	path = vendor/grammars/typespec
 	url = https://github.com/microsoft/typespec.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1162,6 +1162,8 @@ vendor/grammars/toml.tmbundle:
 vendor/grammars/turtle.tmbundle:
 - source.sparql
 - source.turtle
+vendor/grammars/txtx-grammar:
+- source.tx
 vendor/grammars/typespec:
 - source.tsp
 vendor/grammars/typst-grammar:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7909,6 +7909,16 @@ Twig:
   codemirror_mode: twig
   codemirror_mime_type: text/x-twig
   language_id: 377
+Txtx:
+  type: programming
+  color: "#00D992"
+  aliases:
+  - tx
+  extensions:
+  - ".tx"
+  tm_scope: source.tx
+  ace_mode: text
+  language_id: 871036660
 Type Language:
   type: data
   aliases:

--- a/samples/Txtx/bns-registration.tx
+++ b/samples/Txtx/bns-registration.tx
@@ -1,0 +1,54 @@
+addon "stacks" {
+  network_id = input.stacks_network_id
+  rpc_api_url = input.stacks_api_url
+}
+
+signer "alice" "stacks::web_wallet" {
+  expected_address = "ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC"
+}
+
+action "get_name_price" "stacks::call_readonly_fn" {
+  description = "Preorder name"
+  contract_id = "ST000000000000000000002AMW42H.bns"
+  function_name = "get-name-price"
+  function_args = [
+      stacks::cv_buff(encode_hex(variable.namespace)),
+      stacks::cv_buff(encode_hex(variable.name))
+  ]
+  sender = "ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC"
+}
+
+action "send_name_preorder" "stacks::call_contract" {
+  description = "Send Preorder ${variable.name}.${variable.namespace} transaction"
+  contract_id = "ST000000000000000000002AMW42H.bns"
+  function_name = "name-preorder"
+  function_args = [
+      stacks::cv_buff(
+        ripemd160(sha256(
+          [
+            encode_hex("${variable.name}.${variable.namespace}"),
+            encode_hex(variable.salt)
+          ]
+        ))
+      ),
+      stacks::cv_uint(action.get_name_price.value),
+  ]
+  post_condition_mode = "allow"
+  signer = signer.alice
+  confirmations = 1
+}
+
+action "send_name_register" "stacks::call_contract" {
+  description = "Register name"
+  contract_id = "ST000000000000000000002AMW42H.bns"
+  function_name = "name-register"
+  function_args = [
+      stacks::cv_buff(encode_hex(variable.namespace)),
+      stacks::cv_buff(encode_hex(variable.name)),
+      stacks::cv_buff(encode_hex(variable.salt)),
+      stacks::cv_buff(encode_hex(variable.zonefile)),
+  ]
+  signer = signer.alice
+  confirmations = 1
+  depends_on = [action.send_name_preorder]
+}

--- a/samples/Txtx/evm-deployment.tx
+++ b/samples/Txtx/evm-deployment.tx
@@ -1,0 +1,35 @@
+addon "evm" {
+    chain_id = 11155111
+    rpc_api_url = "http://localhost:8545"
+}
+
+signer "alice" "evm::web_wallet" {
+    expected_address = "0xCe246168E59dd8e28e367BB49b38Dc621768F425"
+}
+
+variable "contract" {
+    value = evm::get_contract_from_foundry_project("SimpleStorage")
+}
+
+action "deploy_simple_storage" "evm::deploy_contract_create2" {
+    description = "Deploy SimpleStorage"
+    contract = evm::get_contract_from_foundry_project("SimpleStorage")
+    constructor_args = [14]
+    salt = "0x0000000000000000000000000000000000000000177317f7617d575e615800c7"
+    confirmations = 4
+    signer = signer.alice
+    expected_contract_address = "0x26eA4F95a9D93EB5B97b2cFE6D9D6Dee6DA09E9b"
+}
+
+action "call_simple_storage" "evm::call_contract" {
+    contract_abi = variable.contract.abi
+    contract_address = action.deploy_simple_storage.contract_address
+    function_name = "retrieve"
+    function_args = []
+    confirmations = 4
+    signer = signer.alice
+}
+
+output "contract_address" {
+    value = action.deploy_simple_storage.contract_address
+}

--- a/samples/Txtx/svm-program-deployment.tx
+++ b/samples/Txtx/svm-program-deployment.tx
@@ -1,0 +1,15 @@
+################################################################
+# Manage price-feed deployment through Crypto Infrastructure as Code
+################################################################
+
+addon "svm" {
+    rpc_api_url = input.rpc_api_url
+    network_id = input.network_id
+}
+
+action "deploy_price_feed" "svm::deploy_program" {
+    description = "Deploy price_feed program"
+    program = svm::get_program_from_anchor_project("price_feed")
+    authority = signer.authority
+    payer = signer.payer
+}

--- a/samples/Txtx/svm-pyth-arbitrage.tx
+++ b/samples/Txtx/svm-pyth-arbitrage.tx
@@ -1,0 +1,69 @@
+addon "svm" {
+    rpc_api_url = input.rpc_api_url
+    network_id = input.network_id
+}
+
+variable "program" {
+    value = svm::get_program_from_anchor_project("hello_pyth")
+}
+
+variable "starting_pair" {
+    description = "BTC/USD"
+    value = "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo"
+    editable = true
+}
+
+variable "starting_pair_feed_id" {
+    description = "BTC/USD feed ID"
+    value = "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43"
+    editable = true
+}
+
+variable "bridging_pair" {
+    description = "ETH/BTC"
+    value = "5JwbqPPMNpzE2jVAdobWo6m5gkhsDhRdGBo3FYbSfmaK"
+    editable = true
+}
+
+variable "bridging_pair_feed_id" {
+    description = "ETH/BTC feed ID"
+    value = "0xc96458d393fe9deb7a7d63a0ac41e2898a67a7750dbd166673279e06c868df0a"
+    editable = true
+}
+
+variable "crossing_pair" {
+    description = "ETH/USD"
+    value = "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC"
+    editable = true
+}
+
+variable "crossing_pair_feed_id" {
+    description = "ETH/USD feed ID"
+    value = "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
+    editable = true
+}
+
+action "call" "svm::process_instructions" {
+    signers = [signer.caller]
+    instruction {
+        program_idl = variable.program.idl
+        instruction_name = "update_triangular_arbitrage"
+        instruction_args = [
+            variable.starting_pair_feed_id,
+            variable.bridging_pair_feed_id,
+            variable.crossing_pair_feed_id,
+        ]
+        sender {
+            public_key = signer.caller.public_key
+        }
+        starting_pair_account {
+            public_key = variable.starting_pair
+        }
+        bridging_pair_account {
+            public_key = variable.bridging_pair
+        }
+        crossing_pair_account {
+            public_key = variable.crossing_pair
+        }
+    }
+}

--- a/samples/Txtx/svm-swap-clmm.tx
+++ b/samples/Txtx/svm-swap-clmm.tx
@@ -1,0 +1,163 @@
+################################################################
+# Swap on Raydium CLMM (v3) - Concentrated Liquidity
+#
+# This runbook executes a swap on a Raydium CLMM pool.
+# CLMM uses concentrated liquidity similar to Uniswap v3.
+################################################################
+
+addon "svm" {
+    rpc_api_url = input.rpc_api_url
+    network_id = input.network_id
+}
+
+signer "user" "svm::secret_key" {
+    description = "The account executing the swap"
+    keypair_json = "~/.config/solana/id.json"
+}
+
+variable "program" {
+    description = "The raydium_arbitrage program"
+    value = svm::get_program_from_anchor_project("raydium_arbitrage")
+}
+
+# Token configuration
+variable "input_mint" {
+    description = "Input token mint address"
+    editable = true
+}
+
+variable "output_mint" {
+    description = "Output token mint address"
+    editable = true
+}
+
+# CLMM Pool configuration
+variable "pool_state" {
+    description = "CLMM pool state account"
+    editable = true
+}
+
+variable "amm_config" {
+    description = "CLMM AMM config account"
+    editable = true
+}
+
+variable "input_vault" {
+    description = "CLMM input token vault"
+    editable = true
+}
+
+variable "output_vault" {
+    description = "CLMM output token vault"
+    editable = true
+}
+
+variable "observation_state" {
+    description = "CLMM oracle observation state"
+    editable = true
+}
+
+# Swap parameters
+variable "amount" {
+    description = "Amount to swap (in smallest units)"
+    value = 1000000000
+    editable = true
+}
+
+variable "other_amount_threshold" {
+    description = "Minimum output or maximum input (depending on is_base_input)"
+    value = 0
+    editable = true
+}
+
+variable "sqrt_price_limit_x64" {
+    description = "Price limit for the swap (0 for no limit)"
+    value = 0
+    editable = true
+}
+
+variable "is_base_input" {
+    description = "True for exact input swap, false for exact output"
+    value = true
+    editable = true
+}
+
+# Programs
+variable "token_program" {
+    value = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+}
+
+variable "token_program_2022" {
+    value = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+}
+
+variable "memo_program" {
+    value = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+}
+
+variable "clmm_program" {
+    value = "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK"
+}
+
+action "swap_clmm" "svm::process_instructions" {
+    description = "Execute CLMM swap"
+    signers = [signer.user]
+
+    instruction {
+        program_idl = variable.program.idl
+        instruction_name = "swap_clmm"
+        instruction_args = [
+            variable.amount,
+            variable.other_amount_threshold,
+            variable.sqrt_price_limit_x64,
+            variable.is_base_input
+        ]
+
+        payer {
+            public_key = signer.user.public_key
+        }
+        amm_config {
+            public_key = variable.amm_config
+        }
+        pool_state {
+            public_key = variable.pool_state
+        }
+        input_token_account {
+            public_key = svm::get_associated_token_address(signer.user.public_key, variable.input_mint)
+        }
+        output_token_account {
+            public_key = svm::get_associated_token_address(signer.user.public_key, variable.output_mint)
+        }
+        input_vault {
+            public_key = variable.input_vault
+        }
+        output_vault {
+            public_key = variable.output_vault
+        }
+        observation_state {
+            public_key = variable.observation_state
+        }
+        token_program {
+            public_key = variable.token_program
+        }
+        token_program_2022 {
+            public_key = variable.token_program_2022
+        }
+        memo_program {
+            public_key = variable.memo_program
+        }
+        input_vault_mint {
+            public_key = variable.input_mint
+        }
+        output_vault_mint {
+            public_key = variable.output_mint
+        }
+        clmm_program {
+            public_key = variable.clmm_program
+        }
+    }
+}
+
+output "signature" {
+    value = action.swap_clmm.signature
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -631,6 +631,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Turing:** [Alhadis/language-turing](https://github.com/Alhadis/language-turing)
 - **Turtle:** [peta/turtle.tmbundle](https://github.com/peta/turtle.tmbundle)
 - **Twig:** [Anomareh/PHP-Twig.tmbundle](https://github.com/Anomareh/PHP-Twig.tmbundle)
+- **Txtx:** [txtx/txtx-grammar](https://github.com/txtx/txtx-grammar)
 - **Type Language:** [goodmind/language-typelanguage](https://github.com/goodmind/language-typelanguage)
 - **TypeScript:** [tree-sitter/tree-sitter-typescript](https://github.com/tree-sitter/tree-sitter-typescript) 🐌
 - **TypeSpec:** [microsoft/typespec](https://github.com/microsoft/typespec)

--- a/vendor/licenses/git_submodule/txtx-grammar.dep.yml
+++ b/vendor/licenses/git_submodule/txtx-grammar.dep.yml
@@ -1,0 +1,387 @@
+---
+name: txtx-grammar
+version: 712048d64a8dda0344c713ff814a268b617dc563
+type: git_submodule
+homepage: https://github.com/txtx/txtx-grammar.git
+license: mpl-2.0
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2022 HashiCorp, Inc.
+
+    Mozilla Public License Version 2.0
+    ==================================
+
+    1. Definitions
+    --------------
+
+    1.1. "Contributor"
+        means each individual or legal entity that creates, contributes to
+        the creation of, or owns Covered Software.
+
+    1.2. "Contributor Version"
+        means the combination of the Contributions of others (if any) used
+        by a Contributor and that particular Contributor's Contribution.
+
+    1.3. "Contribution"
+        means Covered Software of a particular Contributor.
+
+    1.4. "Covered Software"
+        means Source Code Form to which the initial Contributor has attached
+        the notice in Exhibit A, the Executable Form of such Source Code
+        Form, and Modifications of such Source Code Form, in each case
+        including portions thereof.
+
+    1.5. "Incompatible With Secondary Licenses"
+        means
+
+        (a) that the initial Contributor has attached the notice described
+            in Exhibit B to the Covered Software; or
+
+        (b) that the Covered Software was made available under the terms of
+            version 1.1 or earlier of the License, but not also under the
+            terms of a Secondary License.
+
+    1.6. "Executable Form"
+        means any form of the work other than Source Code Form.
+
+    1.7. "Larger Work"
+        means a work that combines Covered Software with other material, in
+        a separate file or files, that is not Covered Software.
+
+    1.8. "License"
+        means this document.
+
+    1.9. "Licensable"
+        means having the right to grant, to the maximum extent possible,
+        whether at the time of the initial grant or subsequently, any and
+        all of the rights conveyed by this License.
+
+    1.10. "Modifications"
+        means any of the following:
+
+        (a) any file in Source Code Form that results from an addition to,
+            deletion from, or modification of the contents of Covered
+            Software; or
+
+        (b) any new file in Source Code Form that contains any Covered
+            Software.
+
+    1.11. "Patent Claims" of a Contributor
+        means any patent claim(s), including without limitation, method,
+        process, and apparatus claims, in any patent Licensable by such
+        Contributor that would be infringed, but for the grant of the
+        License, by the making, using, selling, offering for sale, having
+        made, import, or transfer of either its Contributions or its
+        Contributor Version.
+
+    1.12. "Secondary License"
+        means either the GNU General Public License, Version 2.0, the GNU
+        Lesser General Public License, Version 2.1, the GNU Affero General
+        Public License, Version 3.0, or any later versions of those
+        licenses.
+
+    1.13. "Source Code Form"
+        means the form of the work preferred for making modifications.
+
+    1.14. "You" (or "Your")
+        means an individual or a legal entity exercising rights under this
+        License. For legal entities, "You" includes any entity that
+        controls, is controlled by, or is under common control with You. For
+        purposes of this definition, "control" means (a) the power, direct
+        or indirect, to cause the direction or management of such entity,
+        whether by contract or otherwise, or (b) ownership of more than
+        fifty percent (50%) of the outstanding shares or beneficial
+        ownership of such entity.
+
+    2. License Grants and Conditions
+    --------------------------------
+
+    2.1. Grants
+
+    Each Contributor hereby grants You a world-wide, royalty-free,
+    non-exclusive license:
+
+    (a) under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+    (b) under Patent Claims of such Contributor to make, use, sell, offer
+        for sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+    2.2. Effective Date
+
+    The licenses granted in Section 2.1 with respect to any Contribution
+    become effective for each Contribution on the date the Contributor first
+    distributes such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+    The licenses granted in this Section 2 are the only rights granted under
+    this License. No additional rights or licenses will be implied from the
+    distribution or licensing of Covered Software under this License.
+    Notwithstanding Section 2.1(b) above, no patent license is granted by a
+    Contributor:
+
+    (a) for any code that a Contributor has removed from Covered Software;
+        or
+
+    (b) for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+    (c) under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+    This License does not grant any rights in the trademarks, service marks,
+    or logos of any Contributor (except as may be necessary to comply with
+    the notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+    No Contributor makes additional grants as a result of Your choice to
+    distribute the Covered Software under a subsequent version of this
+    License (see Section 10.2) or under the terms of a Secondary License (if
+    permitted under the terms of Section 3.3).
+
+    2.5. Representation
+
+    Each Contributor represents that the Contributor believes its
+    Contributions are its original creation(s) or it has sufficient rights
+    to grant the rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+    This License is not intended to limit any rights You have under
+    applicable copyright doctrines of fair use, fair dealing, or other
+    equivalents.
+
+    2.7. Conditions
+
+    Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+    in Section 2.1.
+
+    3. Responsibilities
+    -------------------
+
+    3.1. Distribution of Source Form
+
+    All distribution of Covered Software in Source Code Form, including any
+    Modifications that You create or to which You contribute, must be under
+    the terms of this License. You must inform recipients that the Source
+    Code Form of the Covered Software is governed by the terms of this
+    License, and how they can obtain a copy of this License. You may not
+    attempt to alter or restrict the recipients' rights in the Source Code
+    Form.
+
+    3.2. Distribution of Executable Form
+
+    If You distribute Covered Software in Executable Form then:
+
+    (a) such Covered Software must also be made available in Source Code
+        Form, as described in Section 3.1, and You must inform recipients of
+        the Executable Form how they can obtain a copy of such Source Code
+        Form by reasonable means in a timely manner, at a charge no more
+        than the cost of distribution to the recipient; and
+
+    (b) You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter
+        the recipients' rights in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+    You may create and distribute a Larger Work under terms of Your choice,
+    provided that You also comply with the requirements of this License for
+    the Covered Software. If the Larger Work is a combination of Covered
+    Software with a work governed by one or more Secondary Licenses, and the
+    Covered Software is not Incompatible With Secondary Licenses, this
+    License permits You to additionally distribute such Covered Software
+    under the terms of such Secondary License(s), so that the recipient of
+    the Larger Work may, at their option, further distribute the Covered
+    Software under the terms of either this License or such Secondary
+    License(s).
+
+    3.4. Notices
+
+    You may not remove or alter the substance of any license notices
+    (including copyright notices, patent notices, disclaimers of warranty,
+    or limitations of liability) contained within the Source Code Form of
+    the Covered Software, except that You may alter any license notices to
+    the extent required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+    You may choose to offer, and to charge a fee for, warranty, support,
+    indemnity or liability obligations to one or more recipients of Covered
+    Software. However, You may do so only on Your own behalf, and not on
+    behalf of any Contributor. You must make it absolutely clear that any
+    such warranty, support, indemnity, or liability obligation is offered by
+    You alone, and You hereby agree to indemnify every Contributor for any
+    liability incurred by such Contributor as a result of warranty, support,
+    indemnity or liability terms You offer. You may include additional
+    disclaimers of warranty and limitations of liability specific to any
+    jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+    ---------------------------------------------------
+
+    If it is impossible for You to comply with any of the terms of this
+    License with respect to some or all of the Covered Software due to
+    statute, judicial order, or regulation then You must: (a) comply with
+    the terms of this License to the maximum extent possible; and (b)
+    describe the limitations and the code they affect. Such description must
+    be placed in a text file included with all distributions of the Covered
+    Software under this License. Except to the extent prohibited by statute
+    or regulation, such description must be sufficiently detailed for a
+    recipient of ordinary skill to be able to understand it.
+
+    5. Termination
+    --------------
+
+    5.1. The rights granted under this License will terminate automatically
+    if You fail to comply with any of its terms. However, if You become
+    compliant, then the rights granted under this License from a particular
+    Contributor are reinstated (a) provisionally, unless and until such
+    Contributor explicitly and finally terminates Your grants, and (b) on an
+    ongoing basis, if such Contributor fails to notify You of the
+    non-compliance by some reasonable means prior to 60 days after You have
+    come back into compliance. Moreover, Your grants from a particular
+    Contributor are reinstated on an ongoing basis if such Contributor
+    notifies You of the non-compliance by some reasonable means, this is the
+    first time You have received notice of non-compliance with this License
+    from such Contributor, and You become compliant prior to 30 days after
+    Your receipt of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+    infringement claim (excluding declaratory judgment actions,
+    counter-claims, and cross-claims) alleging that a Contributor Version
+    directly or indirectly infringes any patent, then the rights granted to
+    You by any and all Contributors for the Covered Software under Section
+    2.1 of this License shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+    end user license agreements (excluding distributors and resellers) which
+    have been validly granted by You or Your distributors under this License
+    prior to termination shall survive termination.
+
+    ************************************************************************
+    *                                                                      *
+    *  6. Disclaimer of Warranty                                           *
+    *  -------------------------                                           *
+    *                                                                      *
+    *  Covered Software is provided under this License on an "as is"       *
+    *  basis, without warranty of any kind, either expressed, implied, or  *
+    *  statutory, including, without limitation, warranties that the       *
+    *  Covered Software is free of defects, merchantable, fit for a        *
+    *  particular purpose or non-infringing. The entire risk as to the     *
+    *  quality and performance of the Covered Software is with You.        *
+    *  Should any Covered Software prove defective in any respect, You     *
+    *  (not any Contributor) assume the cost of any necessary servicing,   *
+    *  repair, or correction. This disclaimer of warranty constitutes an   *
+    *  essential part of this License. No use of any Covered Software is   *
+    *  authorized under this License except under this disclaimer.         *
+    *                                                                      *
+    ************************************************************************
+
+    ************************************************************************
+    *                                                                      *
+    *  7. Limitation of Liability                                          *
+    *  --------------------------                                          *
+    *                                                                      *
+    *  Under no circumstances and under no legal theory, whether tort      *
+    *  (including negligence), contract, or otherwise, shall any           *
+    *  Contributor, or anyone who distributes Covered Software as          *
+    *  permitted above, be liable to You for any direct, indirect,         *
+    *  special, incidental, or consequential damages of any character      *
+    *  including, without limitation, damages for lost profits, loss of    *
+    *  goodwill, work stoppage, computer failure or malfunction, or any    *
+    *  and all other commercial damages or losses, even if such party      *
+    *  shall have been informed of the possibility of such damages. This   *
+    *  limitation of liability shall not apply to liability for death or   *
+    *  personal injury resulting from such party's negligence to the       *
+    *  extent applicable law prohibits such limitation. Some               *
+    *  jurisdictions do not allow the exclusion or limitation of           *
+    *  incidental or consequential damages, so this exclusion and          *
+    *  limitation may not apply to You.                                    *
+    *                                                                      *
+    ************************************************************************
+
+    8. Litigation
+    -------------
+
+    Any litigation relating to this License may be brought only in the
+    courts of a jurisdiction where the defendant maintains its principal
+    place of business and such litigation shall be governed by laws of that
+    jurisdiction, without reference to its conflict-of-law provisions.
+    Nothing in this Section shall prevent a party's ability to bring
+    cross-claims or counter-claims.
+
+    9. Miscellaneous
+    ----------------
+
+    This License represents the complete agreement concerning the subject
+    matter hereof. If any provision of this License is held to be
+    unenforceable, such provision shall be reformed only to the extent
+    necessary to make it enforceable. Any law or regulation which provides
+    that the language of a contract shall be construed against the drafter
+    shall not be used to construe this License against a Contributor.
+
+    10. Versions of the License
+    ---------------------------
+
+    10.1. New Versions
+
+    Mozilla Foundation is the license steward. Except as provided in Section
+    10.3, no one other than the license steward has the right to modify or
+    publish new versions of this License. Each version will be given a
+    distinguishing version number.
+
+    10.2. Effect of New Versions
+
+    You may distribute the Covered Software under the terms of the version
+    of the License under which You originally received the Covered Software,
+    or under the terms of any subsequent version published by the license
+    steward.
+
+    10.3. Modified Versions
+
+    If you create software not governed by this License, and you want to
+    create a new license for such software, you may create and use a
+    modified version of this License if you rename the license and remove
+    any references to the name of the license steward (except to note that
+    such modified license differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary
+    Licenses
+
+    If You choose to distribute Source Code Form that is Incompatible With
+    Secondary Licenses under the terms of this version of the License, the
+    notice described in Exhibit B of this License must be attached.
+
+    Exhibit A - Source Code Form License Notice
+    -------------------------------------------
+
+      This Source Code Form is subject to the terms of the Mozilla Public
+      License, v. 2.0. If a copy of the MPL was not distributed with this
+      file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular
+    file, then You may include the notice in a location (such as a LICENSE
+    file in a relevant directory) where a recipient would be likely to look
+    for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - "Incompatible With Secondary Licenses" Notice
+    ---------------------------------------------------------
+
+      This Source Code Form is "Incompatible With Secondary Licenses", as
+      defined by the Mozilla Public License, v. 2.0.
+- sources: README.md
+  text: MPL-2.0
+notices: []


### PR DESCRIPTION
## Description

This PR adds support for **Txtx**, a declarative language for Web3 smart contract runbooks. Txtx is to Web3 what HashiCorp Terraform is to cloud infrastructure management - it provides infrastructure-as-code for blockchain operations, enabling developers to deploy and operate smart contracts across multiple chains (Ethereum, Solana, Stacks, and more) with enhanced security, composability, and reproducibility.

**Resources:**
- Main repository: https://github.com/txtx/surfpool, https://github.com/txtx/txtx
- Documentation: https://docs.surfpool.run, https://docs.txtx.sh
- VS Code extension: https://marketplace.visualstudio.com/items?itemName=txtx.txtx

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - `.tx` : https://github.com/search?type=code&q=path%3A**%2Frunbooks%2F**%2F*.tx
      - Note: Searching for `*.tx` alone matches `*.txt` files. Txtx projects conventionally place runbooks in `runbooks/*/*.tx` paths. Approximately 1/4 of Txtx projects are public; the majority are private due to the nature of blockchain infrastructure management (deployment scripts, wallet configurations, etc.).
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - Samples were written specifically for this PR to demonstrate different blockchain ecosystems:
        - `bns-registration.tx` - Stacks BNS name registration
        - `evm-deployment.tx` - EVM smart contract deployment
        - `svm-program-deployment.tx` - Solana program deployment
        - `svm-pyth-arbitrage.tx` - Solana Pyth oracle integration
        - `svm-swap-clmm.tx` - Raydium DEX swap operations
    - Sample license(s): MIT
  - [x] I have included a syntax highlighting grammar: https://github.com/txtx/txtx-grammar
  - [x] I have added a color
    - Hex value: `#00D992`
    - Rationale: This is the official Txtx brand color, used consistently across the txtx.sh website and VS Code extension.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
    - Note: The `.tx` extension does not currently conflict with other languages in Linguist. The `.txtx` extension is unique to Txtx. If heuristics are needed, Txtx files can be identified by their HCL-like syntax with blockchain-specific keywords (`action`, `signer`, `variable`, `output`, `addon`).
