### PR TITLE
Add PowerPC Assembly language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1590,3 +1590,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/VSCode-PowerPC-Syntax"]
+	path = vendor/grammars/VSCode-PowerPC-Syntax
+	url = https://github.com/RoyalAce22/VSCode-PowerPC-Syntax.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -184,6 +184,8 @@ vendor/grammars/UrWeb-Language-Definition:
 - source.ur
 vendor/grammars/VBDotNetSyntax:
 - source.vbnet
+vendor/grammars/VSCode-PowerPC-Syntax:
+- source.asm
 vendor/grammars/Vala-TMBundle:
 - source.vala
 vendor/grammars/VscodeAdblockSyntax:

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -779,8 +779,14 @@ disambiguations:
     pattern: '#include|#pragma\s+(rs|version)|__attribute__'
   - language: XML
     pattern: '^\s*<\?xml'
+- extensions: ['.S']
+  rules:
+  - language: PowerPC Assembly
+    pattern: '\b(mflr|mtlr|bdnz|lis|mfspr|mtspr|stwu|lwzu|rlwinm|rldicl|mfocrf|mtocrf|mfsprg[0-3]|stdu|rfid)\b'
 - extensions: ['.s']
   rules:
+  - language: PowerPC Assembly
+    pattern: '\b(mflr|mtlr|bdnz|lis|mfspr|mtspr|stwu|lwzu|rlwinm|rldicl|mfocrf|mtocrf|mfsprg[0-3]|stdu|rfid)\b'
   - language: Unix Assembly
     pattern: '(?i:mov[lq]?)\s+[%\$]'
   - language: Assembly

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4871,7 +4871,7 @@ Motoko:
   language_id: 202937027
 Motorola 68K Assembly:
   type: programming
-  color: "#005daa"
+  color: "#0f62fe"
   group: Assembly
   aliases:
   - m68k
@@ -5948,6 +5948,21 @@ PowerBuilder:
   tm_scope: source.powerbuilder
   ace_mode: text
   language_id: 292
+PowerPC Assembly:
+  type: programming
+  color: "#0f62fe"
+  group: Assembly
+  aliases:
+  - ppc
+  - ppc-asm
+  - powerpc
+  extensions:
+  - ".ppc"
+  - ".S"
+  - ".s"
+  tm_scope: source.asm
+  ace_mode: text
+  language_id: 798592640
 PowerShell:
   type: programming
   color: "#012456"

--- a/samples/PowerPC Assembly/altivec_memset.ppc
+++ b/samples/PowerPC Assembly/altivec_memset.ppc
@@ -1,0 +1,74 @@
+/*
+ * AltiVec/VMX accelerated memset for 64-bit PowerPC.
+ * MIT License
+ */
+
+	.machine "altivec"
+	.section .text
+	.p2align 4
+
+/*
+ * void *memset_altivec(void *dst, int c, size_t len)
+ *   r3 = dst, r4 = fill byte, r5 = length.
+ *   Returns dst in r3.
+ *
+ * Scalar fill until 16-byte aligned, then splat the fill byte
+ * into a vector register and store 16 bytes per iteration.
+ */
+	.globl	memset_altivec
+	.type	memset_altivec, @function
+memset_altivec:
+	mflr	r0
+	std	r0, 16(r1)
+	stdu	r1, -64(r1)
+
+	mr	r9, r3
+	cmpldi	r5, 0
+	beq	.Ldone
+
+	/* scalar head: align to 16 bytes */
+	andi.	r6, r3, 15
+	beq	.Lvec_setup
+	subfic	r6, r6, 16
+	cmplw	r6, r5
+	bgt	.Lsmall
+	mtctr	r6
+	sub	r5, r5, r6
+.Lhead:
+	stb	r4, 0(r3)
+	addi	r3, r3, 1
+	bdnz	.Lhead
+
+.Lvec_setup:
+	stb	r4, -1(r1)
+	li	r7, -1
+	lvebx	v0, r7, r1
+	vspltb	v0, v0, 0		/* fill byte in all 16 lanes */
+
+	srdi	r6, r5, 4
+	andi.	r5, r5, 15
+	cmpldi	r6, 0
+	beq	.Ltail
+	mtctr	r6
+
+.Lvec_store:
+	stvx	v0, 0, r3
+	addi	r3, r3, 16
+	bdnz	.Lvec_store
+
+.Ltail:
+	cmpldi	r5, 0
+	beq	.Ldone
+.Lsmall:
+	mtctr	r5
+.Ltail_byte:
+	stb	r4, 0(r3)
+	addi	r3, r3, 1
+	bdnz	.Ltail_byte
+
+.Ldone:
+	mr	r3, r9
+	ld	r1, 0(r1)
+	ld	r0, 16(r1)
+	mtlr	r0
+	blr

