### PR TITLE
Add Selve Programming Language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7164,6 +7164,13 @@ Self:
   tm_scope: none
   ace_mode: text
   language_id: 345
+Selve:
+  type: programming
+  color: "#FF4F00"
+  extensions:
+  - ".selve"
+  tm_scope: text.html.selve
+  ace_mode: html
 ShaderLab:
   type: programming
   color: "#222c37"

--- a/samples/Selve/example.selve
+++ b/samples/Selve/example.selve
@@ -1,0 +1,11 @@
+<script>
+  let count = 0;
+
+  function increment() {
+    count++;
+  }
+</script>
+
+<button on:click={increment}>
+  Count: {count}
+</button>


### PR DESCRIPTION
## Description

Adds support for **Selve**, a modern compiler-based JavaScript UI framework.

Selve uses a `.selve` file format combining HTML-like templates with embedded `<script>` logic, similar in structure to frameworks like 0 but compiled differently.

Key characteristics:
- No Virtual DOM
- Compile-time optimization
- Fine-grained reactivity
- HTML-first syntax

Repository: https://github.com/selvejs/selve

---

## Checklist:

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.selve+selve
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/selvejs/selve
    - Sample license(s):
      - MIT
  - [ ] I have included a syntax highlighting grammar: 
  - [x] I have added a color
    - Hex value: `#FF4F00`
    - Rationale: Matches Selve's official brand color and ensures clear visibility in GitHub language statistics.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.