### PR TITLE
Add Lateralus language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1590,3 +1590,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/lateralus-grammar"]
+	path = vendor/grammars/lateralus-grammar
+	url = https://github.com/bad-antics/lateralus-grammar.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1440,3 +1440,9 @@ vendor/grammars/zenstack:
 - source.zmodel
 vendor/grammars/zephir-sublime:
 - source.php.zephir
+vendor/grammars/lateralus-grammar:
+- source.ltl
+- source.ltasm
+- source.ltlcfg
+- source.ltlm
+- source.ltlnb

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4129,6 +4129,51 @@ Lasso:
   - lassoscript
   ace_mode: text
   language_id: 195
+Lateralus:
+  type: programming
+  color: "#6e8fdc"
+  extensions:
+  - ".ltl"
+  tm_scope: source.ltl
+  ace_mode: text
+  language_id: 1067292665
+Lateralus Assembly:
+  type: programming
+  color: "#6e8fdc"
+  extensions:
+  - ".ltasm"
+  tm_scope: source.ltasm
+  group: Lateralus
+  ace_mode: text
+  language_id: 1067292666
+Lateralus Config:
+  type: data
+  color: "#6e8fdc"
+  extensions:
+  - ".ltlcfg"
+  tm_scope: source.ltlcfg
+  group: Lateralus
+  ace_mode: text
+  language_id: 1067292667
+Lateralus Markup:
+  type: markup
+  color: "#6e8fdc"
+  extensions:
+  - ".ltlm"
+  - ".ltlml"
+  tm_scope: source.ltlm
+  group: Lateralus
+  ace_mode: text
+  language_id: 1067292668
+Lateralus Notebook:
+  type: programming
+  color: "#6e8fdc"
+  extensions:
+  - ".ltlnb"
+  tm_scope: source.ltlnb
+  group: Lateralus
+  ace_mode: text
+  language_id: 1067292669
 Latte:
   type: markup
   color: "#f2a542"

--- a/samples/Lateralus Assembly/fibonacci.ltasm
+++ b/samples/Lateralus Assembly/fibonacci.ltasm
@@ -1,0 +1,80 @@
+; examples/fibonacci.ltasm  ─  Fibonacci in Lateralus Assembly
+;
+; Recursive fibonacci implementation using the LTasm call stack.
+; Demonstrates: CALL, RET, CMP, JLE, SUB, ADD, DUP, PUSH_IMM
+
+.section code
+.global _start
+
+; ── Entry point ───────────────────────────────────────────────────────────────
+_start:
+    PUSH_STR    "Fibonacci sequence (LTasm):"
+    PRINTLN
+
+    ; Print fib(0) through fib(12)
+    PUSH_IMM    0          ; i = 0
+.loop:
+    DUP                    ; stack: i i
+    PUSH_IMM    12
+    CMPGT                  ; (i > 12) ?
+    JT          .done
+
+    DUP                    ; stack: i i  (for CALL arg)
+    CALL        .fib       ; result = fib(i)  (consumes top i, pushes result)
+
+    ; Build string "fib(i) = result"
+    INT_TO_STR
+    PUSH_STR    " = "
+    SWAP
+    STR_CAT                ; " = result"
+
+    ; Prepend "fib(i)"
+    SWAP                   ; stack: result_str  i
+    DUP
+    INT_TO_STR
+    PUSH_STR    "fib("
+    SWAP
+    STR_CAT
+    PUSH_STR    ")"
+    STR_CAT
+    SWAP                   ; stack: i  "fib(i)"
+    SWAP                   ; stack: "fib(i)"  " = result"
+    STR_CAT
+    PRINTLN
+
+    INC                    ; i += 1
+    JMP         .loop
+
+.done:
+    POP
+    PUSH_IMM    0
+    HALT
+
+
+; ── fib(n) — recursive ────────────────────────────────────────────────────────
+; Input:  n on stack (consumed)
+; Output: fib(n) pushed onto stack
+fib:
+    DUP
+    PUSH_IMM    1
+    CMPLE
+    JT          .fib_base  ; if n <= 1: return n
+
+    ; fib(n-1)
+    DUP
+    DEC
+    CALL        .fib
+
+    ; fib(n-2)
+    SWAP
+    PUSH_IMM    2
+    SUB
+    CALL        .fib
+
+    ; fib(n-1) + fib(n-2)
+    ADD
+    RET
+
+.fib_base:
+    ; n is already on stack (0 or 1)
+    RET