--- a/samples/PowerPC Assembly/cpu_idle_power.S
+++ b/samples/PowerPC Assembly/cpu_idle_power.S
@@ -1,0 +1,100 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2017-2018 QCM Technologies.
+ * Copyright (c) 2017-2018 Semihalf.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/* From FreeBSD sys/powerpc/powerpc/cpu_subr64.S */
+
+#include "assym.inc"
+#include <machine/asm.h>
+
+	.p2align 3
+ENTRY(enter_idle_powerx)
+	mfsprg0	%r3			/* Get the pcpu pointer */
+	ld	%r3,PC_CURTHREAD(%r3)	/* Get current thread */
+	ld	%r3,TD_PCB(%r3)		/* Get PCB of current thread */
+	std	%r12,PCB_CONTEXT(%r3)	/* Save the non-volatile GP regs. */
+	std	%r13,PCB_CONTEXT+1*8(%r3)
+	std	%r14,PCB_CONTEXT+2*8(%r3)
+	std	%r15,PCB_CONTEXT+3*8(%r3)
+	std	%r16,PCB_CONTEXT+4*8(%r3)
+	std	%r17,PCB_CONTEXT+5*8(%r3)
+	std	%r18,PCB_CONTEXT+6*8(%r3)
+	std	%r19,PCB_CONTEXT+7*8(%r3)
+	std	%r20,PCB_CONTEXT+8*8(%r3)
+	std	%r21,PCB_CONTEXT+9*8(%r3)
+	std	%r22,PCB_CONTEXT+10*8(%r3)
+	std	%r23,PCB_CONTEXT+11*8(%r3)
+	std	%r24,PCB_CONTEXT+12*8(%r3)
+	std	%r25,PCB_CONTEXT+13*8(%r3)
+	std	%r26,PCB_CONTEXT+14*8(%r3)
+	std	%r27,PCB_CONTEXT+15*8(%r3)
+	std	%r28,PCB_CONTEXT+16*8(%r3)
+	std	%r29,PCB_CONTEXT+17*8(%r3)
+	std	%r30,PCB_CONTEXT+18*8(%r3)
+	std	%r31,PCB_CONTEXT+19*8(%r3)
+
+	mfcr	%r16			/* Save the condition register */
+	std	%r16,PCB_CR(%r3)
+	mflr	%r16			/* Save the link register */
+	std	%r16,PCB_LR(%r3)
+	std	%r1,PCB_SP(%r3)		/* Save the stack pointer */
+	std	%r2,PCB_TOC(%r3)	/* Save the TOC pointer */
+
+	bl	1f
+1:	mflr	%r3
+	addi	%r3,%r3,power_save_sequence-1b
+	mtsrr0	%r3
+
+	/* Set MSR */
+	li	%r3,0
+#ifdef __LITTLE_ENDIAN__
+	ori	%r3,%r3,(PSL_ME | PSL_RI | PSL_LE)
+#else
+	ori	%r3,%r3,(PSL_ME | PSL_RI)
+#endif
+	li	%r8,0x9			/* PSL_SF and PSL_HV */
+	insrdi	%r3,%r8,4,0
+	mtsrr1	%r3
+
+	rfid
+
+	.p2align 2
+power_save_sequence:
+	bl	1f
+	.llong	0x0			/* Playground for power-save sequence */
+1:	mflr	%r3
+
+	/* Start power-save sequence */
+	std	%r2,0(%r3)
+	ptesync
+	ld	%r2,0(%r3)
+2:	cmpd	%r2,%r2
+	bne	2b
+	nap
+	b	.
+END(enter_idle_powerx)

