### PR TITLE
Make `get_tree_size` robust against git bombs

### DIFF
--- a/lib/linguist/source/rugged.rb
+++ b/lib/linguist/source/rugged.rb
@@ -44,7 +44,31 @@ module Linguist
       end
 
       def get_tree_size(commit_id, limit)
-        get_tree(commit_id).count_recursive(limit)
+        tree = get_tree(commit_id)
+        tree_count = 0
+        count = 0
+        stack = [tree.each]
+
+        while !stack.empty?
+          begin
+            entry = stack.last.next
+          rescue StopIteration
+            stack.pop
+            next
+          end
+
+          if entry[:type] == :tree
+            tree_count += 1
+            return limit if tree_count >= limit
+            subtree = @rugged.lookup(entry[:oid])
+            stack.push(subtree.each)
+          else
+            count += 1
+            return limit if count >= limit
+          end
+        end
+
+        count
       end
 
       def set_attribute_source(commit_id)

--- a/lib/linguist/source/rugged.rb
+++ b/lib/linguist/source/rugged.rb
@@ -44,28 +44,19 @@ module Linguist
       end
 
       def get_tree_size(commit_id, limit)
-        tree = get_tree(commit_id)
         tree_count = 0
         count = 0
-        stack = [tree.each]
 
-        while !stack.empty?
-          begin
-            entry = stack.last.next
-          rescue StopIteration
-            stack.pop
-            next
-          end
-
-          if entry[:type] == :tree
-            tree_count += 1
-            return limit if tree_count >= limit
-            subtree = @rugged.lookup(entry[:oid])
-            stack.push(subtree.each)
-          else
+        get_tree(commit_id).walk(:preorder) do |root, entry|
+          case entry[:type]
+          when :blob
             count += 1
             return limit if count >= limit
+          when :tree
+            tree_count += 1
+            return limit if tree_count >= limit
           end
+          true
         end
 
         count


### PR DESCRIPTION
## Description

For pathological repositories like git bombs with deeply nested tree structures, Rugged's `count_recursive` method can hang indefinitely even with a file limit, because it has to visit every tree object to find and count the blobs. See libgit2/rugged#995.

That causes `RuggedRepository#get_tree_size` to hang, so `git-linguist stats` can hang.

This PR works around that issue by using a custom count method that also applies a tree limit, so that it terminates promptly regardless of repository structure. The return value is still the blob count for normal repos, preserving existing behavior.

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.
