### PR TITLE
Add Emojicode language support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2065,6 +2065,13 @@ EmberScript:
   codemirror_mode: coffeescript
   codemirror_mime_type: text/x-coffeescript
   language_id: 103
+Emojicode:
+  type: programming
+  extensions:
+    - ".emojic"
+    - ".🍇"
+  tm_scope: none
+  ace_mode: text
 Erlang:
   type: programming
   color: "#B83998"


### PR DESCRIPTION
Adds Emojicode to GitHub Linguist with file extensions `.emojic` and `.🍇`.
This helps GitHub recognize Emojicode files and apply syntax highlighting.
Closes #7789