--- a/samples/PowerPC Assembly/exception_handler.S
+++ b/samples/PowerPC Assembly/exception_handler.S
@@ -1,0 +1,71 @@
+/*
+ * Data Storage Interrupt (DSI) handler for bare-metal PowerPC.
+ * Saves trap frame, calls into C, restores and returns via rfi.
+ * MIT License
+ */
+
+#define SPRG_SCRATCH0	272
+#define SPRG_SCRATCH1	273
+
+	.section .text
+	.p2align 2
+
+/*
+ * DSI vector -- entered on data access fault (vector 0x300).
+ * SRR0 = faulting PC, SRR1 = saved MSR.
+ * DSISR (SPR 18) = cause, DAR (SPR 19) = faulting address.
+ */
+	.globl	dsi_vector
+	.type	dsi_vector, @function
+dsi_vector:
+	/* stash r0/r1 in scratch SPRGs to free up working regs */
+	mtspr	SPRG_SCRATCH0, r0
+	mtspr	SPRG_SCRATCH1, r1
+
+	mfsprg0	r1			/* kernel stack pointer */
+	stwu	r1, -160(r1)		/* allocate trap frame */
+
+	/* save GPRs */
+	mfspr	r0, SPRG_SCRATCH0
+	stw	r0, 12(r1)
+	mfspr	r0, SPRG_SCRATCH1
+	stw	r0, 16(r1)
+	stw	r2, 20(r1)
+	stw	r3, 24(r1)
+	stw	r4, 28(r1)
+	stw	r5, 32(r1)
+
+	/* save exception SPRs */
+	mfsrr0	r3
+	stw	r3, 132(r1)
+	mfsrr1	r3
+	stw	r3, 136(r1)
+	mfspr	r3, 18			/* DSISR */
+	stw	r3, 140(r1)
+	mfspr	r3, 19			/* DAR */
+	stw	r3, 144(r1)
+	mflr	r3
+	stw	r3, 148(r1)
+	mfcr	r3
+	stw	r3, 152(r1)
+
+	mr	r3, r1
+	bl	dsi_handler		/* dsi_handler(struct trapframe *) */
+
+	/* restore and return */
+	lwz	r3, 152(r1)
+	mtcr	r3
+	lwz	r3, 148(r1)
+	mtlr	r3
+	lwz	r3, 132(r1)
+	mtsrr0	r3
+	lwz	r3, 136(r1)
+	mtsrr1	r3
+
+	lwz	r5, 32(r1)
+	lwz	r4, 28(r1)
+	lwz	r3, 24(r1)
+	lwz	r2, 20(r1)
+	lwz	r0, 12(r1)
+	lwz	r1, 16(r1)
+	rfi

--- a/samples/PowerPC Assembly/spinlock.s
+++ b/samples/PowerPC Assembly/spinlock.s
@@ -1,0 +1,61 @@
+/*
+ * Simple PowerPC spinlock using lwarx/stwcx. reservation pair.
+ * MIT License
+ */
+
+	.section .text
+	.p2align 2
+
+/*
+ * void spin_lock(uint32_t *lock)
+ *   r3 = pointer to lock word (0 = unlocked, 1 = locked)
+ */
+	.globl	spin_lock
+	.type	spin_lock, @function
+spin_lock:
+1:
+	lwarx	r5, 0, r3		/* load-reserve lock word */
+	cmpwi	r5, 0
+	bne-	2f			/* contended -- go spin */
+	li	r5, 1
+	stwcx.	r5, 0, r3		/* try to store 1 */
+	bne-	1b			/* reservation lost, retry */
+	isync
+	blr
+
+2:	/* spin on ordinary load to avoid flooding the bus */
+	lwz	r5, 0(r3)
+	cmpwi	r5, 0
+	bne	2b
+	b	1b
+
+/*
+ * void spin_unlock(uint32_t *lock)
+ */
+	.globl	spin_unlock
+	.type	spin_unlock, @function
+spin_unlock:
+	lwsync				/* release barrier */
+	li	r5, 0
+	stw	r5, 0(r3)
+	blr
+
+/*
+ * int spin_trylock(uint32_t *lock)
+ *   Returns 1 on success, 0 on failure.
+ */
+	.globl	spin_trylock
+	.type	spin_trylock, @function
+spin_trylock:
+	lwarx	r5, 0, r3
+	cmpwi	r5, 0
+	bne-	.trylock_fail
+	li	r5, 1
+	stwcx.	r5, 0, r3
+	bne-	.trylock_fail
+	isync
+	li	r3, 1
+	blr
+.trylock_fail:
+	li	r3, 0
+	blr

