### PR TITLE
Add Achronyme language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1590,3 +1590,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/achronyme-editor"]
+	path = vendor/grammars/achronyme-editor
+	url = https://github.com/achronyme/achronyme-editor.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -202,6 +202,8 @@ vendor/grammars/abap.tmbundle:
 - source.abap
 vendor/grammars/abl-tmlanguage:
 - source.abl
+vendor/grammars/achronyme-editor:
+- source.ach
 vendor/grammars/actionscript3-tmbundle/:
 - source.actionscript.3
 - text.html.asdoc

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -212,6 +212,15 @@ ATS:
   tm_scope: source.ats
   ace_mode: ocaml
   language_id: 9
+Achronyme:
+  type: programming
+  color: "#A855F7"
+  aliases:
+  - ach
+  extensions:
+  - ".ach"
+  tm_scope: source.ach
+  ace_mode: text
 ActionScript:
   type: programming
   tm_scope: source.actionscript.3

--- a/samples/Achronyme/credential_proof.ach
+++ b/samples/Achronyme/credential_proof.ach
@@ -1,0 +1,80 @@
+// ============================================================================
+// Anonymous Credential Verification
+// ============================================================================
+//
+// Demonstrates: witness auto-inference, for loops in circuits,
+// Merkle membership, hash chains, and multiple independent proofs
+// composed in a single program.
+//
+// Scenario:
+//   A user proves they have a valid credential (age >= 18) issued by
+//   a trusted authority, without revealing their identity or exact age.
+//   The credential is registered in a Merkle tree of valid credentials.
+
+// --- Phase 1: Authority issues credentials (VM mode) ---
+
+// Credential structure: hash(identity_secret, age, issuer_nonce)
+let identity_secret = 0p98765
+let age = 0p25
+let issuer_nonce = 0p42424242
+
+let credential = poseidon(poseidon(identity_secret, age), issuer_nonce)
+
+// Build a registry of 4 valid credentials (Merkle tree)
+let cred_0 = credential                        // our credential
+let cred_1 = poseidon(0p11111, 0p30)           // another user, age 30
+let cred_2 = poseidon(0p22222, 0p45)           // another user, age 45
+let cred_3 = poseidon(0p33333, 0p21)           // another user, age 21
+
+// Depth-2 Merkle tree
+let node_left  = poseidon(cred_0, cred_1)
+let node_right = poseidon(cred_2, cred_3)
+let registry_root = poseidon(node_left, node_right)
+
+// Merkle proof for credential 0: path = [cred_1, node_right], indices = [0, 0]
+let proof_path: Field[2] = [cred_1, node_right]
+let proof_idx: Field[2] = [0p0, 0p0]
+
+print("Credential registry root: " + registry_root.to_string())
+
+// --- Phase 2: Prove credential membership + age >= 18 ---
+
+// The minimum age threshold (public)
+let min_age = 0p18
+
+prove(registry_root: Public, min_age: Public) {
+    // 1. Reconstruct the credential from secret components
+    let inner = poseidon(identity_secret, age)
+    let cred = poseidon(inner, issuer_nonce)
+
+    // 2. Prove membership in the registry via Merkle proof
+    merkle_verify(registry_root, cred, proof_path, proof_idx)
+
+    // 3. Prove age >= min_age (range-checked comparison)
+    range_check(age, 8)           // age fits in 8 bits (0..255)
+    range_check(min_age, 8)
+    assert(age >= min_age)
+}
+
+print("Credential verified: member of registry AND age >= 18")
+
+// --- Phase 3: Prove-and-use pattern ---
+
+// Compute a derived identifier for rate-limiting (like a nullifier)
+// without revealing the real identity
+let service_id = 0p7777
+let pseudonym = poseidon(identity_secret, service_id)
+
+prove(pseudonym: Public, registry_root: Public, service_id: Public) {
+    // Prove the pseudonym is correctly derived from a registered credential
+    let inner = poseidon(identity_secret, age)
+    let cred = poseidon(inner, issuer_nonce)
+    merkle_verify(registry_root, cred, proof_path, proof_idx)
+
+    // Prove pseudonym derivation
+    assert_eq(poseidon(identity_secret, service_id), pseudonym)
+}
+
+print("Pseudonym verified: derived from a valid credential")
+print("Pseudonym: " + pseudonym.to_string())
+print("PASS: credential_proof")