--- a/samples/Lateralus Assembly/hello.ltasm
+++ b/samples/Lateralus Assembly/hello.ltasm
@@ -1,0 +1,39 @@
+; examples/hello.ltasm  ─  Hello World in Lateralus Assembly
+;
+; Demonstrates core LTasm instructions:
+;   PUSH_STR, PRINTLN, PUSH_IMM, ADD, PRINTLN, HALT
+;
+; Assemble and run:
+;   ltlc run hello.ltasm
+
+.section code
+.global _start
+
+_start:
+    ; Push the greeting string and print it
+    PUSH_STR    "Hello from LATERALUS Assembly!"
+    PRINTLN
+
+    ; Arithmetic: compute 6 * 7
+    PUSH_IMM    6
+    PUSH_IMM    7
+    MUL
+    INT_TO_STR
+    PUSH_STR    "6 * 7 = "
+    SWAP
+    STR_CAT
+    PRINTLN
+
+    ; Demonstrate the call stack
+    CALL        .print_version
+    
+    ; Exit with code 0
+    PUSH_IMM    0
+    HALT
+
+
+; Subroutine: print version info
+print_version:
+    PUSH_STR    "LTasm VM  v1.0.0"
+    PRINTLN
+    RET

--- a/samples/Lateralus/advanced_pipeline.ltl
+++ b/samples/Lateralus/advanced_pipeline.ltl
@@ -1,0 +1,237 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// examples/advanced_pipeline.ltl  –  Multi-stage data pipelines  (v1.1.0)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Demonstrates:
+//   • Structs and impl blocks to model a data pipeline stage
+//   • Function references (higher-order programming)
+//   • Collections: map / filter / foldl / zip / chunk
+//   • String formatting helpers from stdlib/strings
+//   • Composing multiple pipeline stages with |> (pipe) style calls
+//   • Type aliases for readability
+// ─────────────────────────────────────────────────────────────────────────────
+
+from stdlib.strings     import join, pad_left, format_int
+from stdlib.collections import map, filter, foldl, zip, chunk, sort, reverse, enumerate_list
+
+// ── Type aliases ─────────────────────────────────────────────────────────────
+
+pub type Row     = list    // A single CSV row (list of values)
+pub type Table   = list    // A list of rows
+pub type PipelineFn = fn   // fn(Table) -> Table
+
+// ── Pipeline stage ────────────────────────────────────────────────────────────
+
+pub struct Stage {
+    name:    str
+    process: fn      // fn(Table) -> Table
+}
+
+impl Stage {
+    pub fn new(name: str, process: fn) -> Stage {
+        return Stage { name: name, process: process }
+    }
+
+    pub fn run(self, data: Table) -> Table {
+        println("  [" + self.name + "] rows in: " + str(len(data)))
+        let result = self.process(data)
+        println("  [" + self.name + "] rows out: " + str(len(result)))
+        return result
+    }
+}
+
+// ── Pipeline ─────────────────────────────────────────────────────────────────
+
+pub struct Pipeline {
+    stages: list
+    name:   str
+}
+
+impl Pipeline {
+    pub fn new(name: str) -> Pipeline {
+        return Pipeline { stages: [], name: name }
+    }
+
+    pub fn add_stage(self, stage: Stage) -> Pipeline {
+        return Pipeline {
+            name:   self.name,
+            stages: push(self.stages, stage)
+        }
+    }
+
+    pub fn execute(self, data: Table) -> Table {
+        println("\nPipeline: " + self.name)
+        println("─────────────────────────────────────")
+        let current = data
+        let i = 0
+        while i < len(self.stages) {
+            current = self.stages[i].run(current)
+            i = i + 1
+        }
+        println("─────────────────────────────────────")
+        return current
+    }
+}
+
+// ── Stage implementations ─────────────────────────────────────────────────────
+
+// Filter rows where column `col` (index) is > threshold.
+fn make_filter_gt(col: int, threshold: any) -> fn {
+    fn stage_fn(data: Table) -> Table {
+        let result = []
+        let i = 0
+        while i < len(data) {
+            let row = data[i]
+            if len(row) > col and row[col] > threshold {
+                result = push(result, row)
+            }
+            i = i + 1
+        }
+        return result
+    }
+    return stage_fn
+}
+
+// Adds a derived column: the product of col_a and col_b at the end of each row.
+fn make_add_product(col_a: int, col_b: int) -> fn {
+    fn stage_fn(data: Table) -> Table {
+        let result = []
+        let i = 0
+        while i < len(data) {
+            let row = data[i]
+            let product = row[col_a] * row[col_b]
+            result = push(result, push(row, product))
+            i = i + 1
+        }
+        return result
+    }
+    return stage_fn
+}
+
+// Sorts the table ascending by the given column index.
+fn make_sort_by_col(col: int) -> fn {
+    fn stage_fn(data: Table) -> Table {
+        // Insertion sort on rows
+        let result = list_copy(data)
+        let n = len(result)
+        let i = 1
+        while i < n {
+            let key = result[i]
+            let j   = i - 1
+            while j >= 0 and result[j][col] > key[col] {
+                result = list_set(result, j + 1, result[j])
+                j = j - 1
+            }
+            result = list_set(result, j + 1, key)
+            i = i + 1
+        }
+        return result
+    }
+    return stage_fn
+}
+
+// Keeps only the top-N rows.
+fn make_top_n(n: int) -> fn {
+    fn stage_fn(data: Table) -> Table {
+        let end = n
+        if end > len(data) { end = len(data) }
+        return slice_list(data, 0, end)
+    }
+    return stage_fn
+}
+
+// ── Pretty-print a table ──────────────────────────────────────────────────────
+
+fn print_table(headers: list, data: Table) {
+    // Header row
+    let header_line = join(map(headers, fn(h: str) -> str { pad_left(h, 12, " ") }), " | ")
+    println(header_line)
+    println(repeat_str("-", len(header_line)))
+    // Data rows
+    let i = 0
+    while i < len(data) {
+        let row = data[i]
+        let cells = []
+        let j = 0
+        while j < len(row) {
+            cells = push(cells, pad_left(str(row[j]), 12, " "))
+            j = j + 1
+        }
+        println(join(cells, " | "))
+        i = i + 1
+    }
+}
+
+// ── Sales analysis pipeline ───────────────────────────────────────────────────
+//
+// Sample dataset: [product_id, units_sold, unit_price]
+
+fn build_sales_data() -> Table {
+    return [
+        [1001, 120,  9],
+        [1002,   5, 99],
+        [1003, 300,  3],
+        [1004,  50, 25],
+        [1005,   0, 15],
+        [1006, 200,  7],
+        [1007,  80, 40],
+        [1008,  15, 60],
+        [1009, 450,  2],
+        [1010,  10, 88]
+    ]
+}
+
+fn main() {
+    let raw = build_sales_data()
+
+    println("=== Raw Sales Data ===")
+    print_table(["product_id", "units_sold", "unit_price"], raw)
+
+    // Build the pipeline
+    let pipeline = Pipeline.new("Sales Analysis")
+        |> add_stage(Stage.new("filter:units>0",    make_filter_gt(1, 0)))
+        |> add_stage(Stage.new("add:revenue",       make_add_product(1, 2)))
+        |> add_stage(Stage.new("filter:revenue>500", make_filter_gt(3, 500)))
+        |> add_stage(Stage.new("sort:revenue_desc", fn(t: Table) -> Table {
+                                                        return reverse(make_sort_by_col(3)(t))
+                                                    }))
+        |> add_stage(Stage.new("top:5",             make_top_n(5)))
+
+    let result = pipeline.execute(raw)
+
+    println("\n=== Top Revenue Products ===")
+    print_table(["product_id", "units_sold", "unit_price", "revenue"], result)
+
+    // Aggregate stats using foldl
+    let total_revenue = foldl(result, 0, fn(acc: int, row: Row) -> int {
+        return acc + row[3]
+    })
+    println("\nTotal revenue (top 5): " + str(total_revenue))
+
+    // Average units sold
+    let total_units = foldl(result, 0, fn(acc: int, row: Row) -> int {
+        return acc + row[1]
+    })
+    let avg_units = total_units / len(result)
+    println("Average units sold:    " + str(avg_units))
+
+    // Chunk into batches for downstream processing
+    let batches = chunk(result, 2)
+    println("\nBatches:")
+    let i = 0
+    while i < len(batches) {
+        let batch = batches[i]
+        let ids = []
+        let j = 0
+        while j < len(batch) {
+            ids = push(ids, str(batch[j][0]))
+            j = j + 1
+        }
+        println("  Batch " + str(i + 1) + ": [" + join(ids, ", ") + "]")
+        i = i + 1
+    }
+
+    println("\nAll done!")
+}
+
+main()

