### PR TITLE
Adding the Sicht programming language

### DIFF
--- a/samples/Sicht/parser_and_path_utils.si
+++ b/samples/Sicht/parser_and_path_utils.si
@@ -1,0 +1,74 @@
+start
+
+create library parser_utils
+
+    create function starts_with(text, prefix)
+        if length of(text) is less than length of(prefix) then
+            give false
+        endif
+
+        set i to 0
+        while i is less than length of(prefix)
+            if character i of(text) is not equal to character i of(prefix) then
+                give false
+            endif
+            set i to i + 1
+        endwhile
+        give true
+    endfunction
+
+    create function split(text, delim)
+        set parts to []
+        if length of(delim) is equal to 0 then
+            add text to(parts)
+            give parts
+        endif
+
+        set chunk to ""
+        set i to 0
+        while i is less than length of(text)
+            set match to true
+            set j to 0
+            while j is less than length of(delim)
+                if i + j is greater than or equal to length of(text) then
+                    set match to false
+                    exit
+                endif
+                if character (i + j) of(text) is not equal to character j of(delim) then
+                    set match to false
+                    exit
+                endif
+                set j to j + 1
+            endwhile
+
+            if match is equal to true then
+                add chunk to(parts)
+                set chunk to ""
+                set i to i + length of(delim)
+                next
+            endif
+
+            set chunk to chunk + character i of(text)
+            set i to i + 1
+        endwhile
+
+        add chunk to(parts)
+        give parts
+    endfunction
+
+    create function get_directory(path)
+        set i to length of(path) - 1
+        while i is greater than or equal to 0
+            set ch to character i of(path)
+            if ch is equal to "/" or ch is equal to character 0 of("\\") then
+                give substring(path, 0, i)
+            endif
+            set i to i - 1
+        endwhile
+        give "."
+    endfunction
+
+endlibrary
+
+end
+

--- a/samples/Sicht/runtime_guard_and_cli.si
+++ b/samples/Sicht/runtime_guard_and_cli.si
@@ -1,0 +1,64 @@
+start
+
+load library native
+load library logger
+
+take cli_args from native as args
+take capture from native
+take print_error from logger
+take print_success from logger
+take print_warning from logger
+
+set REQUIRED_API to "api 1.0"
+
+create function runtime_preflight()
+    set version_out to trim of(capture("sicht version"))
+    if length of(version_out) is equal to 0 then
+        print_warning("Runtime version is unknown, continuing.")
+        give true
+    endif
+
+    if version_out contains REQUIRED_API then
+        give true
+    endif
+
+    if version_out contains "SICHT: VERSION" then
+        print_warning("Runtime did not expose explicit API contract.")
+        give true
+    endif
+
+    print_error("Unsupported runtime contract.")
+    print_error("Expected: " + REQUIRED_API)
+    print_error("Detected: " + version_out)
+    give false
+endfunction
+
+create function main()
+    if runtime_preflight() is equal to false then
+        exit 1
+    endif
+
+    if length of(args) is less than 2 then
+        print_error("usage: sightctl <command>")
+        give false
+    endif
+
+    set cmd to element 1 of(args)
+    if cmd is equal to "check" then
+        print_success("runtime check passed")
+        give true
+    otherwise if cmd is equal to "version" then
+        print_success(capture("sicht version"))
+        give true
+    otherwise
+        print_error("unknown command: " + cmd)
+        give false
+    endif
+endfunction
+
+if main() is equal to false then
+    exit 1
+endif
+
+end
+


### PR DESCRIPTION

## Summary

This PR adds support for the Sicht programming language in Linguist.

### Included changes

- Add `Sicht` to `lib/linguist/languages.yml`
- Map extension `.si` to Sicht
- Add TextMate scope `source.sicht`
- Add samples in `samples/Sicht/`:
  - `runtime_guard_and_cli.si`
  - `parser_and_path_utils.si`

## Why

Sicht source files are currently not classified correctly in GitHub language stats and syntax detection.  

## Usage evidence

GitHub code search (excluding forks):
- `path:*.si -is:fork`

Example repos:
- [Sicht (some files written in itself)](https://github.com/gothardener/sichtlang)
- [Dresden](https://github.com/gothardener/dresden)