--- a/samples/Achronyme/hash_chain_proof.ach
+++ b/samples/Achronyme/hash_chain_proof.ach
@@ -1,0 +1,56 @@
+// ============================================================================
+// Verifiable Hash Chain
+// ============================================================================
+//
+// Demonstrates: for loops in circuits, accumulator patterns,
+// poseidon_many, and function definitions inside prove blocks.
+//
+// Scenario:
+//   Prove knowledge of a preimage that, after N rounds of iterated
+//   hashing, produces a known public digest — without revealing the
+//   preimage or any intermediate hashes.
+
+let preimage = 0p123456789
+let rounds = 5
+
+// Compute the chain in VM mode
+mut digest = preimage
+for i in 0..rounds {
+    digest = poseidon(digest, 0)
+}
+
+let final_hash = digest
+print("Hash chain result after " + rounds.to_string() + " rounds:")
+print("  " + final_hash.to_string())
+
+// Prove knowledge of the preimage
+prove(final_hash: Public) {
+    fn hash_chain(seed, n) {
+        mut acc = seed
+        for i in 0..n {
+            acc = poseidon(acc, 0)
+        }
+        acc
+    }
+
+    let computed = hash_chain(preimage, 5)
+    assert_eq(computed, final_hash)
+}
+
+print("Hash chain proof verified")
+
+// Bonus: prove the chain has a specific structure (each intermediate
+// hash is a valid Poseidon output — implicitly guaranteed by the circuit)
+let mid_point = poseidon(poseidon(preimage, 0), 0)  // after 2 rounds
+
+prove(final_hash: Public, mid_point: Public) {
+    // Prove: preimage → 2 rounds → mid_point → 3 more rounds → final_hash
+    let after_2 = poseidon(poseidon(preimage, 0), 0)
+    assert_eq(after_2, mid_point)
+
+    let after_5 = poseidon(poseidon(poseidon(after_2, 0), 0), 0)
+    assert_eq(after_5, final_hash)
+}
+
+print("Split hash chain proof verified")
+print("PASS: hash_chain_proof")

