### PR TITLE
Add Spectator programming language support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5639,6 +5639,14 @@ Pan:
   tm_scope: source.pan
   ace_mode: text
   language_id: 276
+Panther:
+  type: programming
+  color: "#00f0ff"
+  extensions:
+    - ".pnr"
+  tm_scope: source.panther
+  ace_mode: text
+  language_id: 999999
 Papyrus:
   type: programming
   color: "#6600cc"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7427,6 +7427,26 @@ SourcePawn:
   tm_scope: source.sourcepawn
   ace_mode: text
   language_id: 354
+  ---
+# Spectator Language Definition for GitHub Linguist
+name: Spectator
+type: programming
+color: "#00d4aa"
+aliases:
+  - spectator
+  - spectatorlang
+  - .str
+extensions:
+  - ".str"
+  - ".spectator"
+tm_scope: source.spectator
+ace_mode: text
+codemirror_mode: "javascript"
+codemirror_mime_type: "application/javascript"
+language_id: 999999  
+wrap: true
+searchable: true
+color: "#00d4aa"
 Spline Font Database:
   type: data
   extensions:


### PR DESCRIPTION
## Add Spectator Programming Language to Linguist

### Language Overview
**Spectator** is a cybersecurity scripting language built for pentesters, red teamers, and security researchers. It combines Python-like syntax with built-in security modules, a native GUI framework, and a package manager — all compiled into a single standalone binary.

### Language Statistics
- **File extensions**: `.str`, `.spectator`
- **License**: MIT
- **Version**: 2.0.0 (stable)

### Files Added
- `grammars/spectator.tmLanguage.json` - Complete TextMate grammar
- `.github/linguist/spectator.yml` - Language definition
- `samples/spectator/*.str` - 5 sample files covering all features
- Updated `.gitattributes` with Spectator associations

### Grammar Features
Comments (`##`)
Strings and f-strings with interpolation (`f"Hello {name}"`)
Numbers (integers, floats)
Keywords: `if`, `elseif`, `else`, `loop`, `each`, `match`, `try`, `catch`, `throw`, `func`, `return`, `spawn`, `end`
Special operator: `-->`
Built-in functions: `Trace`, `Recon`, `PortScan`, `resolve`, `http`, `join`, `payloadList`, `missionStart`, etc.
GUI keywords: `GUI.*`, `open.window`
Imports: `#Import`
Shell execution: `# runner<?command>`
Function definitions with parameters
Block scoping (`{}`)
Dot notation for property access

### Sample Code
```spectator
## Port scanner with GUI
#Import Spec.GUI

open.window({"title": "QuickScan", "bg": "#0a0f1a"})
GUI.input("target", "Target IP or domain")
GUI.button("Scan", "run", {"color": "#00d4aa"})
GUI.output("results", {"height": 400})

func runScan(host) {
    ports = [21, 22, 23, 25, 80, 443, 3306, 8080]
    each port in ports {
        if hasPort(host, port) {
            GUI.print("results", "Port " + str(port) + " is OPEN")
        }
    }
}

GUI.on("run", func() {
    target = GUI.get("target")
    runScan(target)
})
end()