### PR TITLE
Add Clef language definition (#new)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1584,3 +1584,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/clef-grammar"]
+	path = vendor/grammars/clef-grammar
+	url = https://github.com/FidelityFramework/clef-grammar.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -326,6 +326,8 @@ vendor/grammars/chapel-tmbundle:
 - source.chapel
 vendor/grammars/circom-highlighting-vscode:
 - source.circom
+vendor/grammars/clef-grammar:
+- source.clef
 vendor/grammars/clarity.tmbundle:
 - source.clar
 vendor/grammars/code-peggy-language:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1231,6 +1231,16 @@ Classic ASP:
   - ".asp"
   ace_mode: text
   language_id: 8
+Clef:
+  type: programming
+  color: "#E8850C"
+  extensions:
+  - ".clef"
+  tm_scope: source.clef
+  ace_mode: fsharp
+  codemirror_mode: mllike
+  codemirror_mime_type: text/x-fsharp
+  language_id: 760024678
 Clean:
   type: programming
   color: "#3F85AF"

--- a/samples/Clef/Behavior.clef
+++ b/samples/Clef/Behavior.clef
@@ -1,0 +1,143 @@
+module HelloArty.Behavior
+
+open Fidelity.Platform.FPGA.Xilinx.Artix7.ArtyA7_100T.Prelude
+open HelloArty.Contract
+
+/// Default wave cycle: 4 seconds for a full LED0→LED3 chase.
+let defaultPeriodMs = 4000
+
+/// PWM resolution: 128 levels.
+let private pwmCeiling = 256
+
+/// Minimum brightness: LEDs brightness is not linear
+let pwmFloor = 0
+
+/// Ramp range: brightness steps from floor to ceiling.
+let private rampRange = pwmCeiling - pwmFloor
+
+/// Full wave cycle: 4 × pwmCeiling = 512 phase steps (power of 2 for free modulus).
+/// Each LED: ramp up (124 steps) + ramp down (124 steps) + dim hold (264 steps).
+let private cycleSteps = 4 * pwmCeiling
+
+/// Phase offset between adjacent LEDs (quarter cycle).
+let private ledOffset = pwmCeiling
+
+/// Ticks between phase steps. Full period maps to cycleSteps increments.
+let ticksPerStep periodMs = (periodMs * ticksPerMs) / cycleSteps
+
+/// Decode 3-bit switch vector to Color (SW2=MSB, SW0=LSB).
+let colorFromSwitches sw0 sw1 sw2 =
+    match sw0, sw1, sw2 with
+    | false, false, false -> Off
+    | true,  false, false -> Red
+    | false, true,  false -> Green
+    | false, false, true  -> Blue
+    | true,  true,  false -> Yellow
+    | false, true,  true  -> Cyan
+    | true,  false, true  -> Magenta
+    | true,  true,  true  -> White
+
+/// Select breath period from buttons (latching, priority-encoded).
+///   BTN0 pressed → default period (slowest)
+///   BTN1 pressed → half
+///   BTN2 pressed → quarter
+///   BTN3 pressed → eighth (fastest)
+///   no buttons   → previous rate held
+let periodFromButtons btn0 btn1 btn2 btn3 currentPeriodMs =
+    if btn3 then defaultPeriodMs / 8
+    else if btn2 then defaultPeriodMs / 4
+    else if btn1 then defaultPeriodMs / 2
+    else if btn0 then defaultPeriodMs
+    else currentPeriodMs
+
+/// Hardware register state for the wave chase design.
+type BreathState = {
+    Counter: int        // free-running tick counter (for PWM sub-cycle)
+    StepTick: int       // ticks since last phase step
+    Phase: int          // master wave phase (0..cycleSteps-1)
+    PeriodMs: int       // latched breath period (full wave cycle)
+}
+
+/// Mealy transition: state × inputs → state × outputs.
+///
+/// Wave chase: 4 green LEDs breathe in sequence with quarter-cycle offsets,
+/// creating a sinusoidal chasing wave. Each RGB LED follows its green
+/// counterpart with SW0-SW2 color selection. SW3 = master on/off.
+/// Buttons latch cadence. Rate persists after button release.
+let step (state: BreathState) (inputs: Inputs) : BreathState * Outputs<ArtyReport> =
+    let color = colorFromSwitches inputs.Sw0 inputs.Sw1 inputs.Sw2
+    let periodMs = periodFromButtons inputs.Btn0 inputs.Btn1 inputs.Btn2 inputs.Btn3 state.PeriodMs
+    let masterOn = inputs.Sw3
+
+    // Advance tick counter within current phase step
+    let nextStepTick = state.StepTick + 1
+    let threshold = ticksPerStep periodMs
+
+    // Time to advance phase?
+    let advancePhase = nextStepTick >= threshold
+
+    let nextPhase =
+        if not advancePhase then state.Phase
+        else (state.Phase + 1) % cycleSteps
+
+    let resetStepTick =
+        if advancePhase then 0
+        else nextStepTick
+
+    // Free-running counter for PWM sub-cycle
+    let maxTicks = defaultPeriodMs * ticksPerMs * 2
+    let nextCounter = (state.Counter + 1) % maxTicks
+    let pwmSubCycle = nextCounter % pwmCeiling
+    let doubleRamp = 2 * rampRange
+
+    // ── LED 0 (no offset) ──
+    let ph0 = nextPhase % cycleSteps
+    let raw0 =
+        if ph0 < rampRange then pwmFloor + ph0
+        else if ph0 < doubleRamp then pwmFloor + (doubleRamp - 1 - ph0)
+        else pwmFloor
+    let p0 = raw0 - pwmFloor
+    let smooth0 = pwmFloor + (3 * p0 * p0 - 2 * p0 * p0 * p0 / rampRange) / rampRange
+    let led0On = if masterOn then pwmSubCycle < smooth0 else false
+
+    // ── LED 1 (quarter-cycle offset) ──
+    let ph1 = (nextPhase + ledOffset) % cycleSteps
+    let raw1 =
+        if ph1 < rampRange then pwmFloor + ph1
+        else if ph1 < doubleRamp then pwmFloor + (doubleRamp - 1 - ph1)
+        else pwmFloor
+    let p1 = raw1 - pwmFloor
+    let smooth1 = pwmFloor + (3 * p1 * p1 - 2 * p1 * p1 * p1 / rampRange) / rampRange
+    let led1On = if masterOn then pwmSubCycle < smooth1 else false
+
+    // ── LED 2 (half-cycle offset) ──
+    let ph2 = (nextPhase + 2 * ledOffset) % cycleSteps
+    let raw2 =
+        if ph2 < rampRange then pwmFloor + ph2
+        else if ph2 < doubleRamp then pwmFloor + (doubleRamp - 1 - ph2)
+        else pwmFloor
+    let p2 = raw2 - pwmFloor
+    let smooth2 = pwmFloor + (3 * p2 * p2 - 2 * p2 * p2 * p2 / rampRange) / rampRange
+    let led2On = if masterOn then pwmSubCycle < smooth2 else false
+
+    // ── LED 3 (three-quarter-cycle offset) ──
+    let ph3 = (nextPhase + 3 * ledOffset) % cycleSteps
+    let raw3 =
+        if ph3 < rampRange then pwmFloor + ph3
+        else if ph3 < doubleRamp then pwmFloor + (doubleRamp - 1 - ph3)
+        else pwmFloor
+    let p3 = raw3 - pwmFloor
+    let smooth3 = pwmFloor + (3 * p3 * p3 - 2 * p3 * p3 * p3 / rampRange) / rampRange
+    let led3On = if masterOn then pwmSubCycle < smooth3 else false
+
+    // RGB LEDs follow corresponding green LED with color selection
+    let rgb0 = colorToRgbBits color led0On
+    let rgb1 = colorToRgbBits color led1On
+    let rgb2 = colorToRgbBits color led2On
+    let rgb3 = colorToRgbBits color led3On
+
+    { Counter = nextCounter; StepTick = resetStepTick; Phase = nextPhase
+      PeriodMs = periodMs },
+    { Leds = { Led0 = led0On; Led1 = led1On; Led2 = led2On; Led3 = led3On
+               Rgb0 = rgb0; Rgb1 = rgb1; Rgb2 = rgb2; Rgb3 = rgb3 }
+      UartReport = ValueNone }

--- a/samples/Clef/CMemory.clef
+++ b/samples/Clef/CMemory.clef
@@ -1,0 +1,12 @@
+/// Minimal libc memory bindings for ExternCall regression test.
+/// This is a subset of the Farscape-generated Fidelity.Libc.Memory module,
+/// containing only malloc and free to isolate the ExternCall pathway test.
+module ExternCallSample.CMemory
+
+[<FidelityExtern("c", "malloc")>]
+let malloc (size: unativeint) : option<nativeint> =
+    NativeDefault.zeroed ()
+
+[<FidelityExtern("c", "free")>]
+let free (ptr: nativeint) : unit =
+    NativeDefault.zeroed ()

--- a/samples/Clef/Contract.clef
+++ b/samples/Clef/Contract.clef
@@ -1,0 +1,15 @@
+module HelloArty.Contract
+
+open Fidelity.Platform.FPGA.Xilinx.Artix7.ArtyA7_100T.Prelude
+
+/// BAREWire-serialisable report transmitted from the FPGA to the CPU monitor
+/// over the Arty A7 USB-UART connection.
+///
+/// The FPGA Program emits this on UartReport; the Monitor decodes it from
+/// /dev/ttyUSB1. Both programs reference this module — neither owns it.
+[<BAREWireSchema>]
+type ArtyReport = {
+    Color:    Color
+    Mode:     Mode
+    PeriodMs: int
+}

--- a/samples/Clef/ExternCall.clef
+++ b/samples/Clef/ExternCall.clef
@@ -1,0 +1,29 @@
+/// Sample 17: ExternCall — First sample using [<FidelityExtern>] bindings
+///
+/// Exercises the ExternCall pathway end-to-end:
+///   [<FidelityExtern>] declaration → PlatformBindingResolution → ExternCall coeffect
+///   → pExternCallResolved witness → func.call @malloc with "link" = "c"
+///
+/// Also exercises CaseElimination on option-typed ExternCall return:
+///   malloc returns option<nativeint> → match Some/None
+module ExternCallSample
+
+open ExternCallSample.CMemory
+
+[<EntryPoint>]
+let main _ =
+    Console.writeln "=== ExternCall Test ==="
+
+    // Call malloc via ExternCall — returns option<nativeint>
+    let result = malloc 64un
+
+    match result with
+    | Some ptr ->
+        Console.writeln "malloc succeeded"
+        // Free the allocated memory
+        free ptr
+        Console.writeln "free completed"
+        0
+    | None ->
+        Console.writeln "malloc failed"
+        1

--- a/samples/Clef/FPGAProgram.clef
+++ b/samples/Clef/FPGAProgram.clef
@@ -1,0 +1,13 @@
+module HelloArty.Program
+
+open Fidelity.Platform.FPGA.Xilinx.Artix7.ArtyA7_100T.Prelude
+open HelloArty.Contract
+open HelloArty.Behavior
+
+[<HardwareModule>]
+let helloArtyTop : Design<BreathState, ArtyReport> = {
+    InitialState = { Counter = 0; StepTick = 0; Phase = 0
+                     PeriodMs = defaultPeriodMs }
+    Step = step
+    Clock = Endpoints.clock
+}

--- a/samples/Clef/TomlTypes.clef
+++ b/samples/Clef/TomlTypes.clef
@@ -1,0 +1,164 @@
+/// TOML value types for representing parsed TOML documents.
+/// Fully compliant with TOML 1.0.0 specification.
+/// Designed to be BCL-minimal, to support Clef dimensional types.
+namespace Fidelity.Data.TOML
+
+/// Represents a TOML date-time value with optional timezone offset.
+[<Struct>]
+type TomlDateTime =
+    { Year: int
+      Month: int
+      Day: int
+      Hour: int
+      Minute: int
+      Second: int
+      Nanosecond: int
+      /// Offset from UTC in minutes. None for local date-times.
+      OffsetMinutes: int voption }
+
+/// Represents a TOML local date (no time component).
+[<Struct>]
+type TomlLocalDate =
+    { Year: int
+      Month: int
+      Day: int }
+
+/// Represents a TOML local time (no date component).
+[<Struct>]
+type TomlLocalTime =
+    { Hour: int
+      Minute: int
+      Second: int
+      Nanosecond: int }
+
+/// Represents any TOML value type.
+[<RequireQualifiedAccess>]
+type TomlValue =
+    /// A string value (basic or literal, single or multiline).
+    | String of string
+    /// A 64-bit signed integer.
+    | Integer of int64
+    /// A 64-bit floating point number.
+    | Float of float
+    /// A boolean value.
+    | Boolean of bool
+    /// An offset date-time (with timezone).
+    | OffsetDateTime of TomlDateTime
+    /// A local date-time (no timezone).
+    | LocalDateTime of TomlDateTime
+    /// A local date (no time component).
+    | LocalDate of TomlLocalDate
+    /// A local time (no date component).
+    | LocalTime of TomlLocalTime
+    /// An array of values.
+    | Array of TomlValue list
+    /// An inline table.
+    | InlineTable of TomlTable
+    /// A regular table (from [table] header).
+    | Table of TomlTable
+
+/// Represents a TOML table (key-value pairs) using Map.
+and TomlTable = Map<string, TomlValue>
+
+/// Represents a complete TOML document.
+type TomlDocument = TomlTable
+
+/// Module for working with TOML tables.
+module TomlTable =
+    /// Creates an empty TOML table.
+    let empty: TomlTable = Map.empty
+
+    /// Adds a key-value pair to a table.
+    let add (key: string) (value: TomlValue) (table: TomlTable): TomlTable =
+        Map.add key value table
+
+    /// Tries to get a value by key.
+    let tryFind (key: string) (table: TomlTable): TomlValue option =
+        Map.tryFind key table
+
+    /// Gets all keys in the table.
+    let keys (table: TomlTable): string list =
+        table |> Map.toList |> List.map fst
+
+    /// Checks if a key exists.
+    let containsKey (key: string) (table: TomlTable): bool =
+        Map.containsKey key table
+
+/// Module for working with TOML documents.
+module TomlDocument =
+    /// Creates an empty TOML document.
+    let empty: TomlDocument = TomlTable.empty
+
+    /// Navigates to a nested value using a dotted key path.
+    /// For example, "package.name" navigates to table["package"]["name"].
+    let tryGetPath (path: string) (doc: TomlDocument): TomlValue option =
+        let keys = path.Split('.') |> Array.toList
+        let rec navigate (keys: string list) (current: TomlValue): TomlValue option =
+            match keys with
+            | [] -> Some current
+            | key :: rest ->
+                match current with
+                | TomlValue.Table t
+                | TomlValue.InlineTable t ->
+                    match TomlTable.tryFind key t with
+                    | Some v -> navigate rest v
+                    | None -> None
+                | _ -> None
+
+        match keys with
+        | [] -> None
+        | firstKey :: rest ->
+            match TomlTable.tryFind firstKey doc with
+            | Some v ->
+                if List.isEmpty rest then Some v
+                else navigate rest v
+            | None -> None
+
+    /// Gets a string value by dotted key path.
+    let tryGetString (path: string) (doc: TomlDocument): string option =
+        match tryGetPath path doc with
+        | Some (TomlValue.String s) -> Some s
+        | _ -> None
+
+    /// Gets an integer value by dotted key path.
+    let tryGetInt (path: string) (doc: TomlDocument): int64 option =
+        match tryGetPath path doc with
+        | Some (TomlValue.Integer i) -> Some i
+        | _ -> None
+
+    /// Gets a float value by dotted key path.
+    let tryGetFloat (path: string) (doc: TomlDocument): float option =
+        match tryGetPath path doc with
+        | Some (TomlValue.Float f) -> Some f
+        | _ -> None
+
+    /// Gets a boolean value by dotted key path.
+    let tryGetBool (path: string) (doc: TomlDocument): bool option =
+        match tryGetPath path doc with
+        | Some (TomlValue.Boolean b) -> Some b
+        | _ -> None
+
+    /// Gets a string array by dotted key path.
+    let tryGetStringArray (path: string) (doc: TomlDocument): string list option =
+        match tryGetPath path doc with
+        | Some (TomlValue.Array arr) ->
+            let strings =
+                arr
+                |> List.choose (function TomlValue.String s -> Some s | _ -> None)
+            if List.length strings = List.length arr then Some strings
+            else None
+        | _ -> None
+
+    /// Gets a table by dotted key path.
+    let tryGetTable (path: string) (doc: TomlDocument): TomlTable option =
+        match tryGetPath path doc with
+        | Some (TomlValue.Table t) -> Some t
+        | Some (TomlValue.InlineTable t) -> Some t
+        | _ -> None
+
+    /// Gets an inline table value by key path.
+    let tryGetInlineTable (path: string) (doc: TomlDocument): (string * TomlValue) list option =
+        match tryGetPath path doc with
+        | Some (TomlValue.InlineTable t) ->
+            t |> Map.toList |> Some
+        | _ -> None


### PR DESCRIPTION
Add Clef language

## Description

Clef is a systems programming language in the ML family, targeting MLIR/LLVM/CIRCT and other back ends for native compilation to CPU, FPGA, GPU/APU, and NPU with designs to target other processor types. It uses ML-family syntax with significant divergences: no nulls, no OO constructs, no managed runtime dependencies.

The language is developed under the [[Fidelity Framework](https://github.com/FidelityFramework)](https://github.com/FidelityFramework) organization and documented at [[clef-lang.org](https://clef-lang.com/)](https://clef-lang.com).

Changes included:

- `languages.yml`: Clef entry (`source.clef`, `#E8850C`, language_id `760024678`)
- `grammars.yml`: register `FidelityFramework/clef-grammar`
- `vendor/grammars/clef-grammar`: TextMate grammar derived from [[ionide-fsgrammar](https://github.com/ionide/ionide-fsgrammar)](https://github.com/ionide/ionide-fsgrammar), with scope `source.clef`
- `samples/Clef/`: 6 samples from [[Composer](https://github.com/FidelityFramework/Composer)](https://github.com/FidelityFramework/Composer), [[Fidelity.Data](https://github.com/FidelityFramework/Fidelity.Data)](https://github.com/FidelityFramework/Fidelity.Data), and [[HelloArty](https://github.com/FidelityFramework/HelloArty)](https://github.com/FidelityFramework/HelloArty)

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in dozens of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.clef+module
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/FidelityFramework/Composer (ExternCall.clef, CMemory.clef)
      - https://github.com/FidelityFramework/Fidelity.Data (TomlTypes.clef)
      - https://github.com/FidelityFramework/HelloArty (FPGAProgram.clef, Behavior.clef, Contract.clef)
    - Sample license(s):
      - MIT
  - [x] I have included a syntax highlighting grammar: https://github.com/FidelityFramework/clef-grammar
  - [x] I have added a color
    - Hex value: `#E8850C`
    - Rationale: Amber/orange chosen to represent hardware proximity and distinguish Clef visually from F# (`#b845fc`) and other ML-family languages on GitHub.
  - [] I have updated the heuristics to distinguish my language from others using the same extension.