--- a/samples/Achronyme/private_auction.ach
+++ b/samples/Achronyme/private_auction.ach
@@ -1,0 +1,87 @@
+// ============================================================================
+// Private Sealed-Bid Auction
+// ============================================================================
+//
+// Demonstrates: prove(x: Public) syntax, Poseidon commitments,
+// range checks, comparison gadgets, Merkle eligibility, and multi-proof
+// composition — all in a single hybrid VM + ZK program.
+//
+// Scenario:
+//   Three bidders submit sealed bids for an item. Each bid is committed
+//   via Poseidon hash. A ZK proof verifies that the winner's bid is:
+//     1. Valid (within the allowed range 1..2^32)
+//     2. Committed (matches the published commitment)
+//     3. Higher than all other bids
+//   Without revealing any losing bid values.
+
+// --- Phase 1: Setup (VM mode) ---
+
+// Bidder secrets and bids
+let bid_alice   = 0p500
+let bid_bob     = 0p750
+let bid_charlie = 0p300
+
+// Nonces prevent commitment replay attacks
+let nonce_alice   = 0p1111
+let nonce_bob     = 0p2222
+let nonce_charlie = 0p3333
+
+// Public commitments: hash(bid, nonce) — published on-chain
+let commit_alice   = poseidon(bid_alice,   nonce_alice)
+let commit_bob     = poseidon(bid_bob,     nonce_bob)
+let commit_charlie = poseidon(bid_charlie, nonce_charlie)
+
+print("Commitments published:")
+print("  Alice:   " + commit_alice.to_string())
+print("  Bob:     " + commit_bob.to_string())
+print("  Charlie: " + commit_charlie.to_string())
+
+// --- Phase 2: Reveal & Prove Winner (VM + ZK) ---
+
+// The auctioneer (Bob) proves he won without revealing Alice/Charlie's bids.
+// Bob knows all bids (received sealed), but the proof only reveals his commitment.
+
+let winning_bid   = bid_bob
+let winning_nonce = nonce_bob
+let winning_commit = commit_bob
+
+// Prove: winning bid is valid, committed, and highest
+prove(winning_commit: Public, commit_alice: Public, commit_charlie: Public) {
+    // 1. Commitment integrity: hash(bid, nonce) == published commitment
+    assert_eq(poseidon(winning_bid, winning_nonce), winning_commit)
+
+    // 2. Range validity: bid is in [1, 2^32)
+    range_check(winning_bid, 32)
+
+    // 3. Winning bid > Alice's bid
+    let alice_bid_recovered = bid_alice
+    assert_eq(poseidon(alice_bid_recovered, nonce_alice), commit_alice)
+    range_check(alice_bid_recovered, 32)
+    assert(winning_bid > alice_bid_recovered)
+
+    // 4. Winning bid > Charlie's bid
+    let charlie_bid_recovered = bid_charlie
+    assert_eq(poseidon(charlie_bid_recovered, nonce_charlie), commit_charlie)
+    range_check(charlie_bid_recovered, 32)
+    assert(winning_bid > charlie_bid_recovered)
+}
+
+print("Auction verified: winner's bid is valid, committed, and highest")
+
+// --- Phase 3: Independent bid-validity proofs ---
+
+// Each bidder can independently prove their bid was in range
+// without revealing the amount
+
+fn prove_bid_valid(bid, nonce, commitment) {
+    prove(commitment: Public) {
+        assert_eq(poseidon(bid, nonce), commitment)
+        range_check(bid, 32)
+    }
+}
+
+prove_bid_valid(bid_alice, nonce_alice, commit_alice)
+prove_bid_valid(bid_charlie, nonce_charlie, commit_charlie)
+
+print("All bid validity proofs verified")
+print("PASS: private_auction")