--- a/samples/Lateralus/data_pipeline.ltl
+++ b/samples/Lateralus/data_pipeline.ltl
@@ -1,0 +1,137 @@
+// ═══════════════════════════════════════════════════════════════════
+// LATERALUS v1.5 — Data Pipeline Example
+// Demonstrates pipeline operators for ETL-style data processing
+// ═══════════════════════════════════════════════════════════════════
+
+import math
+import strings
+
+// ── Stage 1: Generate sample data ─────────────────────────────────
+
+fn make_record(product: str, region: str, amount: float, units: int) -> map {
+    let r = {}
+    r["product"] = product
+    r["region"]  = region
+    r["amount"]  = amount
+    r["units"]   = units
+    return r
+}
+
+fn generate_sales_data() -> list {
+    return [
+        make_record("Widget A", "North", 1250.50, 42),
+        make_record("Widget B", "South", 890.25,  31),
+        make_record("Widget A", "East",  2100.00, 67),
+        make_record("Widget C", "North", 450.75,  15),
+        make_record("Widget B", "West",  1780.00, 55),
+        make_record("Widget A", "South", 3200.00, 98),
+        make_record("Widget C", "East",  675.50,  22),
+        make_record("Widget B", "North", 1100.00, 38),
+    ]
+}
+
+// ── Stage 2: Transform pipeline ───────────────────────────────────
+
+fn enrich_record(record: map) -> map {
+    let amount = record["amount"]
+    let units  = record["units"]
+    let price_per_unit = amount / units
+    record["price_per_unit"] = round(price_per_unit, 2)
+    if amount > 2000 {
+        record["revenue_tier"] = "high"
+    } else {
+        if amount > 1000 {
+            record["revenue_tier"] = "medium"
+        } else {
+            record["revenue_tier"] = "low"
+        }
+    }
+    return record
+}
+
+// ── Stage 3: Analysis ─────────────────────────────────────────────
+
+fn analyze_by_product(data: list) -> map {
+    let products = data
+        |> map(fn(r) { r["product"] })
+        |> unique()
+
+    let result = {}
+    for product in products {
+        let product_data = data
+            |> filter(fn(r) { r["product"] == product })
+
+        let total_revenue = product_data
+            |> map(fn(r) { r["amount"] })
+            |> sum()
+
+        let total_units = product_data
+            |> map(fn(r) { r["units"] })
+            |> sum()
+
+        let avg_price = product_data
+            |> map(fn(r) { r["price_per_unit"] })
+            |> mean()
+
+        let stats = {}
+        stats["total_revenue"]      = round(total_revenue, 2)
+        stats["total_units"]        = total_units
+        stats["avg_price_per_unit"] = round(avg_price, 2)
+        stats["num_regions"]        = len(product_data)
+        result[product] = stats
+    }
+    return result
+}
+
+// ── Stage 4: Reporting ────────────────────────────────────────────
+
+fn format_report(analysis: map) -> str {
+    let lines = ["═══ Sales Analysis Report ═══", ""]
+
+    for product in sorted(keys(analysis)) {
+        let stats = analysis[product]
+        lines = lines + [
+            "Product: " + product,
+            "  Revenue:    \$" + str(stats["total_revenue"]),
+            "  Units:      " + str(stats["total_units"]),
+            "  Avg Price:  \$" + str(stats["avg_price_per_unit"]),
+            "  Regions:    " + str(stats["num_regions"]),
+            "",
+        ]
+    }
+
+    return lines |> join("\n")
+}
+
+// ── Main: The full ETL pipeline ───────────────────────────────────
+
+fn main() {
+    let report = generate_sales_data()
+        |> map(enrich_record)
+        |> analyze_by_product()
+        |> format_report()
+
+    println(report)
+
+    // Pipeline with filtering
+    println("\n═══ High-Revenue Records ═══")
+    let enriched = generate_sales_data() |> map(enrich_record)
+    let high_rev = enriched |> filter(fn(r) { r["revenue_tier"] == "high" })
+    for r in high_rev {
+        println(r["product"] + " (" + r["region"] + "): \$" + str(r["amount"]))
+    }
+
+    // Sequential pipeline
+    let data = generate_sales_data()
+    data = data |> map(enrich_record)
+    data = data |> filter(fn(r) { r["units"] > 30 })
+    data = data |> sort_by(fn(r) { r["amount"] })
+    data = data |> reverse()
+
+    println("\n═══ Top Records (>30 units, by revenue) ═══")
+    for record in data {
+        println(record["product"] + ": " + str(record["units"]) + " units, \$" + str(record["amount"]))
+    }
+}
+
+main()

