### PR TITLE
Add A2ML and K9 as recognized languages

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -60,6 +60,16 @@
   tm_scope: source.4dm
   ace_mode: text
   language_id: 577529595
+A2ML:
+  type: data
+  color: "#4B0082"
+  extensions:
+  - ".a2ml"
+  tm_scope: source.a2ml
+  ace_mode: yaml
+  codemirror_mode: yaml
+  codemirror_mime_type: text/x-yaml
+  language_id: 1099511627776
 ABAP:
   type: programming
   color: "#E8274B"
@@ -3872,6 +3882,17 @@ Just:
   - ".just"
   ace_mode: text
   language_id: 128447695
+K9:
+  type: data
+  color: "#D4A017"
+  extensions:
+  - ".k9"
+  - ".k9.ncl"
+  tm_scope: source.k9
+  ace_mode: yaml
+  codemirror_mode: yaml
+  codemirror_mime_type: text/x-yaml
+  language_id: 1099511627777
 KCL:
   type: programming
   color: "#7ABABF"

--- a/samples/A2ML/sample.a2ml
+++ b/samples/A2ML/sample.a2ml
@@ -1,0 +1,13 @@
+# A2ML Overview
+
+@abstract:
+A2ML is a typed, attested markup format.
+@end
+
+## Claims
+- Required sections must exist.
+- References must resolve.
+
+@refs:
+[1] Attested Markup Language Spec (draft)
+@end

--- a/samples/K9/sample.k9
+++ b/samples/K9/sample.k9
@@ -1,0 +1,40 @@
+K9!
+# SPDX-License-Identifier: MIT
+# hello.k9 - Example Kennel-level component (pure data)
+#
+# Security Level: 'Kennel (no execution, safe anywhere)
+#
+# This is the simplest K9 component: just data.
+# It can be parsed and displayed without any risk.
+
+---
+metadata:
+  name: hello-k9
+  version: 1.0.0
+  description: A friendly greeting from the K9 pack
+  author: hyperpolymath
+  license: PMPL-1.0-or-later
+
+content:
+  greeting: "Hello from K9!"
+  message: |
+    Welcome to the K9 Self-Validating Component system.
+
+    This file demonstrates the 'Kennel security level:
+    - Pure data only
+    - No code execution
+    - Safe to open anywhere
+
+    Think of it as a smarter YAML that knows what it is.
+
+  facts:
+    - K9 files start with the magic number "K9!"
+    - The must-just-nickel triad enables self-validation
+    - Three security levels: 'Kennel, 'Yard, 'Hunt
+    - Podman-first deployment prevents host pollution
+
+tags:
+  - example
+  - kennel
+  - hello-world
+  - safe

--- a/samples/K9/sample.k9.ncl
+++ b/samples/K9/sample.k9.ncl
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+# hello.k9.ncl - Example K9 Self-Validating Component
+#
+# This is a minimal .k9 component demonstrating the pedigree structure.
+# It validates itself against the pedigree schema.
+
+let pedigree = import "../pedigree.ncl" in
+
+pedigree.K9Pedigree & {
+  metadata = {
+    name = "hello-k9",
+    version = "1.0.0-alpha",
+    description = "A minimal K9 component that says hello",
+  },
+
+  target = {
+    os = 'Linux,
+    is_edge = false,
+    requires_podman = false,
+  },
+
+  security = {
+    trust_level = 'Yard,
+    allow_network = false,
+    allow_filesystem_write = false,
+    allow_subprocess = false,
+  },
+
+  validation = {
+    checksum = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    pedigree_version = "1.0.0",
+    hunt_authorized = false,
+  },
+
+  recipes = {
+    install = "echo 'Hello from K9!'",
+    validate = "nickel typecheck examples/hello.k9.ncl",
+    deploy = "echo 'K9 deployed successfully'",
+    migrate = "echo 'No migration needed'",
+  },
+}


### PR DESCRIPTION
## Description

Adding two new data languages used in the attested markup and self-validating component ecosystems:

**A2ML (Attested Markup Language)** — a typed, attested markup format for structured claims with attestation metadata. Uses `@abstract:`, `@refs:` blocks and Markdown-like headings.

**K9** — a self-validating component format with two variants:
- `.k9` — YAML-based data files with a `K9!` magic number, metadata, and content sections
- `.k9.ncl` — Nickel-based variant with typed pedigree validation, security levels (`'Kennel`, `'Yard`, `'Hunt`), and recipe definitions

Both are part of the [contractile](https://github.com/hyperpolymath/contractile) must-just-nickel triad ecosystem.

## Checklist:

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.a2ml
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.k9
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.k9.ncl
    - **Note:** These are emerging formats. Usage is currently concentrated in the hyperpolymath ecosystem with active adoption across multiple repositories. We understand this may not yet meet the usage threshold and are happy to wait or discuss.
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - A2ML: https://github.com/hyperpolymath/pandoc-a2ml/blob/main/sample.a2ml
      - K9 (.k9): https://github.com/hyperpolymath/pandoc-k9/blob/main/sample.k9
      - K9 (.k9.ncl): https://github.com/hyperpolymath/pandoc-k9/blob/main/sample.k9.ncl
    - Sample license(s): PMPL-1.0-or-later (all samples written by PR author)
  - [ ] I have included a syntax highlighting grammar: N/A — `tm_scope: source.a2ml` and `tm_scope: source.k9` are placeholders; no TextMate grammar exists yet. We plan to create grammars and can update this PR or follow up.
  - [x] I have added a color
    - A2ML: `#4B0082` (indigo — representing attestation/verification trust)
    - K9: `#D4A017` (gold — representing the "golden pedigree" validation concept)
    - Rationale: Colors chosen to be distinctive and thematically connected to each format's purpose.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
    - No heuristic needed: `.a2ml`, `.k9`, and `.k9.ncl` are unique extensions not shared with other languages.