--- a/samples/Achronyme/proof_of_membership.ach
+++ b/samples/Achronyme/proof_of_membership.ach
@@ -1,0 +1,121 @@
+// ============================================================================
+// Proof of Membership — Zero-Knowledge Set Inclusion
+// ============================================================================
+//
+// Demonstrates: Poseidon commitments, Merkle tree construction,
+// private witnesses, public inputs, and merkle_verify in a prove block.
+//
+// Scenario: A club has 8 members, each identified by a secret key.
+// Member commitments form a Merkle tree.  Any member can prove they
+// belong to the club WITHOUT revealing which member they are.
+//
+//                        root
+//                      /      \
+//                   n01        n23
+//                  /    \     /    \
+//                n0     n1   n2    n3
+//               / \    / \  / \   / \
+//              m0 m1 m2 m3 m4 m5 m6 m7
+//
+// Public input:  merkle_root (the club's public commitment)
+// Private witness: secret_key, merkle path (3 siblings + 3 direction bits)
+
+// --- Phase 1: Club setup (all in the clear, done by club operator) ---
+
+// 8 member secret keys (in production, each member keeps theirs private)
+let key_0 = 0p101
+let key_1 = 0p202
+let key_2 = 0p303
+let key_3 = 0p404
+let key_4 = 0p505
+let key_5 = 0p606
+let key_6 = 0p707
+let key_7 = 0p808
+
+// Member commitments: hash of secret key (one-way binding)
+let m0 = poseidon(key_0, 0)
+let m1 = poseidon(key_1, 0)
+let m2 = poseidon(key_2, 0)
+let m3 = poseidon(key_3, 0)
+let m4 = poseidon(key_4, 0)
+let m5 = poseidon(key_5, 0)
+let m6 = poseidon(key_6, 0)
+let m7 = poseidon(key_7, 0)
+
+// Build depth-3 Merkle tree (bottom-up)
+// Level 1: pair leaves
+let n0 = poseidon(m0, m1)
+let n1 = poseidon(m2, m3)
+let n2 = poseidon(m4, m5)
+let n3 = poseidon(m6, m7)
+
+// Level 2: pair level-1 nodes
+let n01 = poseidon(n0, n1)
+let n23 = poseidon(n2, n3)
+
+// Root
+let merkle_root = poseidon(n01, n23)
+
+print("=== Proof of Membership ===")
+print("Club Merkle root: " + merkle_root.to_string())
+print("8 members registered")
+print("")
+
+// --- Phase 2: Member 5 proves membership ---
+//
+// Member 5 (key_5) wants to prove they're in the club.
+// They construct a Merkle proof: the path from their leaf to the root.
+//
+// m5 is at index 5 (binary: 101)
+//   Level 0: m5 is RIGHT child of n2 → sibling = m4, index = 1
+//   Level 1: n2 is LEFT child of n23 → sibling = n3, index = 0
+//   Level 2: n23 is RIGHT child of root → sibling = n01, index = 1
+//
+let proof_path: Field[3] = [m4, n3, n01]
+let proof_indices: Field[3] = [0p1, 0p0, 0p1]
+
+print("Member 5 proving membership...")
+
+prove membership(merkle_root: Public) {
+    // The prover knows their secret key (private witness via capture)
+    let my_commitment = poseidon(key_5, 0)
+
+    // Verify: my_commitment is a leaf in the tree rooted at merkle_root
+    // This unfolds into 3 levels of: conditional swap + single hash
+    // (2 mux + 1 poseidon per level), then assert_eq(computed_root, merkle_root)
+    merkle_verify(merkle_root, my_commitment, proof_path, proof_indices)
+}
+
+print("Membership verified!")
+print("")
+
+// --- Phase 3: Verify the proof reveals nothing ---
+//
+// The verifier sees: merkle_root (public) + a valid proof.
+// They learn NOTHING about which member proved membership.
+// The secret key, the leaf index, and the path are all private.
+
+// --- Phase 4: Member 0 also proves membership ---
+
+let path_0: Field[3] = [m1, n1, n23]
+let idx_0: Field[3] = [0p0, 0p0, 0p0]
+
+print("Member 0 proving membership...")
+
+prove membership_0(merkle_root: Public) {
+    let my_commitment = poseidon(key_0, 0)
+    merkle_verify(merkle_root, my_commitment, path_0, idx_0)
+}
+
+print("Membership verified!")
+print("")
+
+// --- Phase 5: Non-member fails ---
+//
+// A non-member with a fake key cannot produce a valid proof
+// because no leaf in the tree matches their commitment.
+// (We don't demonstrate failure here — the prover simply cannot
+// construct a valid witness that satisfies the constraints.)
+
+print("=== Both members proved membership without revealing identity ===")
+print("PASS: proof_of_membership")

