### PR TITLE
Support JetBrains colour scheme (`.icls`) files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8685,6 +8685,7 @@ XML:
   - ".grxml"
   - ".gst"
   - ".hzp"
+  - ".icls"
   - ".iml"
   - ".ivy"
   - ".jelly"

--- a/samples/XML/Deep_Ocean.icls
+++ b/samples/XML/Deep_Ocean.icls
@@ -1,0 +1,65 @@
+<scheme name="Deep Ocean" version="142" parent_scheme="Darcula">
+  <metaInfo>
+    <property name="ide">AndroidStudio</property>
+    <property name="ideVersion">2025.3.2.6</property>
+    <property name="originalScheme">Deep Ocean</property>
+  </metaInfo>
+  <colors>
+    <option name="CARET_ROW_COLOR" value="1A1D2D" />
+    <option name="GUTTER_BACKGROUND" value="1E2132" />
+    <option name="LINE_NUMBERS_COLOR" value="3C4257" />
+    <option name="SELECTION_BACKGROUND" value="333852" />
+    <option name="TEARLINE_COLOR" value="1E2132" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546e7a" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="82aaff" />
+      </value>
+    </option>
+    <option name="DEFAULT_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="89ddff" />
+      </value>
+    </option>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="c792ea" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546e7a" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="f78c6c" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="c3e88d" />
+      </value>
+    </option>
+    <option name="KOTLIN_PROPERTY">
+      <value>
+        <option name="FOREGROUND" value="a6accd" />
+      </value>
+    </option>
+    <option name="TEXT">
+      <value>
+        <option name="FOREGROUND" value="a6accd" />
+        <option name="BACKGROUND" value="1e2132" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/test/test_strategies.rb
+++ b/test/test_strategies.rb
@@ -193,6 +193,7 @@ class TestStrategies < Minitest::Test
       "#{samples_path}/XML/MainView.axaml",
       "#{samples_path}/XML/Robots.slnx",
       "#{samples_path}/XML/Win64.pubxml",
+      "#{samples_path}/XML/Deep_Ocean.icls",
     ]
     assert_all_xml all_xml_fixtures("*") - no_root_tag
 


### PR DESCRIPTION
## Description
This PR adds [JetBrains colour scheme](https://www.jetbrains.com/help/idea/configuring-colors-and-fonts.html#export-color-cheme-xml) (`.icls`) files to the list of supported XML extensions.

## Checklist
- [x] **I am adding a new extension to a language.**
  - [x] **The new extension is used in hundreds of repositories on GitHub.com**
    [~11.1k search results](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.icls+%22%3Cscheme%20%22+NOT+%22%3C%3Fxml+%22)
  - [x] **I have included a real-world usage sample.**
    - `Deep_Ocean.icls`: [Source](https://github.com/hearsilent/Intellij-Themes/blob/main/Color%20Schemes/) | MIT-licensed
  - [ ] I have included a change to the heuristics.