### PR TITLE
Add `apples` to AppleScript aliases

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -396,6 +396,7 @@ Apollo Guidance Computer:
 AppleScript:
   type: programming
   aliases:
+  - apples
   - osascript
   extensions:
   - ".applescript"


### PR DESCRIPTION
Description
===========

Emacs has two packages for AppleScript support: an older one (~2002) named [`applescript-mode`](https://melpa.org/#/applescript-mode), and a newer, more modernised one named [`apples-mode`](https://melpa.org/#/apples-mode). In the case of the latter, modelines of `-*- apples -*-` are possible and need to be considered for the sake of Linguist's `Modeline` strategy.

_(Checklist removed as it doesn't apply)._