--- a/samples/Achronyme/tornado_mixer.ach
+++ b/samples/Achronyme/tornado_mixer.ach
@@ -1,0 +1,152 @@
+// ============================================================================
+// Tornado Cash–style Private Mixer
+// ============================================================================
+//
+// Demonstrates: circuit declarations with typed visibility params,
+// Poseidon commitments, Merkle membership, nullifier derivation, and
+// the deposit→withdraw flow of a privacy-preserving mixer.
+//
+// Protocol overview:
+//   1. DEPOSIT: User picks (nullifier, secret), computes
+//      commitment = Poseidon(nullifier, secret), and publishes it.
+//      Commitments form leaves in a Merkle tree.
+//
+//   2. WITHDRAW: User proves in ZK:
+//      a) They know (nullifier, secret) for some commitment in the tree
+//      b) The nullifier_hash matches (prevents double-spending)
+//      c) A recipient address is bound to the proof (prevents front-running)
+//      Without revealing WHICH commitment is theirs.
+//
+// This is a faithful translation of the Tornado Cash circuit from Circom,
+// adapted to Achronyme's syntax with type annotations and visibility.
+
+// --- Phase 1: Setup deposit tree (VM mode) ---
+
+// Four users deposit into the mixer
+// Each user generates a random (nullifier, secret) pair
+
+let nullifier_0 = 0p111111
+let secret_0    = 0p222222
+let commitment_0 = poseidon(nullifier_0, secret_0)
+
+let nullifier_1 = 0p333333
+let secret_1    = 0p444444
+let commitment_1 = poseidon(nullifier_1, secret_1)
+
+let nullifier_2 = 0p555555
+let secret_2    = 0p666666
+let commitment_2 = poseidon(nullifier_2, secret_2)
+
+let nullifier_3 = 0p777777
+let secret_3    = 0p888888
+let commitment_3 = poseidon(nullifier_3, secret_3)
+
+// Build a depth-2 Merkle tree of commitments
+//
+//           root
+//          /    \
+//      node_L   node_R
+//      /   \     /   \
+//    c_0  c_1  c_2  c_3
+
+let node_left  = poseidon(commitment_0, commitment_1)
+let node_right = poseidon(commitment_2, commitment_3)
+let root = poseidon(node_left, node_right)
+
+print("=== Tornado Mixer ===")
+print("Deposit tree root: " + root.to_string())
+print("4 deposits registered")
+
+// --- Phase 2: User 0 withdraws (VM + ZK) ---
+
+// User 0 wants to withdraw. They prove they know a valid deposit
+// without revealing which one.
+
+// Public: root, nullifier_hash, recipient
+// Witness: nullifier, secret, merkle proof path + indices
+
+// Nullifier hash: published on-chain to prevent double-spending
+let nullifier_hash = poseidon(nullifier_0, 0p0)
+
+// Recipient address (a field element representing an Ethereum address)
+let recipient = 0p42
+
+// Merkle proof for commitment_0:
+//   Sibling path: [commitment_1, node_right]
+//   Indices:      [0, 0] (left at both levels)
+let path: Field[2] = [commitment_1, node_right]
+let indices: Field[2] = [0p0, 0p0]
+
+print("")
+print("User 0 withdrawing...")
+
+prove withdrawal(root: Public, nullifier_hash: Public, recipient: Public) {
+    // === Core Tornado Cash circuit ===
+
+    // 1. Reconstruct commitment from secret inputs
+    let commitment = poseidon(nullifier_0, secret_0)
+
+    // 2. Verify commitment is in the Merkle tree
+    //    This proves "I deposited" without revealing which leaf
+    merkle_verify(root, commitment, path, indices)
+
+    // 3. Verify nullifier hash matches
+    //    Nullifier is derived deterministically from the secret,
+    //    so each deposit can only be withdrawn once
+    assert_eq(poseidon(nullifier_0, 0p0), nullifier_hash)
+
+    // 4. Bind the recipient to the proof
+    //    Without this, a miner could replace the recipient address
+    //    (front-running attack). The recipient is a public input,
+    //    so changing it invalidates the proof.
+    //    We include it as a dummy constraint: recipient² = recipient²
+    let r_sq = recipient * recipient
+    assert_eq(r_sq, recipient * recipient)
+}
+
+print("Withdrawal proof verified!")
+print("Nullifier hash: " + nullifier_hash.to_string())
+print("Recipient:      " + recipient.to_string())
+
+// --- Phase 3: Double-spend prevention ---
+
+// If user 0 tries to withdraw again with the same nullifier,
+// the on-chain contract would reject it because nullifier_hash
+// was already seen. In ZK, we can demonstrate this:
+
+prove double_spend_check(nullifier_hash: Public) {
+    // Same nullifier produces same hash — deterministic
+    assert_eq(poseidon(nullifier_0, 0p0), nullifier_hash)
+}
+
+print("")
+print("Same nullifier → same hash (double-spend detected on-chain)")
+print("Nullifier hash: " + nullifier_hash.to_string())
+
+// --- Phase 4: User 2 withdraws independently ---
+
+let nullifier_hash_2 = poseidon(nullifier_2, 0p0)
+let recipient_2 = 0p99
+
+// Merkle proof for commitment_2:
+//   Sibling path: [commitment_3, node_left]
+//   Indices:      [0, 1] (left at level 0, right at level 1)
+let path_2: Field[2] = [commitment_3, node_left]
+let idx_2: Field[2] = [0p0, 0p1]
+
+print("")
+print("User 2 withdrawing...")
+
+prove withdrawal_2(root: Public, nullifier_hash_2: Public, recipient_2: Public) {
+    let commitment = poseidon(nullifier_2, secret_2)
+    merkle_verify(root, commitment, path_2, idx_2)
+    assert_eq(poseidon(nullifier_2, 0p0), nullifier_hash_2)
+
+    let r_sq = recipient_2 * recipient_2
+    assert_eq(r_sq, recipient_2 * recipient_2)
+}
+
+print("User 2 withdrawal verified!")
+print("")
+print("=== Both withdrawals complete, no identities revealed ===")
+print("PASS: tornado_mixer")


