### PR TITLE
Add GROQ language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -554,6 +554,9 @@
 [submodule "vendor/grammars/groovy.tmbundle"]
 	path = vendor/grammars/groovy.tmbundle
 	url = https://github.com/textmate/groovy.tmbundle
+[submodule "vendor/grammars/groq-syntax"]
+	path = vendor/grammars/groq-syntax
+	url = https://github.com/sanity-io/groq-syntax.git
 [submodule "vendor/grammars/haxe-TmLanguage"]
 	path = vendor/grammars/haxe-TmLanguage
 	url = https://github.com/vshaxe/haxe-TmLanguage

--- a/grammars.yml
+++ b/grammars.yml
@@ -453,6 +453,10 @@ vendor/grammars/graphviz.tmbundle:
 - source.dot
 vendor/grammars/groovy.tmbundle:
 - source.groovy
+vendor/grammars/groq-syntax:
+- groq-injection.js
+- groq-injection.markdown
+- source.groq
 vendor/grammars/haxe-TmLanguage:
 - documentation.markdown.injection.haxe
 - markdown.haxe.codeblock

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2467,6 +2467,14 @@ GN:
   codemirror_mode: python
   codemirror_mime_type: text/x-python
   language_id: 302957008
+GROQ:
+  type: data
+  color: "#fa84ff"
+  extensions:
+  - ".groq"
+  tm_scope: source.groq
+  ace_mode: groq
+  language_id: 727704671
 GSC:
   type: programming
   color: "#FF6800"

--- a/samples/GROQ/blog-posts.groq
+++ b/samples/GROQ/blog-posts.groq
@@ -1,0 +1,25 @@
+// Fetch published blog posts with resolved author references
+*[_type == "post" && !(_id in path("drafts.**"))] | order(publishedAt desc) [0...10] {
+  _id,
+  title,
+  "slug": slug.current,
+  publishedAt,
+  "excerpt": pt::text(body[0..2]),
+  mainImage {
+    asset-> {
+      url,
+      "dimensions": metadata.dimensions
+    },
+    alt
+  },
+  author-> {
+    name,
+    image {
+      asset-> { url }
+    }
+  },
+  categories[]-> {
+    title,
+    "slug": slug.current
+  }
+}

--- a/samples/GROQ/product-filter.groq
+++ b/samples/GROQ/product-filter.groq
@@ -1,0 +1,26 @@
+// Product listing with faceted filtering and pagination
+*[
+  _type == "product"
+  && category->slug.current == $category
+  && price >= $minPrice
+  && price <= $maxPrice
+  && ($brand == null || brand == $brand)
+  && count(variants[inStock == true]) > 0
+] | order(
+  select(
+    $sort == "price-asc" => price asc,
+    $sort == "price-desc" => price desc,
+    $sort == "newest" => _createdAt desc,
+    _createdAt desc
+  )
+) [$offset...$offset + $limit] {
+  _id,
+  title,
+  "slug": slug.current,
+  price,
+  "compareAtPrice": math::max(variants[].compareAtPrice),
+  "thumbnail": images[0].asset->url,
+  "inStockCount": count(variants[inStock == true]),
+  brand,
+  category-> { title, "slug": slug.current }
+}