--- a/samples/Lateralus/enum_demo.ltl
+++ b/samples/Lateralus/enum_demo.ltl
@@ -1,0 +1,159 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// examples/enum_demo.ltl  –  Enums, variants & pattern matching  (v1.1.0)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Demonstrates:
+//   • Simple enum (no data fields)
+//   • Enum with associated data per variant
+//   • type aliases
+//   • match expressions on enum values
+//   • impl blocks on enums
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── Direction ─────────────────────────────────────────────────────────────────
+
+pub enum Direction {
+    North
+    South
+    East
+    West
+}
+
+impl Direction {
+    pub fn opposite(self) -> Direction {
+        match self {
+            Direction.North => Direction.South
+            Direction.South => Direction.North
+            Direction.East  => Direction.West
+            Direction.West  => Direction.East
+        }
+    }
+
+    pub fn to_delta(self) -> list {
+        match self {
+            Direction.North => [0, 1]
+            Direction.South => [0, -1]
+            Direction.East  => [1, 0]
+            Direction.West  => [-1, 0]
+        }
+    }
+
+    pub fn to_str(self) -> str {
+        match self {
+            Direction.North => "North"
+            Direction.South => "South"
+            Direction.East  => "East"
+            Direction.West  => "West"
+        }
+    }
+}
+
+// ── Color (enum with integer values) ─────────────────────────────────────────
+
+pub enum Color {
+    Red   = 0xff0000
+    Green = 0x00ff00
+    Blue  = 0x0000ff
+    Black = 0x000000
+    White = 0xffffff
+}
+
+// ── Result<T, E> style enum ───────────────────────────────────────────────────
+
+pub enum Outcome {
+    Ok    // success (no data in this demo)
+    Err   // failure
+    Empty // neither
+}
+
+// type alias
+pub type MaybeInt = Outcome
+
+fn safe_divide(a: int, b: int) -> Outcome {
+    if b == 0 {
+        return Outcome.Err
+    }
+    return Outcome.Ok
+}
+
+fn describe_outcome(o: Outcome) -> str {
+    match o {
+        Outcome.Ok    => "Success"
+        Outcome.Err   => "Error"
+        Outcome.Empty => "Empty"
+    }
+}
+
+// ── Token enum (like a real lexer) ────────────────────────────────────────────
+
+pub enum Token {
+    Number
+    Plus
+    Minus
+    Star
+    Slash
+    LParen
+    RParen
+    EOF
+}
+
+fn token_name(t: Token) -> str {
+    match t {
+        Token.Number  => "Number"
+        Token.Plus    => "+"
+        Token.Minus   => "-"
+        Token.Star    => "*"
+        Token.Slash   => "/"
+        Token.LParen  => "("
+        Token.RParen  => ")"
+        Token.EOF     => "<EOF>"
+    }
+}
+
+// ── Demo ─────────────────────────────────────────────────────────────────────
+
+fn main() {
+    // Direction demo
+    println("=== Direction ===")
+    let d = Direction.North
+    println("Direction: " + d.to_str())
+    println("Opposite:  " + d.opposite().to_str())
+
+    let delta = d.to_delta()
+    println("Delta:     [" + str(delta[0]) + ", " + str(delta[1]) + "]")
+
+    // Compass walk
+    let dirs = [Direction.North, Direction.East, Direction.East, Direction.South]
+    let x = 0
+    let y = 0
+    let i = 0
+    while i < len(dirs) {
+        let dv = dirs[i].to_delta()
+        x = x + dv[0]
+        y = y + dv[1]
+        i = i + 1
+    }
+    println("After walk: (" + str(x) + ", " + str(y) + ")")
+
+    // Outcome demo
+    println("\n=== Outcome ===")
+    println("10 / 2  → " + describe_outcome(safe_divide(10, 2)))
+    println("10 / 0  → " + describe_outcome(safe_divide(10, 0)))
+
+    // Token stream
+    println("\n=== Token stream ===")
+    let tokens = [
+        Token.Number, Token.Plus, Token.Number,
+        Token.Star,   Token.LParen, Token.Number, Token.RParen, Token.EOF
+    ]
+    let j = 0
+    while j < len(tokens) {
+        print(token_name(tokens[j]) + " ")
+        j = j + 1
+    }
+    println("")
+
+    println("\nAll done!")
+}
+
+main()


