### PR TITLE
Add TorqueScript

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -215,6 +215,15 @@ disambiguations:
     pattern: '![\w\s]+methodsFor: '
   - language: 'C#'
     pattern: '^\s*(using\s+[A-Z][\s\w.]+;|namespace\s*[\w\.]+\s*(\{|;)|\/\/)'
+- extensions:
+  - .cs
+  rules:
+  - language: TorqueScript
+    and:
+      - pattern: |
+          (?m)^datablock\s+\w+\s*\(|^function\s+\w+\s*\(
+      - pattern: |
+          (?m)^\s*(?:\$|%)\w+\s*=
 - extensions: ['.csc']
   rules:
   - language: GSC
@@ -862,6 +871,8 @@ disambiguations:
   - language: STAR
     pattern: '^loop_\s*$'
   - language: Starlark
+
+
 - extensions: ['.stl']
   rules:
   - language: STL
@@ -903,6 +914,7 @@ disambiguations:
     - pattern: '--.*'
     - pattern: '\b(local|function|end|record|interface|enum)\b'
   - language: Type Language
+
 - extensions: ['.tlv']
   rules:
   - language: TL-Verilog
@@ -931,6 +943,7 @@ disambiguations:
   - language: TSPLIB data
     pattern: '^(NAME|TYPE|DIMENSION|EDGE_WEIGHT_TYPE|EDGE_WEIGHT_FORMAT)\s*:'
 - extensions: ['.tst']
+
   rules:
   - language: GAP
     pattern: 'gap> '

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7674,7 +7674,7 @@ TMDL:
   extensions:
   - ".tmdl"
   aliases:
-  - "Tabular Model Definition Language"
+  - Tabular Model Definition Language
   tm_scope: source.tmdl
   ace_mode: text
   language_id: 769162295
@@ -7979,6 +7979,15 @@ Tor Config:
   aliases:
   - torrc
   language_id: 1016912802
+TorqueScript:
+  type: programming
+  color: "#e30000"
+  extensions:
+  - ".tscript"
+  - ".cs"
+  tm_scope: none
+  ace_mode: c_cpp
+  language_id: 659520821
 Tree-sitter Query:
   type: programming
   color: "#8ea64c"

--- a/samples/TorqueScript/ClientSide.tscript
+++ b/samples/TorqueScript/ClientSide.tscript
@@ -1,0 +1,3 @@
+function onClientEnterGame(%client) {
+    messageClient(%client, 'MsgWelcome', "Hello, World!");
+}

--- a/samples/TorqueScript/ConsoleVariableHelloWorld.tscript
+++ b/samples/TorqueScript/ConsoleVariableHelloWorld.tscript
@@ -1,0 +1,2 @@
+$myGreeting = "Hello, World!";
+echo($myGreeting);

--- a/samples/TorqueScript/DataBlockHelloWorld.tscript
+++ b/samples/TorqueScript/DataBlockHelloWorld.tscript
@@ -1,0 +1,5 @@
+datablock ScriptObject(GreetingData) {
+    message = "Hello, World!";
+};
+
+echo(GreetingData.message);

--- a/samples/TorqueScript/HelloNonTScript.cs
+++ b/samples/TorqueScript/HelloNonTScript.cs
@@ -1,0 +1,7 @@
+datablock PlayerData(DefaultPlayer) {
+   maxForwardSpeed = 10;
+};
+
+function onAdd(%this, %obj) {
+   echo("Hello from TorqueScript!");
+}

--- a/samples/TorqueScript/HelloWorld.tscript
+++ b/samples/TorqueScript/HelloWorld.tscript
@@ -1,0 +1,2 @@
+
+echo("Hello, World!");

--- a/samples/TorqueScript/HelloWorldFuncWrapped.tscript
+++ b/samples/TorqueScript/HelloWorldFuncWrapped.tscript
@@ -1,0 +1,3 @@
+function sayHello() {
+    echo("Hello, World!");
+}


### PR DESCRIPTION
Hello i went to add a programming language used on some of the Popular games like BeamNG Drive, etc

The language name is TorqueScript a programming language used on Torque3D and some games made in torque3d with mod scripting

I added the language because Torque3D and Torque3D Made games are like so damn popular including their own programming language 

Color:#e30000
Language ID:659520821
Extensions: .cs, .tscript

Though i think if its Torques C# version i do want it to be modified gitattributes but .tscript is gonna be shown automatically

No tmscope unfortunately im too lazy to make a textmate grammer

Attention:if its incorrcetly intinazlized may you fix it lildude?

Anyway its me Jcsab111 or 1112 `the guy who wanted to add Z# Sorry if i didnt read the instructions but anyway can you takke a look from the branch thats gonna be pulled? may you fix it if incorrectly intinalized?

Thank you, sincerely Jcsab