--- a/samples/GROQ/site-navigation.groq
+++ b/samples/GROQ/site-navigation.groq
@@ -1,0 +1,29 @@
+// Resolve site-wide navigation with conditional projections
+*[_type == "siteConfig"][0] {
+  title,
+  description,
+  "logoUrl": logo.asset->url,
+  mainNavigation[] {
+    _type == "navLink" => {
+      "type": "link",
+      title,
+      url
+    },
+    _type == "navGroup" => {
+      "type": "group",
+      title,
+      children[] {
+        title,
+        url,
+        "icon": icon.asset->url
+      }
+    }
+  },
+  footer {
+    copyright,
+    socialLinks[] {
+      platform,
+      url
+    }
+  }
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -213,6 +213,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **GEDCOM:** [fguitton/vscode-gedcom](https://github.com/fguitton/vscode-gedcom)
 - **GLSL:** [euler0/sublime-glsl](https://github.com/euler0/sublime-glsl)
 - **GN:** [devoncarew/language-gn](https://github.com/devoncarew/language-gn)
+- **GROQ:** [sanity-io/groq-syntax](https://github.com/sanity-io/groq-syntax)
 - **GSC:** [Jake-NotTheMuss/CoDT7-Sublime](https://github.com/Jake-NotTheMuss/CoDT7-Sublime)
 - **Game Maker Language:** [mikomikotaishi/c.tmbundle](https://github.com/mikomikotaishi/c.tmbundle)
 - **Gemfile.lock:** [hmarr/gemfile-lock-tmlanguage](https://github.com/hmarr/gemfile-lock-tmlanguage)

--- a/vendor/licenses/git_submodule/groq-syntax.dep.yml
+++ b/vendor/licenses/git_submodule/groq-syntax.dep.yml
@@ -1,0 +1,33 @@
+---
+name: groq-syntax
+version: a0d15cf651c04963f8dafe836eda37cca97f5723
+type: git_submodule
+homepage: https://github.com/sanity-io/groq-syntax.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2026 Sanity.io
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+- sources: README.md
+  text: MIT - see [LICENSE](LICENSE).
+notices: []


### PR DESCRIPTION
Add GROQ (Graph-Relational Object Queries) as a recognized data language with syntax highlighting for `.groq` files, JS/TS template literal injection, and markdown code block injection.

- Grammar source: [sanity-io/groq-syntax (textmate-groq)](https://github.com/sanity-io/groq-syntax/tree/main/packages/textmate-groq) (MIT licensed)
- Scopes: `source.groq`, `groq-injection.js`, `groq-injection.markdown`
- Samples: blog query, product filter, site navigation

## Description

[GROQ](https://groq.dev) is an open query language for JSON-like data, created by [Sanity.io](https://www.sanity.io) and published under the [OWFa 1.0 license](https://github.com/sanity-io/GROQ) since 2019. It is purpose-built for querying and transforming content in document stores, with first-class support for references, projections, and filtering.

GROQ is widely used across the Sanity ecosystem, which includes companies like Nike, Figma, Cloudflare, Spotify, Shopify, and Riot Games. The `groq` npm package sees [800k+ weekly downloads](https://www.npmjs.com/package/groq) (24M+ annually).

While `.groq` files represent one surface for the language, the majority of GROQ is written as tagged template literals in JavaScript/TypeScript (`` groq`*[_type == "post"]` ``) and in markdown code blocks (` ```groq `). The grammar source ([sanity-io/groq-syntax](https://github.com/sanity-io/groq-syntax)) provides injection grammars for both of these, following the same pattern as GraphQL in Linguist (`inline.graphql`, `inline.graphql.markdown.codeblock` via graphql/graphiql).

An [ace mode](https://github.com/ajaxorg/ace/pull/5940) recently landed as well, so this PR is also set to use that.

### Usage evidence

| Signal | Count | Search |
|--------|-------|--------|
| `groq` template literals in TS | 3,400+ files | [search](https://github.com/search?type=code&q=%22groq%60%22+language%3Atypescript+NOT+is%3Afork) |
| `groq` template literals in JS | 2,100+ files | [search](https://github.com/search?type=code&q=%22groq%60%22+language%3Ajavascript+NOT+is%3Afork) |
| ` ```groq ` markdown blocks | 630+ files | [search](https://github.com/search?type=code&q=%22%60%60%60groq%22+language%3Amarkdown+NOT+is%3Afork) |
| `import groq` in JS/TS | 2,600+ files | [search](https://github.com/search?type=code&q=%22import+groq%22+language%3Atypescript+NOT+is%3Afork) |
| `.groq` files (excl. forks) | 200+ files / 40+ repos | [search](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.groq) |

The `.groq` extension meets the 200-file threshold for extensions that typically occur once per repository (like `Makefile`). The results show broad distribution across independent users and organizations - not concentrated in Sanity's own repos.

The broader surface (5,500+ template literal files, 630+ markdown code blocks) demonstrates that the community already treats GROQ as a distinct language deserving syntax highlighting.

### VS Code extension

The [Sanity VS Code extension](https://marketplace.visualstudio.com/items?itemName=sanity-io.vscode-sanity) has 50,000+ installs and has provided GROQ syntax highlighting since 2018. The grammar was recently extracted to a dedicated repo ([sanity-io/groq-syntax](https://github.com/sanity-io/groq-syntax)) to support multiple editors and Linguist integration.

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.groq
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - Samples written for this PR, representative of common GROQ patterns (content queries with references, faceted filtering with parameters, conditional projections)
    - Sample license(s): MIT (same as Linguist)
  - [x] I have included a syntax highlighting grammar: https://github.com/sanity-io/groq-syntax
  - [x] I have added a color
    - Hex value: `#fa84ff`
    - Rationale: Magenta from GROQ's brand palette.
  - [x] ~~I have updated the heuristics to distinguish my language from others using the same extension.~~
    Not needed - `.groq` is not used by any other language.
 