### PR TITLE
a languaje called e4asm has been added

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -1434,3 +1434,15 @@ vendor/grammars/zenstack:
 - source.zmodel
 vendor/grammars/zephir-sublime:
 - source.php.zephir
+e4asm:
+  type: programming
+  aliases:
+    - e4asm
+  extensions:
+    - .e4asm
+  tm_scope: source.e4asm
+  ace_mode: text
+  colorize: true
+  fs_name: e4asm
+  grammar: vendor/grammars/e4asm.tmLanguage.json
+  color: "#6E4C13"

--- a/samples/e4asm/stru.e4asm
+++ b/samples/e4asm/stru.e4asm
@@ -1,0 +1,37 @@
+
+; ** ultrahla.e4asm **
+
+; persona
+stru Persona {
+    ; puntero al nombre
+    .Nombre db 4
+    ; u8 de edad, por que quien puede
+    ; tener -1 años, y aparte quien puede 
+    ; aguantar mas de 255 dias
+    .Edad db 1
+}
+
+; salario
+stru Salario {
+    ; nadie puede tener mas que un u32 o si? aparte
+    ; no te pueden quitar dinero
+    .SalarioPorCadaDias db 4
+    ; cada cuantos dias
+    .SalarioCadaCuantos db 1
+}
+
+; un trabajador
+imp Trabajador {
+    ; implementa estructura de persona
+    imps stru Persona
+    ; implementar salario
+    imps stru Salario
+}
+
+; implementar el trabajador
+imp Trabajador at Pablo
+
+; el salario por cada cuantos dias
+Pablo.SalarioPorCadaDias = (dword)10
+; cada cuantos se da salario
+Pablo.SalarioCadaCuantos = (byte)2

--- a/vendor/grammars/e4asm/e4asm.tmLanguage.json
+++ b/vendor/grammars/e4asm/e4asm.tmLanguage.json
@@ -1,0 +1,160 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "e4asm",
+	"patterns": [
+		{
+			"include": "#keywords"
+		},
+		{
+			"include": "#strings"
+		},
+		{
+			"include": "#comments"
+		},
+		{
+			"include": "#methods"
+		},
+		{
+			"include": "#registers"
+		},
+		{
+			"include": "#numbers"
+		},
+		{
+			"include": "#modules"
+		},
+		{
+			"include": "#propietys"
+		},
+		{
+			"include": "#functions"
+		},
+		{
+			"include": "#ultra_hla"
+		},
+		{
+			"name": "variable.e4asm",
+			"match": "\\w"
+		}
+	],
+	"repository": {
+		"ultra_hla": {
+			"patterns": [
+				{
+					"name": "constant.language.e4asm",
+					"match": "\\b(stru|imp|at|imps)\\b"
+				},
+				{
+					"name": "entity.name.class.e4asm",
+					"match": "(?<=\\bstru\\b\\s+)\\w+"
+				},
+				{
+					"name": "entity.name.type.struct.e4asm",
+					"match": "(?<=\\bimp\\b\\s+)\\w+"
+				}
+			]	
+		},
+		"functions": {
+			"name": "entity.name.function.e4asm",
+			"match": "(?<=\\b(label|call|cq|cnq|cg|cng)\\b)\\s+(\\w+)"
+		},
+		"keywords": {
+			"patterns": [{
+				"name": "keyword.control.e4asm",
+				"match": "\\b(mov|add|sub|div|mul|ret|call|cq|cnq|cg|cng|pub|pul|gub|gul|ivar|push|pop|loop|inc|dec|in|out|sti|cli|hlt|cmp|shl|shr)\\b"
+			}]
+		},
+		"modules": {
+			"comment": "se que es ensamblador pero tambien puedo darle sus gustos",
+			"patterns": [
+				{
+					"name": "keyword.control.e4asm",
+					"match": "\\b(import)\\b(?=\\s+<-\\s+\\w+)"
+				},
+				{
+					"name": "keyword.control.e4asm",
+					"match": "\\b(namespace)\\b(?=\\s+\\w+\\s+<-\\s+\\w+)"
+				},
+				{
+					"name": "entity.name.class.e4asm",
+					"match": "(?<=\\bnamespace\\b\\s+)\\w+(?=\\s*<-)"
+				},
+				{
+					"name": "entity.name.class.e4asm",
+					"match": "(?<=\\bnamespace\\b\\s+\\w+\\s+<-\\s*)[\\w.]+"
+				},
+				{
+					"name": "entity.name.class.e4asm",
+					"match": "(?<=\\bimport\\b\\s+<-\\s*)\\w+(?:.\\w+)*"
+				},
+				{
+					"name": "entity.name.class.e4asm",
+					"match": "(?<=\\bimport\\b\\s+<-\\s*)\\w+"
+				}
+			]
+		},
+		"comments":{
+			"patterns": [{
+				"name": "comment.line",
+				"begin": ";",
+				"end": "\n"
+			}]
+		},
+		"propietys":{
+			"patterns": [
+				{
+					"name": "entity.name.function.e4asm",
+					"match": "(?<=@)\\b(for|impl_begins|impl_ends)\\b"
+				},
+				{
+					"name": "entity.name.class.e4asm",
+					"match": "(?<=@)\\w+"
+				}
+			]
+		},
+		"methods": {
+			"patterns": [{
+				"name": "constant.language.e4asm",
+				"match": "\\b(label|align|db|byte|dword|org)\\b"
+			}]
+		},
+		"registers": {
+			"patterns": [{
+				"name": "storage.type.e4asm",
+				"match": "\\b(a|b|c|d|e|f|cycl|off|ds|sp)\\b"
+			}]
+		},
+		"strings": {
+			"name": "string.quoted.double.e4asm",
+			"begin": "'",
+			"end": "'",
+			"patterns": [
+				{
+					"name": "constant.character.escape.e4asm",
+					"match": "\\\\."
+				}
+			]
+		},
+		"numbers": {
+			"patterns": [
+				{
+				"name": "constant.numeric.hex.e4asm",
+				"match": "\\b0x[0-9A-Fa-f]+\\b"
+				},
+				{
+				"name": "constant.numeric.decimal.e4asm",
+				"match": "\\b[0-9]+\\b"
+				},
+				{
+				"name": "constant.numeric.hexsuffix.e4asm",
+				"match": "\\b[0-9A-Fa-f]+h\\b"
+				},
+				{
+				"name": "constant.numeric.binary.e4asm",
+				"match": "\\b[01]+b\\b"
+				}
+			]
+		}
+	},
+	"scopeName": "source.e4asm"
+}


### PR DESCRIPTION
## Summary

This PR adds support for the **E4ASM** language to GitHub Linguist.

## Changes

* Added `E4ASM` entry to `languages.yml` (alphabetically sorted).
* Registered grammar in `grammars.yml`.
* Added sample file under `samples/e4asm/stru.e4asm`.

## Motivation

E4ASM is a custom assembly-like language created for [your project name].  
Adding it to Linguist allows GitHub repositories containing `.e4asm` files to be properly detected and highlighted.

## Checklist

- [x] `languages.yml` updated and alphabetically sorted
- [x] `grammars.yml` updated and alphabetically sorted
- [x] Sample file added under `samples/`
- [x] `bundle exec rake test` passes locally