--- a/samples/PowerPC Assembly/strcpy.s
+++ b/samples/PowerPC Assembly/strcpy.s
@@ -1,0 +1,68 @@
+/*
+ * Word-at-a-time strcpy for 32-bit PowerPC.
+ * MIT License
+ */
+
+	.section .text
+	.p2align 2
+
+/*
+ * char *strcpy(char *dst, const char *src)
+ *   r3 = dst, r4 = src.  Returns dst in r3.
+ *
+ * Copies bytes until src is word-aligned, then checks four bytes
+ * at a time for a null using the standard (word - 0x01010101) &
+ * ~word & 0x80808080 trick.
+ */
+	.globl	strcpy
+	.type	strcpy, @function
+strcpy:
+	mr	r9, r3
+
+	/* byte loop until src is word-aligned */
+	andi.	r5, r4, 3
+	beq	.Laligned
+.Lbyte_loop:
+	lbz	r6, 0(r4)
+	stb	r6, 0(r3)
+	cmpwi	r6, 0
+	beqlr
+	addi	r3, r3, 1
+	addi	r4, r4, 1
+	andi.	r5, r4, 3
+	bne	.Lbyte_loop
+
+.Laligned:
+	lis	r7, 0x0101
+	ori	r7, r7, 0x0101		/* r7 = 0x01010101 */
+	lis	r8, 0x8080
+	ori	r8, r8, 0x8080		/* r8 = 0x80808080 */
+
+.Lword_loop:
+	lwz	r6, 0(r4)
+	subf	r10, r7, r6
+	andc	r10, r10, r6
+	and.	r10, r10, r8
+	bne	.Ltail
+	stw	r6, 0(r3)
+	addi	r3, r3, 4
+	addi	r4, r4, 4
+	b	.Lword_loop
+
+.Ltail:
+	lbz	r6, 0(r4)
+	stb	r6, 0(r3)
+	cmpwi	r6, 0
+	beqlr
+	lbz	r6, 1(r4)
+	stb	r6, 1(r3)
+	cmpwi	r6, 0
+	beqlr
+	lbz	r6, 2(r4)
+	stb	r6, 2(r3)
+	cmpwi	r6, 0
+	beqlr
+	li	r6, 0
+	stb	r6, 3(r3)
+	mr	r3, r9
+	blr


### PR DESCRIPTION
Add PowerPC Assembly as a recognized language.

## Description

PowerPC assembly shows up in the Linux kernel (`arch/powerpc/`), FreeBSD, GCC, glibc, LLVM test suites, and the PS3/Wii/GC homebrew scene. Currently there's no way to distinguish it from other assembly on GitHub.

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.S+mflr+blr
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.s+lis+stw+bdnz
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.S+path%3Apowerpc
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - `cpu_idle_power.S` -- from FreeBSD [`sys/powerpc/powerpc/cpu_subr64.S`](https://github.com/freebsd/freebsd-src/blob/main/sys/powerpc/powerpc/cpu_subr64.S)
      - `exception_handler.S`, `spinlock.s`, `strcpy.s`, `altivec_memset.ppc` -- written for this PR
    - Sample license(s): BSD-2-Clause (FreeBSD), MIT (rest)
  - [x] I have included a syntax highlighting grammar: https://github.com/RoyalAce22/VSCode-PowerPC-Syntax
  - [x] I have added a color
    - Hex value: `#0f62fe`
    - Rationale: IBM Blue 60 from the Carbon Design System
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.
