### PR TITLE
Add A2ML (Attested Markup Language)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1590,3 +1590,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/vscode-a2ml"]
+	path = vendor/grammars/vscode-a2ml
+	url = https://github.com/hyperpolymath/vscode-a2ml.git

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -60,6 +60,14 @@
   tm_scope: source.4dm
   ace_mode: text
   language_id: 577529595
+A2ML:
+  type: data
+  color: "#4B0082"
+  extensions:
+  - ".a2ml"
+  tm_scope: source.a2ml
+  ace_mode: yaml
+  language_id: 1099511627776
 ABAP:
   type: programming
   color: "#E8274B"

--- a/samples/A2ML/example.a2ml
+++ b/samples/A2ML/example.a2ml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: PMPL-1.0-or-later
+# A2ML — Attested Markup Language example
+
+@abstract
+  name: burble-voice-platform
+  version: 1.0.0
+  type: application
+  purpose: "P2P encrypted voice chat with AI data channel"
+
+@pedigree
+  attested-by: "Jonathan D.A. Jewell"
+  trust-level: verified
+  provenance: https://github.com/hyperpolymath/burble
+  integrity: sha256:e3b0c44298fc1c149afbf4c8996fb924
+  chain-of-custody: hyperpolymath → rhodibot → hypatia
+  compliance: PMPL-1.0-or-later
+
+@refs
+  specification: https://github.com/hyperpolymath/standards/tree/main/a2ml
+  related: burble, gossamer, panll


### PR DESCRIPTION
## Description

Add [A2ML](https://github.com/hyperpolymath/standards/tree/main/a2ml) (Attested Markup Language) as a recognized data language.

A2ML is a lightweight attested markup format with typed, formally verified attestation semantics. It's used for AI manifests, pedigree/provenance chains, and machine-readable metadata.

## Details

- **Type:** data
- **Extension:** `.a2ml`
- **Color:** `#4B0082` (indigo)
- **Grammar:** [hyperpolymath/vscode-a2ml](https://github.com/hyperpolymath/vscode-a2ml) (TextMate, MPL-2.0)
- **MIME:** `application/vnd.a2ml` (IANA registration pending)

## Usage on GitHub

[840+ files with `.a2ml` extension](https://github.com/search?q=path%3A*.a2ml&type=code) across multiple repositories, used for:
- AI agent manifests (`0-AI-MANIFEST.a2ml`)
- Machine-readable project state (`STATE.a2ml`)
- Ecosystem metadata (`ECOSYSTEM.a2ml`, `META.a2ml`)

## Checklist

- [x] Language entry in `languages.yml`
- [x] TextMate grammar (via submodule)
- [x] Sample file in `samples/A2ML/`
- [x] 200+ files on GitHub (840+ found)