### PR TITLE
Add TML programming language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1590,3 +1590,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/tml-textmate"]
+	path = vendor/grammars/tml-textmate
+	url = https://github.com/hivellm/tml-textmate

--- a/grammars.yml
+++ b/grammars.yml
@@ -1185,6 +1185,8 @@ vendor/grammars/thrift.tmbundle:
 - source.thrift
 vendor/grammars/tlv-vscode:
 - source.tlverilog
+vendor/grammars/tml-textmate:
+- source.tml
 vendor/grammars/toml.tmbundle:
 - source.toml
 vendor/grammars/turtle.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7678,6 +7678,16 @@ TMDL:
   tm_scope: source.tmdl
   ace_mode: text
   language_id: 769162295
+TML:
+  type: programming
+  color: "#5A3FBE"
+  extensions:
+  - ".tml"
+  tm_scope: source.tml
+  ace_mode: text
+  aliases:
+  - tml
+  language_id: 0
 TOML:
   type: data
   color: "#9c4221"

--- a/samples/TML/async_http.tml
+++ b/samples/TML/async_http.tml
@@ -1,0 +1,110 @@
+/// Asynchronous HTTP server example demonstrating TML's async/await model.
+use std::net::{TcpListener, TcpStream}
+use std::http::{Request, Response, Method, StatusCode}
+use std::json
+use std::collections::HashMap
+use std::runtime::Runtime
+
+// ─── Request handler ─────────────────────────────────────────────────────────
+
+@auto(duplicate)
+pub type AppState {
+    counters: Shared[Mutex[HashMap[Str, I64]]],
+}
+
+impl AppState {
+    pub func new() -> AppState {
+        return AppState {
+            counters: Shared::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+pub async func handle_request(req: Request, state: AppState) -> Response {
+    when req.method {
+        Method::GET => {
+            let path = req.path()
+            when path {
+                "/health" => {
+                    return Response::ok().json(`{"status": "healthy"}`)
+                },
+                "/counters" => {
+                    let guard = state.counters.lock().await
+                    let body = format_counters(ref *guard)
+                    return Response::ok().json(body)
+                },
+                _ => {
+                    return Response::not_found().text("Not Found")
+                },
+            }
+        },
+        Method::POST => {
+            let path = req.path()
+            if path.starts_with("/counter/") {
+                let name = path.trim_start("/counter/")
+                let mut guard = state.counters.lock().await
+                let current = guard.get(name).unwrap_or(0)
+                guard.set(name, current + 1)
+                return Response::ok().json(`{"name": "{name}", "value": {current + 1}}`)
+            }
+            return Response::not_found().text("Not Found")
+        },
+        _ => {
+            return Response::status(StatusCode::MethodNotAllowed).text("Method Not Allowed")
+        },
+    }
+}
+
+func format_counters(counters: ref HashMap[Str, I64]) -> Str {
+    var parts: List[Str] = List::new()
+    // Iteration over HashMap entries
+    let iter = counters.iter()
+    loop {
+        let Just(entry) = iter.next() else { break }
+        parts.push(`"{entry.key}": {entry.value}`)
+    }
+    return `{` + parts.join(", ") + `}`
+}
+
+// ─── Server setup ────────────────────────────────────────────────────────────
+
+pub async func run_server(addr: Str) -> Outcome[Unit, Str] {
+    let listener = TcpListener::bind(addr).await?
+    println(`Listening on {addr}`)
+
+    let state = AppState::new()
+
+    loop {
+        let (stream, peer_addr) = listener.accept().await?
+        let state_clone = state.duplicate()
+
+        // Spawn a task per connection
+        Runtime::spawn(async {
+            when handle_connection(stream, peer_addr, state_clone).await {
+                Ok(_)    => {},
+                Err(msg) => println(`Connection error from {peer_addr}: {msg}`),
+            }
+        })
+    }
+
+    return Ok(())
+}
+
+async func handle_connection(
+    mut stream: TcpStream,
+    peer_addr: Str,
+    state: AppState
+) -> Outcome[Unit, Str] {
+    let req = Request::parse(ref mut stream).await?
+    let resp = handle_request(req, state).await
+    resp.write(ref mut stream).await?
+    return Ok(())
+}
+
+func main() {
+    let rt = Runtime::new()
+    when rt.block_on(run_server("0.0.0.0:8080")) {
+        Ok(_)    => {},
+        Err(msg) => println(`Server error: {msg}`),
+    }
+}

--- a/samples/TML/generics_and_bounds.tml
+++ b/samples/TML/generics_and_bounds.tml
@@ -1,0 +1,149 @@
+/// Generic types with behavior bounds, associated types, and lifetime-free memory.
+use core::traits::cmp::{Ord, PartialEq, Eq}
+use core::traits::clone::Duplicate
+use core::fmt::Display
+
+// ─── Behavior with associated type ──────────────────────────────────────────
+
+pub behavior Transformer {
+    type Input
+    type Output
+
+    func transform(this, input: This::Input) -> This::Output
+    func transform_all(this, inputs: List[This::Input]) -> List[This::Output] {
+        let mut outputs: List[This::Output] = List::new()
+        for i in 0 to inputs.len() {
+            outputs.push(this.transform(inputs.get(i)))
+        }
+        return outputs
+    }
+}
+
+// ─── Multiple behavior bounds ────────────────────────────────────────────────
+
+pub func sort_and_display[T: Ord + Display + Duplicate](mut items: List[T]) -> Str {
+    // Insertion sort
+    for i in 1 to items.len() {
+        var j = i
+        loop (j > 0 and items.get(j).lt(ref items.get(j - 1))) {
+            let tmp = items.get(j).duplicate()
+            items.set(j, items.get(j - 1).duplicate())
+            items.set(j - 1, tmp)
+            j = j - 1
+        }
+    }
+    var parts: List[Str] = List::new()
+    for i in 0 to items.len() {
+        parts.push(items.get(i).fmt())
+    }
+    return "[" + parts.join(", ") + "]"
+}
+
+// ─── Behavior aliases ────────────────────────────────────────────────────────
+
+pub behavior SortKey = Ord + Duplicate + Display
+
+// ─── Heap-allocated recursive type ──────────────────────────────────────────
+
+pub type Tree[T] {
+    Leaf(T),
+    Node(Heap[Tree[T]], T, Heap[Tree[T]]),
+}
+
+impl[T: Ord + Duplicate] Tree[T] {
+    pub func insert(this, value: T) -> Tree[T] {
+        when this {
+            Tree::Leaf(v) => {
+                if value.lt(ref v) {
+                    return Tree::Node(
+                        Heap::new(Tree::Leaf(value)),
+                        v,
+                        Heap::new(Tree::Leaf(value)),
+                    )
+                }
+                return Tree::Node(
+                    Heap::new(Tree::Leaf(v.duplicate())),
+                    value,
+                    Heap::new(Tree::Leaf(v)),
+                )
+            },
+            Tree::Node(left, v, right) => {
+                if value.lt(ref v) {
+                    return Tree::Node(
+                        Heap::new((*left).insert(value)),
+                        v,
+                        right,
+                    )
+                }
+                return Tree::Node(
+                    left,
+                    v,
+                    Heap::new((*right).insert(value)),
+                )
+            },
+        }
+    }
+
+    pub func contains(this, value: ref T) -> Bool {
+        when this {
+            Tree::Leaf(v)              => return v.eq(value),
+            Tree::Node(left, v, right) => {
+                if value.eq(ref v)  { return true }
+                if value.lt(ref v)  { return (*left).contains(value) }
+                return (*right).contains(value)
+            },
+        }
+    }
+
+    pub func to_sorted_list(this) -> List[T] {
+        when this {
+            Tree::Leaf(v) => {
+                let mut list: List[T] = List::new()
+                list.push(v)
+                return list
+            },
+            Tree::Node(left, v, right) => {
+                let mut list = (*left).to_sorted_list()
+                list.push(v)
+                let right_list = (*right).to_sorted_list()
+                for i in 0 to right_list.len() {
+                    list.push(right_list.get(i))
+                }
+                return list
+            },
+        }
+    }
+}
+
+// ─── impl with where clause ──────────────────────────────────────────────────
+
+pub func zip_with[A, B, C](
+    a: List[A],
+    b: List[B],
+    f: func(A, B) -> C
+) -> List[C] where A: Duplicate, B: Duplicate {
+    let len = if a.len() < b.len() { a.len() } else { b.len() }
+    let mut result: List[C] = List::new()
+    for i in 0 to len {
+        result.push(f(a.get(i).duplicate(), b.get(i).duplicate()))
+    }
+    return result
+}
+
+func main() {
+    let mut tree = Tree::Leaf(5)
+    let values = [3, 7, 1, 4, 6, 8, 2]
+    for i in 0 to values.len() {
+        tree = tree.insert(values.get(i))
+    }
+
+    let sorted = tree.to_sorted_list()
+    println(`Sorted: {sorted}`)
+    println(`Contains 4: {tree.contains(ref 4)}`)
+    println(`Contains 9: {tree.contains(ref 9)}`)
+
+    let nums  = [1, 2, 3, 4, 5]
+    let words = ["one", "two", "three", "four", "five"]
+    let pairs = zip_with(nums, words, do(n, w) `{n}={w}`)
+    println(`Pairs: {pairs}`)
+}

--- a/samples/TML/hello_world.tml
+++ b/samples/TML/hello_world.tml
@@ -1,0 +1,6 @@
+/// The classic first program in TML.
+use std::io
+
+func main() {
+    println("Hello, World!")
+}

--- a/samples/TML/lowlevel_memory.tml
+++ b/samples/TML/lowlevel_memory.tml
@@ -1,0 +1,138 @@
+/// Low-level memory operations and FFI bindings.
+use core::alloc::{Layout, GlobalAlloc}
+
+// ─── External C function binding ────────────────────────────────────────────
+
+@extern("c")
+func memcpy(dst: *U8, src: *U8, n: I64) -> *U8
+
+@extern("c")
+func memset(dst: *U8, val: I32, n: I64) -> *U8
+
+@extern("c")
+func malloc(size: I64) -> *U8
+
+@extern("c")
+func free(ptr: *U8)
+
+// ─── Arena allocator ────────────────────────────────────────────────────────
+
+pub type Arena {
+    buffer: *U8,
+    capacity: I64,
+    offset: I64,
+}
+
+impl Arena {
+    @allocates
+    pub func new(capacity: I64) -> Arena {
+        let buf = lowlevel { mem_alloc(capacity as U64) as *U8 }
+        return Arena {
+            buffer: buf,
+            capacity: capacity,
+            offset: 0,
+        }
+    }
+
+    pub func alloc(mut this, size: I64, align: I64) -> Maybe[*U8] {
+        let aligned = (this.offset + align - 1) and (not (align - 1))
+        if aligned + size > this.capacity {
+            return Nothing
+        }
+        let ptr = lowlevel { ptr_add[U8](this.buffer, aligned as U64) }
+        this.offset = aligned + size
+        return Just(ptr)
+    }
+
+    pub func reset(mut this) {
+        this.offset = 0
+    }
+
+    pub func free(this) {
+        lowlevel { mem_free(this.buffer as *U8) }
+    }
+}
+
+// ─── SIMD vector operations ──────────────────────────────────────────────────
+
+use core::simd::{F32x4, I32x4}
+
+pub func dot_product_simd(a: *F32, b: *F32, len: I64) -> F32 {
+    var sum = F32x4::zero()
+    let chunks = len / 4
+    for i in 0 to chunks {
+        let va = F32x4::load(lowlevel { ptr_add[F32](a, (i * 4) as U64) })
+        let vb = F32x4::load(lowlevel { ptr_add[F32](b, (i * 4) as U64) })
+        sum = sum + va * vb
+    }
+    var result: F32 = sum.horizontal_sum()
+    // Handle remainder
+    let start = chunks * 4
+    for i in start to len {
+        let ai = lowlevel { ptr_read[F32](ptr_add[F32](a, i as U64)) }
+        let bi = lowlevel { ptr_read[F32](ptr_add[F32](b, i as U64)) }
+        result = result + ai * bi
+    }
+    return result
+}
+
+// ─── Custom global allocator ─────────────────────────────────────────────────
+
+pub type BumpAllocator {
+    start: *U8,
+    current: *U8,
+    end: *U8,
+}
+
+impl GlobalAlloc for BumpAllocator {
+    pub func alloc(mut this, layout: Layout) -> *U8 {
+        let size  = layout.size() as I64
+        let align = layout.align() as I64
+        let addr  = this.current as I64
+        let aligned = (addr + align - 1) and (not (align - 1))
+        let new_ptr = aligned + size
+        if new_ptr > this.end as I64 {
+            return 0 as *U8  // null — out of memory
+        }
+        this.current = new_ptr as *U8
+        return aligned as *U8
+    }
+
+    pub func dealloc(mut this, ptr: *U8, layout: Layout) {
+        // Bump allocators don't support individual dealloc
+    }
+}
+
+// ─── Inline assembly / compiler intrinsic ────────────────────────────────────
+
+@intrinsic
+pub func count_leading_zeros(x: U64) -> I32
+
+@intrinsic
+pub func count_trailing_zeros(x: U64) -> I32
+
+pub func next_power_of_two(n: U64) -> U64 {
+    if n <= 1 { return 1 }
+    let clz = count_leading_zeros(n - 1) as U64
+    return 1 << (64 - clz)
+}
+
+func main() {
+    let mut arena = Arena::new(1024 * 1024)  // 1 MB
+
+    let ptr = arena.alloc(64, 8)
+    when ptr {
+        Just(p) => println(`Allocated 64 bytes at offset {arena.offset - 64}`),
+        Nothing => println("Allocation failed"),
+    }
+
+    arena.free()
+
+    let a = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+    let b = [8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0]
+    // dot product: 1*8+2*7+3*6+4*5+5*4+6*3+7*2+8*1 = 120
+    println(`SIMD dot product: {dot_product_simd(a.as_ptr(), b.as_ptr(), 8)}`)
+
+    println(`next_power_of_two(100) = {next_power_of_two(100)}`)
+    println(`next_power_of_two(128) = {next_power_of_two(128)}`)
+}

--- a/samples/TML/pattern_matching.tml
+++ b/samples/TML/pattern_matching.tml
@@ -1,0 +1,120 @@
+/// Demonstrates TML pattern matching, let-else, and optional chaining.
+use std::json
+use std::collections::HashMap
+
+// ─── Algebraic data type ─────────────────────────────────────────────────────
+
+pub type Expr {
+    Num(F64),
+    Var(Str),
+    Add(Heap[Expr], Heap[Expr]),
+    Mul(Heap[Expr], Heap[Expr]),
+    Neg(Heap[Expr]),
+}
+
+pub func eval(expr: ref Expr, env: ref HashMap[Str, F64]) -> Maybe[F64] {
+    when *expr {
+        Expr::Num(n)    => return Just(n),
+        Expr::Var(name) => return env.get(name),
+        Expr::Neg(e)    => {
+            let Just(v) = eval(ref *e, env) else { return Nothing }
+            return Just(-v)
+        },
+        Expr::Add(lhs, rhs) => {
+            let Just(l) = eval(ref *lhs, env) else { return Nothing }
+            let Just(r) = eval(ref *rhs, env) else { return Nothing }
+            return Just(l + r)
+        },
+        Expr::Mul(lhs, rhs) => {
+            let Just(l) = eval(ref *lhs, env) else { return Nothing }
+            let Just(r) = eval(ref *rhs, env) else { return Nothing }
+            return Just(l * r)
+        },
+    }
+}
+
+// ─── Pattern guards ──────────────────────────────────────────────────────────
+
+pub func classify(n: I64) -> Str {
+    when n {
+        0             => "zero",
+        x if x < 0   => "negative",
+        x if x < 10  => "small positive",
+        x if x < 100 => "medium positive",
+        _             => "large positive",
+    }
+}
+
+// ─── Optional chaining ───────────────────────────────────────────────────────
+
+pub func get_user_city(json_str: Str) -> Maybe[Str] {
+    return json::parse(json_str)?.get_object("address")?.get_string("city")
+}
+
+// ─── For-in loops ────────────────────────────────────────────────────────────
+
+pub func fibonacci(n: I64) -> List[I64] {
+    let mut fibs: List[I64] = List::new()
+    fibs.push(0)
+    fibs.push(1)
+    for i in 2 to n {
+        let a = fibs.get(i - 2)
+        let b = fibs.get(i - 1)
+        fibs.push(a + b)
+    }
+    return fibs
+}
+
+// ─── Error handling with Outcome ─────────────────────────────────────────────
+
+pub type ParseError {
+    EmptyInput,
+    InvalidChar(Char, I64),
+    Overflow,
+}
+
+pub func parse_positive_int(s: Str) -> Outcome[I64, ParseError] {
+    if s.len() == 0 {
+        return Err(ParseError::EmptyInput)
+    }
+    var result: I64 = 0
+    for i in 0 to s.len() {
+        let c = s.char_at(i)
+        if c < '0' or c > '9' {
+            return Err(ParseError::InvalidChar(c, i))
+        }
+        result = result * 10 + (c as I64 - '0' as I64)
+        if result < 0 {
+            return Err(ParseError::Overflow)
+        }
+    }
+    return Ok(result)
+}
+
+func main() {
+    let mut env: HashMap[Str, F64] = HashMap::new()
+    env.set("x", 3.0)
+    env.set("y", 4.0)
+
+    let expr = Expr::Add(
+        Heap::new(Expr::Var("x")),
+        Heap::new(Expr::Mul(
+            Heap::new(Expr::Num(2.0)),
+            Heap::new(Expr::Var("y")),
+        )),
+    )
+
+    when eval(ref expr, ref env) {
+        Just(result) => println(`x + 2*y = {result}`),
+        Nothing      => println("Evaluation failed"),
+    }
+
+    let numbers = [-5, 0, 3, 42, 999]
+    for i in 0 to numbers.len() {
+        let n = numbers.get(i)
+        println(`{n} is {classify(n)}`)
+    }
+
+    let fibs = fibonacci(10)
+    println(`First 10 Fibonacci numbers: {fibs}`)
+}

--- a/samples/TML/types_and_behaviors.tml
+++ b/samples/TML/types_and_behaviors.tml
@@ -1,0 +1,137 @@
+/// Type definitions, behaviors (traits), and generic implementations.
+use core::traits::cmp::{Ord, PartialEq, Ordering}
+use std::fmt::Display
+
+// ─── Struct type ─────────────────────────────────────────────────────────────
+
+pub type Point {
+    x: F64,
+    y: F64,
+}
+
+impl Point {
+    pub func new(x: F64, y: F64) -> Point {
+        return Point { x: x, y: y }
+    }
+
+    pub func distance(this, other: ref Point) -> F64 {
+        let dx = this.x - other.x
+        let dy = this.y - other.y
+        return (dx * dx + dy * dy).sqrt()
+    }
+}
+
+impl Display for Point {
+    pub func fmt(this) -> Str {
+        return `({this.x}, {this.y})`
+    }
+}
+
+// ─── Enum type ───────────────────────────────────────────────────────────────
+
+pub type Shape {
+    Circle(F64),
+    Rectangle(F64, F64),
+    Triangle(F64, F64, F64),
+}
+
+impl Shape {
+    pub func area(this) -> F64 {
+        when this {
+            Shape::Circle(r)         => 3.14159265 * r * r,
+            Shape::Rectangle(w, h)   => w * h,
+            Shape::Triangle(a, b, c) => {
+                let s = (a + b + c) / 2.0
+                return (s * (s - a) * (s - b) * (s - c)).sqrt()
+            },
+        }
+    }
+
+    pub func perimeter(this) -> F64 {
+        when this {
+            Shape::Circle(r)         => 2.0 * 3.14159265 * r,
+            Shape::Rectangle(w, h)   => 2.0 * (w + h),
+            Shape::Triangle(a, b, c) => a + b + c,
+        }
+    }
+}
+
+// ─── Generic behavior ────────────────────────────────────────────────────────
+
+pub behavior Summable[T] {
+    func sum(this) -> T
+}
+
+pub behavior Container[T] {
+    func len(this) -> I64
+    func is_empty(this) -> Bool {
+        return this.len() == 0
+    }
+    func get(this, index: I64) -> Maybe[T]
+}
+
+// ─── Generic struct ──────────────────────────────────────────────────────────
+
+pub type Stack[T] {
+    items: List[T],
+}
+
+impl[T] Stack[T] {
+    pub func new() -> Stack[T] {
+        return Stack { items: List::new() }
+    }
+
+    pub func push(mut this, value: T) {
+        this.items.push(value)
+    }
+
+    pub func pop(mut this) -> Maybe[T] {
+        if this.items.len() == 0 {
+            return Nothing
+        }
+        return Just(this.items.pop())
+    }
+
+    pub func peek(this) -> Maybe[ref T] {
+        if this.items.len() == 0 {
+            return Nothing
+        }
+        return Just(ref this.items.get(this.items.len() - 1))
+    }
+}
+
+impl[T] Container[T] for Stack[T] {
+    pub func len(this) -> I64 {
+        return this.items.len()
+    }
+
+    pub func get(this, index: I64) -> Maybe[T] {
+        if index < 0 or index >= this.items.len() {
+            return Nothing
+        }
+        return Just(this.items.get(index))
+    }
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+func main() {
+    let p1 = Point::new(0.0, 0.0)
+    let p2 = Point::new(3.0, 4.0)
+    println(`Distance: {p1.distance(ref p2)}`)
+
+    let circle = Shape::Circle(5.0)
+    let rect   = Shape::Rectangle(4.0, 6.0)
+    println(`Circle area: {circle.area()}`)
+    println(`Rectangle area: {rect.area()}`)
+
+    let mut stack: Stack[I64] = Stack::new()
+    stack.push(10)
+    stack.push(20)
+    stack.push(30)
+
+    loop {
+        let Just(value) = stack.pop() else { break }
+        println(`Popped: {value}`)
+    }
+}


### PR DESCRIPTION
## New language: TML

- **Type**: Programming
- **Website**: https://github.com/hivellm/tml
- **Extensions**: `.tml`
- **Grammar**: https://github.com/hivellm/tml-textmate
- **Color**: `#5A3FBE`

TML is a systems programming language with a self-hosting compiler
targeting LLVM IR. It features:
- Algebraic data types (`type`/`enum` with variants)
- Behaviors (like Rust traits) via `behavior` / `impl`
- Generic types with bounds (`func foo[T: Ord + Display](…)`)
- Pattern matching via `when`
- Optional chaining `?.` and let-else unwrapping
- Async/await concurrency model
- Low-level memory access via `lowlevel` blocks

The compiler and ~150k lines of standard library are written in TML itself.

### Changes

- `lib/linguist/languages.yml` — new entry under "T" (between TMDL and TOML)
- `grammars.yml` — `source.tml` pointing to `vendor/grammars/tml-textmate`
- `vendor/grammars/tml-textmate` — submodule (TextMate grammar, Apache-2.0)
- `samples/TML/` — 6 sample files: hello world, types/behaviors, pattern matching, generics, async HTTP, low-level memory