### PR TITLE
Add support for `Eask` files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2033,6 +2033,8 @@ Emacs Lisp:
   tm_scope: source.emacs.lisp
   color: "#c065db"
   aliases:
+  - cask
+  - eask
   - elisp
   - emacs
   filenames:
@@ -2043,6 +2045,7 @@ Emacs Lisp:
   - ".spacemacs"
   - ".viper"
   - Cask
+  - Eask
   - Project.ede
   - _emacs
   - abbrev_defs

--- a/samples/Emacs Lisp/filenames/Eask
+++ b/samples/Emacs Lisp/filenames/Eask
@@ -1,0 +1,21 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
+(package "composer"
+         "0.2.0"
+         "Interface to PHP Composer")
+
+(website-url "https://github.com/emacs-php/composer.el")
+(keywords "tools" "php" "dependency" "manager")
+
+(package-file "composer.el")
+
+(script "test" "echo \"Error: no test specified\" && exit 1")
+
+(source 'gnu)
+(source 'melpa)
+
+(depends-on "emacs" "25.1")
+(depends-on "seq")
+(depends-on "php-runtime")
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432


### PR DESCRIPTION
## Description
[Eask](https://emacs-eask.github.io/) is a CLI for managing Emacs Lisp dependencies, and is intended to replace [Cask](https://cask.readthedocs.io/en/latest/) for managing Elisp projects. Like Cask, it uses a similarly-named Elisp file named `Eask`, which is the spiritual equivalent of Ruby's `Gemfile`s (meaning it's very much a one-file-per-repository type of format).

Inexplicably, both [Cask](https://github.com/Wilfred/cask-mode) and [Eask](https://github.com/emacs-eask/eask-mode) define their own modes for their respective files (despite both containing ordinary Emacs Lisp code), so modelines like  `-*- mode: eask; -*-` have to be considered.[^1] I've therefore added their names to Emacs Lisp's aliases list for the benefit of Linguist's `Modeline` strategy.


## Checklist
- [x] **I am adding a new extension to a language.**
	-	[x] **The new extension is used in hundreds of repositories.**  
		[~788 search results for `Eask`](https://github.com/search?q=path%3A**%2FEask&type=code) as of this writing.
	- [x] **I have included a real-world usage sample.**  
		Source: [`emacs-php/composer.el/Eask`](https://github.com/emacs-php/composer.el/blob/6c7e19256ff964546cea682edd21446c465a663c/Eask)  
		License: [GPL-3.0-or-later](https://github.com/emacs-php/composer.el/blob/6c7e19256ff964546cea682edd21446c465a663c/composer.el#L11)[^2]

[^1]: See [`auto-complete`'s Eask](https://github.com/auto-complete/auto-complete/blob/07f9915e08342410b933145d7934998709753a29/Eask#L1) for a real-world example.

[^2]: I couldn't find a non-GPL sample, and this is the same source that provided our existing [`Cask` filename sample](https://github.com/github-linguist/linguist/blob/27bb41aa4d97b6f809bfe16db95258361154e547/samples/Emacs%20Lisp/filenames/Cask) back in #3416. Hence I'm assuming copyleft won't be a problem).