### PR DESCRIPTION
## Description

Add [Achronyme](https://achrony.me), a programming language for zero-knowledge cryptography.

Achronyme features a dual-execution model: a full VM mode for general computation and a circuit mode that compiles to R1CS and Plonkish constraint systems for ZK proof generation. Key language features include:

- `prove {}` blocks that compile to zero-knowledge circuits
- Built-in Poseidon hashing, Merkle verification, and range checks
- First-class proof values (generate, verify, and compose proofs in the same program)
- Typed visibility annotations (`Public`/`Witness`) for circuit inputs
- BN254 field arithmetic as a native type

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.ach+prove+poseidon
    - Note: Achronyme is a new language (currently in beta). The `.ach` extension is unique to this language and does not conflict with any existing language in Linguist. The main repository ([achronyme/achronyme](https://github.com/achronyme/achronyme)) contains 170+ `.ach` files across tests and examples.
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [tornado_mixer.ach](https://github.com/achronyme/achronyme/blob/main/examples/tornado_mixer.ach) — Tornado Cash-style private mixer (Poseidon commitments, Merkle membership, nullifier derivation)
      - [proof_of_membership.ach](https://github.com/achronyme/achronyme/blob/main/examples/proof_of_membership.ach) — Zero-knowledge set inclusion with Merkle trees
      - [credential_proof.ach](https://github.com/achronyme/achronyme/blob/main/examples/credential_proof.ach) — Anonymous credential verification with range checks
      - [private_auction.ach](https://github.com/achronyme/achronyme/blob/main/examples/private_auction.ach) — Sealed-bid auction with commitment schemes
      - [hash_chain_proof.ach](https://github.com/achronyme/achronyme/blob/main/examples/hash_chain_proof.ach) — Verifiable iterated hash chain
    - Sample license(s): GPL-3.0 (same as the language repository)
  - [x] I have included a syntax highlighting grammar: https://github.com/achronyme/achronyme-editor
    - The grammar is a comprehensive TextMate `.tmLanguage.json` with 14 pattern groups covering comments, imports, strings, numbers (including field literals `0p` and big integers `0i256`), type annotations, ZK builtins, prove/circuit blocks, and operators.
  - [x] I have added a color
    - Hex value: `#A855F7`
    - Rationale: This is the official brand color of the Achronyme project, used across the documentation site ([docs.achrony.me](https://docs.achrony.me)), playground ([play.achrony.me](https://play.achrony.me)), and VS Code extension. It represents a purple tone commonly associated with cryptography and zero-knowledge proofs.
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.
    - The `.ach` extension is not used by any other language currently in Linguist, so no disambiguation heuristics are needed.