### PR TITLE
Add Sline language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1151,6 +1151,9 @@
 [submodule "vendor/grammars/slang-vscode-extension"]
 	path = vendor/grammars/slang-vscode-extension
 	url = https://github.com/shader-slang/slang-vscode-extension.git
+[submodule "vendor/grammars/sline-textmate"]
+	path = vendor/grammars/sline-textmate
+	url = https://github.com/shoplineos/sline-textmate.git
 [submodule "vendor/grammars/slint-tmLanguage"]
 	path = vendor/grammars/slint-tmLanguage
 	url = https://github.com/slint-ui/slint-tmLanguage.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1047,6 +1047,8 @@ vendor/grammars/shaders-tmLanguage:
 - source.shaderlab
 vendor/grammars/slang-vscode-extension:
 - source.slang
+vendor/grammars/sline-textmate:
+- text.html.sline
 vendor/grammars/slint-tmLanguage:
 - source.slint
 vendor/grammars/smali-sublime:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7350,6 +7350,14 @@ Slim:
   codemirror_mode: slim
   codemirror_mime_type: text/x-slim
   language_id: 350
+Sline:
+  type: markup
+  color: "#5F9AE0"
+  extensions:
+  - ".slt"
+  tm_scope: text.html.sline
+  ace_mode: text
+  language_id: 853616656
 Slint:
   type: markup
   color: "#2379F4"

