### PR TITLE
Add `py` and `py3` to Python aliases

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6139,6 +6139,7 @@ Python:
   - pypy3
   - uv
   aliases:
+  - py
   - python3
   - rusthon
   language_id: 303

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6140,6 +6140,7 @@ Python:
   - uv
   aliases:
   - py
+  - py3
   - python3
   - rusthon
   language_id: 303


### PR DESCRIPTION
## Summary

Add `py` as an alias for Python, matching how other popular languages handle short aliases.

## Motivation

Python is the only major language without its common short alias:

| Language | Short Alias |
|----------|-------------|
| JavaScript | `js` ✅ |
| TypeScript | `ts` ✅ |
| Ruby | `rb` ✅ |
| Rust | `rs` ✅ |
| Python | `py` ❌ |

In #4026 (2018), adding `py` was discussed and the response was:

> "Let's keep the `python3` alias only for now. We can always add new aliases if/when we see them being used."

Seven years later, `py` is extensively used in code blocks across GitHub. The alias is so expected that GitHub's markdown renderer added extension-based fallback to support ` ```py ` even without it being an official alias.

## Impact

- Tools using Linguist's `find_by_alias()` will recognize `py`
- Aligns official aliases with GitHub's rendering behavior
- Zero risk: no other language uses `py`

## Changes

Add `py` to the Python aliases in `lib/linguist/languages.yml`.