### PR TITLE
Add Izel language support (.iz)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3434,6 +3434,13 @@ Isabelle ROOT:
   tm_scope: source.isabelle.root
   ace_mode: text
   language_id: 171
+Izel:
+  type: programming
+  tm_scope: none
+  ace_mode: text
+  extensions:
+  - ".iz"
+  language_id: 291945562
 J:
   type: programming
   color: "#9EEDFF"
@@ -7674,7 +7681,7 @@ TMDL:
   extensions:
   - ".tmdl"
   aliases:
-  - "Tabular Model Definition Language"
+  - Tabular Model Definition Language
   tm_scope: source.tmdl
   ace_mode: text
   language_id: 769162295

--- a/samples/Izel/compiler_lexer.iz
+++ b/samples/Izel/compiler_lexer.iz
@@ -1,0 +1,104 @@
+// Izel Lexer implementation in Izel
+// Part of Phase 7: Self-Hosting
+
+shape Token {
+    kind: Kind
+    start: Int
+    end: Int
+}
+
+forge tokenize {
+    params: [source: Str]
+    ret: List[Token]
+    body: {
+        ~ tokens: List[Token] = []
+        ~ i = 0
+        ~ len = source.len()
+
+        while i < len {
+            ~ char = source[i]
+
+            given char {
+                ' ' | '\t' | '\r' | '\n' -> { i = i + 1 }
+                '+' -> { tokens.push(Token { kind: Kind::Plus, start: i, end: i + 1 }); i = i + 1 }
+                '-' -> {
+                    if i + 1 < len and source[i+1] == '>' {
+                        tokens.push(Token { kind: Kind::Arrow, start: i, end: i + 2 })
+                        i = i + 2
+                    } else {
+                        tokens.push(Token { kind: Kind::Minus, start: i, end: i + 1 })
+                        i = i + 1
+                    }
+                }
+                '*' -> { tokens.push(Token { kind: Kind::Star, start: i, end: i + 1 }); i = i + 1 }
+                '/' -> { tokens.push(Token { kind: Kind::Slash, start: i, end: i + 1 }); i = i + 1 }
+                '=' -> {
+                    if i + 1 < len and source[i+1] == '=' {
+                        tokens.push(Token { kind: Kind::EqEq, start: i, end: i + 2 })
+                        i = i + 2
+                    } else if i + 1 < len and source[i+1] == '>' {
+                        tokens.push(Token { kind: Kind::FatArrow, start: i, end: i + 2 })
+                        i = i + 2
+                    } else {
+                        tokens.push(Token { kind: Kind::Eq, start: i, end: i + 1 })
+                        i = i + 1
+                    }
+                }
+                ':' -> {
+                    if i + 1 < len and source[i+1] == ':' {
+                        tokens.push(Token { kind: Kind::DoubleColon, start: i, end: i + 2 })
+                        i = i + 2
+                    } else {
+                        tokens.push(Token { kind: Kind::Colon, start: i, end: i + 1 })
+                        i = i + 1
+                    }
+                }
+                '(' -> { tokens.push(Token { kind: Kind::LParen, start: i, end: i + 1 }); i = i + 1 }
+                ')' -> { tokens.push(Token { kind: Kind::RParen, start: i, end: i + 1 }); i = i + 1 }
+                '{' -> { tokens.push(Token { kind: Kind::LBrace, start: i, end: i + 1 }); i = i + 1 }
+                '}' -> { tokens.push(Token { kind: Kind::RBrace, start: i, end: i + 1 }); i = i + 1 }
+                '[' -> { tokens.push(Token { kind: Kind::LBracket, start: i, end: i + 1 }); i = i + 1 }
+                ']' -> { tokens.push(Token { kind: Kind::RBracket, start: i, end: i + 1 }); i = i + 1 }
+                ',' -> { tokens.push(Token { kind: Kind::Comma, start: i, end: i + 1 }); i = i + 1 }
+                ';' -> { tokens.push(Token { kind: Kind::Semi, start: i, end: i + 1 }); i = i + 1 }
+                '.' -> { tokens.push(Token { kind: Kind::Dot, start: i, end: i + 1 }); i = i + 1 }
+                '~' -> { tokens.push(Token { kind: Kind::Tide, start: i, end: i + 1 }); i = i + 1 }
+
+                _ -> {
+                    if is_digit(char) {
+                        ~ start = i
+                        while i < len and is_digit(source[i]) { i = i + 1 }
+                        tokens.push(Token { kind: Kind::Int, start: start, end: i })
+                    } else if is_alpha(char) {
+                        ~ start = i
+                        while i < len and (is_alpha(source[i]) or is_digit(source[i])) { i = i + 1 }
+                        ~ text = source.slice(start, i)
+                        tokens.push(Token { kind: get_keyword_kind(text), start: start, end: i })
+                    } else {
+                        i = i + 1 // skip unknown
+                    }
+                }
+            }
+        }
+
+        return tokens
+    }
+}
+
+forge get_keyword_kind {
+    params: [text: Str]
+    ret: Kind
+    body: {
+        given text {
+            "forge" -> return Kind::Forge
+            "shape" -> return Kind::Shape
+            "given" -> return Kind::Given
+            "each"  -> return Kind::Each
+            "return" -> return Kind::Return
+            "let"   -> return Kind::Let
+            "if"    -> return Kind::If
+            "else"  -> return Kind::Else
+            _       -> return Kind::Ident
+        }
+    }
+}