--- a/samples/Sline/example1.slt
+++ b/samples/Sline/example1.slt
@@ -1,0 +1,61 @@
+{{!-- Sline injection example: HTML / JSON / Script / Style --}}
+{{!-- Written for the GitHub Linguist PR. MIT License. --}}
+
+<div
+  {{ settings.color_scheme.id }}
+
+  class="{{ settings.color_scheme.id }}"
+
+  data-options="{{settings.spacing | class_list()}}"
+
+  {{#if settings.article_card_style == "card"}}article-card-border-shadow{{/if}}
+>
+
+  {{ product.title }}
+
+</div>
+
+<script type="application/ld+json" {{{settings.test}}} {{#if true}}data-test="123"{{/if}}>
+  {
+    "@type": "Product",
+
+    "name": "{{product.title}}",
+
+    "url": "{{{request.origin | append(product.url)}}}",
+
+    {{#if seo_media}}
+      "image": [
+        "{{{seo_media.preview_image.src}}}"
+      ],
+    {{/if}}
+
+    "description": {{{product.description | strip_html() | json()}}}
+  }
+</script>
+
+<script {{settings.test}}>
+
+  let foo: string = {{settings.var}};
+
+  let foo: string = "{{settings.string}}";
+
+  function test() {
+
+    var arr = [0,1,2,3,4,5,{{settings.item | append("123")}}];
+
+    console.log(arr);
+
+  }
+</script>
+
+<style {{settings.test}}>
+  .foo {
+
+    width: "{{settings.width | append("123")}}px";
+
+    height: {{settings.height | append("456")}};
+
+    {{settings.display}}: block;
+
+  }
+</style>

--- a/samples/Sline/example2.slt
+++ b/samples/Sline/example2.slt
@@ -1,0 +1,90 @@
+{{!-- Sline grammar example --}}
+{{!-- Written for the GitHub Linguist PR. MIT License. --}}
+
+{{product | image_url(width=100, height=200, quality=100) | append("?test=1")}}
+
+{{ "str1" }}
+
+{{ `str1` }}
+
+{{ 123 }}
+
+{{ as }}
+
+{{ true }}
+
+{{ product }}
+
+{{ abc }}
+
+{{ aaa }}
+
+{{ page_title }}
+
+{{ product.featured_image }}
+
+{{ product.featured_image.id }}
+
+{{ product.tags[123] }}
+
+{{ product.tags["id"] }}
+
+{{ product.tags[id] }}
+
+{{#var tags = product.tags /}}
+
+{{ tags[123] }}
+
+{{ tags["id"] }}
+
+{{ tags[key] }}
+
+{{#var num = 123 /}}
+
+{{#var bool = true /}}
+
+{{#var str1 = "hello" /}}
+
+{{#var str2 = `hello` /}}
+
+{{#var str3 = "string：\<>\"',abc：😂🎉🚀" /}}
+
+{{#if num > 1}}hello{{/if}}
+
+{{#for item in arr }}
+  {{#var current_price_break = item.price /}}
+{{/for}}
+
+{{#component "stylesheet" src="./customers-account.css" | asset_url() /}}
+
+{{#image_tag
+  src | image_url(width=100, height=200, quality=100) | append("?test=1")
+  class="img"
+  loading=loading
+/}}
+
+{{#if arr | size() > 0 || (b == "test" && c ) }}
+  OK
+{{/if}}
+
+{{#schema}}
+{
+  "name": "account",
+  "settings": [
+    {
+      "id": "color_scheme",
+      "type": "color_scheme",
+      "label": 123,
+      "default": true
+    },
+    {
+      {{#if settings.test}}
+        "type": "style.spacing",
+      {{/if}}
+      "id": "{{settings.id}}",
+      "label": {{settings.label}},
+      "default": ""
+    }
+  ]
+}
+{{/schema}}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -588,6 +588,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Slash:** [slash-lang/Slash.tmbundle](https://github.com/slash-lang/Slash.tmbundle)
 - **Slice:** [zeroc-ice/vscode-slice](https://github.com/zeroc-ice/vscode-slice)
 - **Slim:** [borama/vscode-ruby-slim](https://github.com/borama/vscode-ruby-slim)
+- **Sline:** [shoplineos/sline-textmate](https://github.com/shoplineos/sline-textmate)
 - **Slint:** [slint-ui/slint-tmLanguage](https://github.com/slint-ui/slint-tmLanguage)
 - **SmPL:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **Smali:** [ShaneWilton/sublime-smali](https://github.com/ShaneWilton/sublime-smali)

--- a/vendor/licenses/git_submodule/sline-textmate.dep.yml
+++ b/vendor/licenses/git_submodule/sline-textmate.dep.yml
@@ -1,0 +1,20 @@
+---
+name: sline-textmate
+version: aad9894da81778d770c4089db1ec2cda39a2f7ed
+type: git_submodule
+homepage: https://github.com/shoplineos/sline-textmate.git
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |-
+    Copyright (c) 2026 Shopline Commerce Pte. Ltd.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: This project is licensed under the MIT License - see the [LICENSE.md](./LICENSE.md)
+    file for details.
+notices: []


### PR DESCRIPTION
  Add Sline (.slt) markup language support. Sline is an HTML templating language used by the SHOPLINE e-commerce platform for storefront themes.

  ## Description

  Sline is a markup/templating language that extends HTML with template syntax (`{{ }}`, `{{#if}}`, filters like `{{ value | filter() }}`). It is used by merchants on the SHOPLINE platform to build and customize online store
  themes.

  - Grammar repository: https://github.com/shoplineos/sline-textmate
  - Language homepage: https://developer.shopline.com/docs/sline/sline-overview

  ## Checklist:

  - [x] **I am adding a new language.**
    - [x] I have included a real-world usage sample for all extensions added in this PR:
      - Sample source(s):
        - Written specifically for this PR
      - Sample license(s):
        - MIT (same as Linguist)
    - [x] I have included a syntax highlighting grammar: https://github.com/shoplineos/sline-textmate
    - [x] I have added a color
      - Hex value: `#5F9AE0`
      - Rationale: Blue tone reflecting the SHOPLINE brand identity
    - [x] I have updated the heuristics to distinguish my language from others using the same extension.
      - `.slt` is not used by any other language in Linguist, so no heuristics are needed.

  ## References:

  Developer documentation: https://developer.shopline.com/docs/sline/sline-overview

  VS Code extension: https://marketplace.visualstudio.com/items?itemName=shopline-developer.shopline-developer-plugin

  TextMate grammar: https://github.com/shoplineos/sline-textmate

  NPM package: https://www.npmjs.com/package/@shoplineos/sline-textmate

  Maintained by: https://shopline.com