### PR TITLE
Update Astro grammar source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -295,7 +295,7 @@
 	url = https://github.com/nanoant/assembly.tmbundle
 [submodule "vendor/grammars/astro"]
 	path = vendor/grammars/astro
-	url = https://github.com/withastro/language-tools.git
+	url = https://github.com/withastro/astro.git
 [submodule "vendor/grammars/atom-editorconfig"]
 	path = vendor/grammars/atom-editorconfig
 	url = https://github.com/sindresorhus/atom-editorconfig

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -44,7 +44,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **AsciiDoc:** [zuckschwerdt/asciidoc.tmbundle](https://github.com/zuckschwerdt/asciidoc.tmbundle)
 - **AspectJ:** [pchaigno/sublime-aspectj](https://github.com/pchaigno/sublime-aspectj)
 - **Assembly:** [Nessphoro/sublimeassembly](https://github.com/Nessphoro/sublimeassembly)
-- **Astro:** [withastro/language-tools](https://github.com/withastro/language-tools)
+- **Astro:** [withastro/astro](https://github.com/withastro/astro)
 - **Asymptote:** [mikomikotaishi/c.tmbundle](https://github.com/mikomikotaishi/c.tmbundle)
 - **AutoHotkey:** [ahkscript/SublimeAutoHotkey](https://github.com/ahkscript/SublimeAutoHotkey)
 - **AutoIt:** [AutoIt/SublimeAutoItScript](https://github.com/AutoIt/SublimeAutoItScript)

--- a/vendor/licenses/git_submodule/astro.dep.yml
+++ b/vendor/licenses/git_submodule/astro.dep.yml
@@ -1,15 +1,15 @@
 ---
 name: astro
-version: b4bcb4fc02cd960936a5faee6c9cc0ad94fc4c05
+version: 2c6484a4c34e86b8a26342a48986da26768de27b
 type: git_submodule
-homepage: https://github.com/withastro/language-tools.git
-license: mit
+homepage: https://github.com/withastro/astro.git
+license: other
 licenses:
 - sources: LICENSE
   text: |
     MIT License
 
-    Copyright (c) 2022 The Astro Technology Company
+    Copyright (c) 2021 Fred K. Schott
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
@@ -28,4 +28,42 @@ licenses:
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
+
+    """
+    This license applies to parts of the `packages/create-astro` and `packages/astro` subdirectories originating from the https://github.com/sveltejs/kit repository:
+
+    Copyright (c) 2020 [these people](https://github.com/sveltejs/kit/graphs/contributors)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    """
+
+    """
+    This license applies to parts of the `packages/create-astro` and `packages/astro` subdirectories originating from the https://github.com/vitejs/vite repository:
+
+    MIT License
+
+    Copyright (c) 2019-present, Yuxi (Evan) You and Vite contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+    """
 notices: []

--- a/vendor/licenses/git_submodule/astro.dep.yml
+++ b/vendor/licenses/git_submodule/astro.dep.yml
@@ -3,7 +3,7 @@ name: astro
 version: 2c6484a4c34e86b8a26342a48986da26768de27b
 type: git_submodule
 homepage: https://github.com/withastro/astro.git
-license: other
+license: mit
 licenses:
 - sources: LICENSE
   text: |


### PR DESCRIPTION

## Description

Hello! We merged our language-tools repo at Astro into our Astro monorepo, as such the location of the grammar has now changed. I've updated all the paths to point to the new repo.

## Checklist:

- [x] **I am changing the source of a syntax highlighting grammar**
  - Old: https://github.com/withastro/language-tools
  - New: https://github.com/withastro/astro

- [x] **I am updating a grammar submodule**