### PR DESCRIPTION
## Add Lateralus language

### Summary

Adds syntax highlighting and language recognition for **Lateralus**, a statically-typed systems programming language with pipeline operators, algebraic data types, and Hindley-Milner type inference.

### Changes

- **`lib/linguist/languages.yml`** — 5 new entries:
  - `Lateralus` (type: programming, ext: `.ltl`, scope: `source.ltl`)
  - `Lateralus Assembly` (group: Lateralus, ext: `.ltasm`, scope: `source.ltasm`)
  - `Lateralus Config` (group: Lateralus, ext: `.ltlcfg`, scope: `source.ltlcfg`)
  - `Lateralus Markup` (group: Lateralus, ext: `.ltlm`/`.ltlml`, scope: `source.ltlm`)
  - `Lateralus Notebook` (group: Lateralus, ext: `.ltlnb`, scope: `source.ltlnb`)
- **`vendor/grammars/lateralus-grammar`** — submodule pointing to https://github.com/bad-antics/lateralus-grammar (MIT license)
- **`grammars.yml`** — all 5 scopes registered
- **`samples/Lateralus/`** — 3 real-world `.ltl` samples (pipelines, enums, data processing)
- **`samples/Lateralus Assembly/`** — 2 `.ltasm` samples (fibonacci, hello world equivalent)

### Extensions

All extensions are unique and not used by any existing language in the registry:
- `.ltl`, `.ltasm`, `.ltlcfg`, `.ltlm`, `.ltlml`, `.ltlnb`

### Grammar

The grammar repo (https://github.com/bad-antics/lateralus-grammar) is MIT-licensed and contains 5 TextMate grammar files. The grammar was validated using `script/add-grammar` which confirmed all 5 scopes.

### Samples

Samples are original code written specifically for this PR and are MIT-licensed (same as the Linguist project).

### References

- Language repo: https://github.com/bad-antics/lateralus-lang
- Grammar repo: https://github.com/bad-antics/lateralus-grammar
- npm package: https://www.npmjs.com/package/lateralus-grammar
- VS Code extension: https://marketplace.visualstudio.com/items?itemName=lateralus.lateralus-lang