--- a/samples/Izel/compiler_parser.iz
+++ b/samples/Izel/compiler_parser.iz
@@ -1,0 +1,82 @@
+// Izel Parser implementation in Izel
+// Part of Phase 7: Self-Hosting
+
+shape Parser {
+    tokens: List[Token]
+    pos: Int
+}
+
+forge parse_forge {
+    params: [p: Parser]
+    ret: AstNode
+    body: {
+        p.expect(Kind::Forge)
+        ~ name = p.expect(Kind::Ident).text()
+        ~ params = p.parse_params()
+        ~ ret_type = p.parse_type()
+        ~ body = p.parse_block()
+        return AstNode::Forge(name, params, ret_type, body)
+    }
+}
+
+forge parse_stmt {
+    params: [p: Parser]
+    ret: AstNode
+    body: {
+        ~ token = p.peek()
+        given token.kind {
+            Kind::Let   -> return p.parse_let()
+            Kind::Given -> return p.parse_given()
+            Kind::Each  -> return p.parse_each()
+            Kind::Return -> return p.parse_return()
+            _           -> return p.parse_expr_stmt()
+        }
+    }
+}
+
+forge parse_expr {
+    params: [p: Parser, min_prec: Int]
+    ret: AstNode
+    body: {
+        ~ left = p.parse_primary()
+
+        loop {
+            ~ op = p.peek()
+            ~ prec = get_precedence(op.kind)
+            if prec < min_prec { break }
+
+            p.advance()
+            ~ right = p.parse_expr(prec + 1)
+            left = AstNode::Binary(op.kind, left, right)
+        }
+
+        return left
+    }
+}
+
+forge get_precedence {
+    params: [kind: Kind]
+    ret: Int
+    body: {
+        given kind {
+            Kind::Plus | Kind::Minus -> return 10
+            Kind::Star | Kind::Slash -> return 20
+            Kind::EqEq | Kind::NotEq -> return 5
+            _ -> return 0
+        }
+    }
+}
+
+// ... helper methods for Parser ...
+forge expect {
+    params: [p: Parser, kind: Kind]
+    ret: Token
+    body: {
+        ~ t = p.peek()
+        if t.kind == kind {
+            return p.advance()
+        }
+        // error handling here
+        return t
+    }
+}


### PR DESCRIPTION
## Description
Add support for **Izel** as a new language with the `.iz` extension.

This PR includes:
- `lib/linguist/languages.yml` entry for `Izel` (detection-first, `tm_scope: none`)
- Two real-world samples:
  - `samples/Izel/compiler_lexer.iz`
  - `samples/Izel/compiler_parser.iz`

Notes:
- `script/update-ids` was run and generated the `language_id` for Izel.
- `.iz` is currently unclaimed in `languages.yml`, so no heuristic disambiguation change is included in this PR.
- This is a detection-first PR; grammar can be proposed in a follow-up.

## Checklist:
- [ ] **I am adding a new extension to a language.**

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.iz
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.iz+(forge+OR+shape+OR+given)
    - Additional measured signal from API while preparing this PR:
      - `extension:iz NOT is:fork` => 276 code results
      - ~70 distinct repositories across first 10 pages (`per_page=100`)
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/VoxDroid/izel/blob/main/compiler/lexer.iz
      - https://github.com/VoxDroid/izel/blob/main/compiler/parser.iz
    - Sample license(s):
      - MIT: https://github.com/VoxDroid/izel/blob/main/LICENSE
  - [ ] I have included a syntax highlighting grammar: [URL to grammar repo]
  - [ ] I have added a color
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
- [ ] **I am changing the source of a syntax highlighting grammar**
- [ ] **I am updating a grammar submodule**
- [ ] **I am adding new or changing current functionality**
- [ ] **I am changing the color associated with a language**
