### PR TITLE
Add ENGCODE programming language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -9275,3 +9275,12 @@ xBase:
   tm_scope: source.harbour
   ace_mode: text
   language_id: 421
+ENGCODE:
+  type: programming
+  extensions:
+    - ".eng"
+    - ".engb"
+  color: "#00ff88"
+  ace_mode: text
+  interpreters:
+    - engcode


### PR DESCRIPTION
ENGCODE is a programming language with .eng source files and .engb bytecode files.
Dynamically fetches English words from GitHub JSON repo for commands.