### PR TITLE
Add Sline language support (.slt)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1590,3 +1590,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/sline-textmate"]
+	path = vendor/grammars/sline-textmate
+	url = https://github.com/shoplineos/sline-textmate

--- a/grammars.yml
+++ b/grammars.yml
@@ -1049,6 +1049,8 @@ vendor/grammars/slang-vscode-extension:
 - source.slang
 vendor/grammars/slint-tmLanguage:
 - source.slint
+vendor/grammars/sline-textmate:
+- text.html.sline
 vendor/grammars/smali-sublime:
 - source.smali
 vendor/grammars/smalltalk-tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7358,6 +7358,14 @@ Slint:
   tm_scope: source.slint
   ace_mode: text
   language_id: 119900149
+Sline:
+  type: markup
+  color: "#5F9AE0"
+  extensions:
+  - ".slt"
+  tm_scope: text.html.sline
+  ace_mode: sline
+  language_id: 888
 SmPL:
   type: programming
   extensions:

--- a/samples/Sline/example1.slt
+++ b/samples/Sline/example1.slt
@@ -1,0 +1,61 @@
+{{!-- Sline injection example: HTML / JSON / Script / Style --}}
+{{!-- Written for the GitHub Linguist PR. MIT License. --}}
+
+<div
+  {{ settings.color_scheme.id }}
+
+  class="{{ settings.color_scheme.id }}"
+
+  data-options="{{settings.spacing | class_list()}}"
+
+  {{#if settings.article_card_style == "card"}}article-card-border-shadow{{/if}}
+>
+
+  {{ product.title }}
+
+</div>
+
+<script type="application/ld+json" {{{settings.test}}} {{#if true}}data-test="123"{{/if}}>
+  {
+    "@type": "Product",
+
+    "name": "{{product.title}}",
+
+    "url": "{{{request.origin | append(product.url)}}}",
+
+    {{#if seo_media}}
+      "image": [
+        "{{{seo_media.preview_image.src}}}"
+      ],
+    {{/if}}
+
+    "description": {{{product.description | strip_html() | json()}}}
+  }
+</script>
+
+<script {{settings.test}}>
+
+  let foo: string = {{settings.var}};
+
+  let foo: string = "{{settings.string}}";
+
+  function test() {
+
+    var arr = [0,1,2,3,4,5,{{settings.item | append("123")}}];
+
+    console.log(arr);
+
+  }
+</script>
+
+<style {{settings.test}}>
+  .foo {
+
+    width: "{{settings.width | append("123")}}px";
+
+    height: {{settings.height | append("456")}};
+
+    {{settings.display}}: block;
+
+  }
+</style>

--- a/samples/Sline/example2.slt
+++ b/samples/Sline/example2.slt
@@ -1,0 +1,90 @@
+{{!-- Sline grammar example --}}
+{{!-- Written for the GitHub Linguist PR. MIT License. --}}
+
+{{product | image_url(width=100, height=200, quality=100) | append("?test=1")}}
+
+{{ "str1" }}
+
+{{ `str1` }}
+
+{{ 123 }}
+
+{{ as }}
+
+{{ true }}
+
+{{ product }}
+
+{{ abc }}
+
+{{ aaa }}
+
+{{ page_title }}
+
+{{ product.featured_image }}
+
+{{ product.featured_image.id }}
+
+{{ product.tags[123] }}
+
+{{ product.tags["id"] }}
+
+{{ product.tags[id] }}
+
+{{#var tags = product.tags /}}
+
+{{ tags[123] }}
+
+{{ tags["id"] }}
+
+{{ tags[key] }}
+
+{{#var num = 123 /}}
+
+{{#var bool = true /}}
+
+{{#var str1 = "hello" /}}
+
+{{#var str2 = `hello` /}}
+
+{{#var str3 = "string：\<>\"',abc：😂🎉🚀" /}}
+
+{{#if num > 1}}hello{{/if}}
+
+{{#for item in arr }}
+  {{#var current_price_break = item.price /}}
+{{/for}}
+
+{{#component "stylesheet" src="./customers-account.css" | asset_url() /}}
+
+{{#image_tag
+  src | image_url(width=100, height=200, quality=100) | append("?test=1")
+  class="img"
+  loading=loading
+/}}
+
+{{#if arr | size() > 0 || (b == "test" && c ) }}
+  OK
+{{/if}}
+
+{{#schema}}
+{
+  "name": "account",
+  "settings": [
+    {
+      "id": "color_scheme",
+      "type": "color_scheme",
+      "label": 123,
+      "default": true
+    },
+    {
+      {{#if settings.test}}
+        "type": "style.spacing",
+      {{/if}}
+      "id": "{{settings.id}}",
+      "label": {{settings.label}},
+      "default": ""
+    }
+  ]
+}
+{{/schema}}


### PR DESCRIPTION
  This PR adds support for the Sline language to GitHub Linguist.

  ## What is Sline?

  Sline is a markup language (`.slt` extension) developed by [SHOPLINE](https://shopline.com) for building e-commerce storefront themes. It extends HTML with template syntax for dynamic content rendering.

  ## Changes

  - Added Sline entry to `lib/linguist/languages.yml`
  - Added `sline-textmate` grammar submodule to `vendor/grammars/`
  - Added grammar reference to `grammars.yml`
  - Added sample files in `samples/Sline/`

  ## References

  - Developer documentation: https://developer.shopline.com/docs/sline/sline-overview
  - VS Code extension: https://marketplace.visualstudio.com/items?itemName=shopline-developer.shopline-developer-plugin
  - TextMate grammar: https://github.com/shoplineos/sline-textmate
  - npm package: https://www.npmjs.com/package/@shoplineos/sline-textmate
  - Maintained by: https://shopline.com