### PR TITLE
Add Lateralus programming language

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -1440,3 +1440,5 @@ vendor/grammars/zenstack:
 - source.zmodel
 vendor/grammars/zephir-sublime:
 - source.php.zephir
+vendor/grammars/lateralus-textmate-grammar:
+- source.lateralus

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4129,6 +4129,20 @@ Lasso:
   - lassoscript
   ace_mode: text
   language_id: 195
+Lateralus:
+  type: programming
+  color: "#8B5CF6"
+  extensions:
+  - ".ltl"
+  tm_scope: source.lateralus
+  ace_mode: text
+  codemirror_mode: null
+  codemirror_mime_type: null
+  aliases:
+  - ltl
+  interpreters:
+  - ltlc
+  language_id: 1067292665
 Latte:
   type: markup
   color: "#f2a542"

--- a/samples/Lateralus/codegen.ltl
+++ b/samples/Lateralus/codegen.ltl
@@ -1,0 +1,100 @@
+// =======================================================================
+// LATERALUS Self-Hosting Bootstrap — Code Generator (Identity Transform)
+// Translates LATERALUS AST back to LATERALUS source code
+//
+// This is the third stage of the self-hosting compiler:
+//   v2_lexer.ltl → v2_parser.ltl → v2_codegen.ltl
+//
+// Generates LATERALUS output (identity transform / pretty-printer).
+// See v2_ir_codegen.ltl for the IR generation backend.
+// =======================================================================
+
+// --- Code Generation Context -----------------------------------------
+
+struct CodeGenContext {
+    output: str,
+    indent_level: int,
+    indent_str: str,
+}
+
+fn new_codegen() -> CodeGenContext {
+    return CodeGenContext {
+        output: "",
+        indent_level: 0,
+        indent_str: "    ",
+    }
+}
+
+fn cg_emit(ctx: CodeGenContext, text: str) {
+    ctx.output = ctx.output + text
+}
+
+fn cg_emit_indent(ctx: CodeGenContext) {
+    for i in range(ctx.indent_level) {
+        cg_emit(ctx, ctx.indent_str)
+    }
+}
+
+fn cg_emit_line(ctx: CodeGenContext, text: str) {
+    cg_emit_indent(ctx)
+    cg_emit(ctx, text + "\n")
+}
+
+fn indent(ctx: CodeGenContext) {
+    ctx.indent_level = ctx.indent_level + 1
+}
+
+fn dedent(ctx: CodeGenContext) {
+    ctx.indent_level = ctx.indent_level - 1
+}
+
+// --- Expression Generation -------------------------------------------
+
+fn gen_expression(ctx: CodeGenContext, node: ASTNode) -> str {
+    match node.kind {
+        "INT_LIT" => { return node.value },
+        "FLOAT_LIT" => { return node.value },
+        "STRING_LIT" => { return "\"" + node.value + "\"" },
+        "BOOL_LIT" => { return node.value },
+        "NONE_LIT" => { return "none" },
+
+        "IDENT_EXPR" => { return node.value },
+
+        "BINARY_EXPR" => {
+            let left = gen_expression(ctx, node.children[0])
+            let right = gen_expression(ctx, node.children[1])
+            return left + " " + node.value + " " + right
+        },
+
+        "UNARY_EXPR" => {
+            let operand = gen_expression(ctx, node.children[0])
+            if node.value == "not" {
+                return "not " + operand
+            }
+            return node.value + operand
+        },
+
+        "CALL_EXPR" => {
+            let args = []
+            for child in node.children {
+                args = args + [gen_expression(ctx, child)]
+            }
+            return node.value + "(" + join(args, ", ") + ")"
+        },
+
+        "PIPE_EXPR" => {
+            let left = gen_expression(ctx, node.children[0])
+            let right = gen_expression(ctx, node.children[1])
+            return left + " " + node.value + " " + right
+        },
+
+        "LIST_LIT" => {
+            let items = []
+            for child in node.children {
+                items = items + [gen_expression(ctx, child)]
+            }
+            return "[" + join(items, ", ") + "]"
+        },
+
+        _ => {
+            return "/* unknown: " + node.kind + " */"

--- a/samples/Lateralus/enum_demo.ltl
+++ b/samples/Lateralus/enum_demo.ltl
@@ -1,0 +1,159 @@
+// -----------------------------------------------------------------------------
+// examples/enum_demo.ltl  –  Enums, variants & pattern matching  (v1.1.0)
+// -----------------------------------------------------------------------------
+//
+// Demonstrates:
+//   • Simple enum (no data fields)
+//   • Enum with associated data per variant
+//   • type aliases
+//   • match expressions on enum values
+//   • impl blocks on enums
+// -----------------------------------------------------------------------------
+
+// -- Direction -----------------------------------------------------------------
+
+pub enum Direction {
+    North
+    South
+    East
+    West
+}
+
+impl Direction {
+    pub fn opposite(self) -> Direction {
+        match self {
+            Direction.North => Direction.South
+            Direction.South => Direction.North
+            Direction.East  => Direction.West
+            Direction.West  => Direction.East
+        }
+    }
+
+    pub fn to_delta(self) -> list {
+        match self {
+            Direction.North => [0, 1]
+            Direction.South => [0, -1]
+            Direction.East  => [1, 0]
+            Direction.West  => [-1, 0]
+        }
+    }
+
+    pub fn to_str(self) -> str {
+        match self {
+            Direction.North => "North"
+            Direction.South => "South"
+            Direction.East  => "East"
+            Direction.West  => "West"
+        }
+    }
+}
+
+// -- Color (enum with integer values) -----------------------------------------
+
+pub enum Color {
+    Red   = 0xff0000
+    Green = 0x00ff00
+    Blue  = 0x0000ff
+    Black = 0x000000
+    White = 0xffffff
+}
+
+// -- Result<T, E> style enum ---------------------------------------------------
+
+pub enum Outcome {
+    Ok    // success (no data in this demo)
+    Err   // failure
+    Empty // neither
+}
+
+// type alias
+pub type MaybeInt = Outcome
+
+fn safe_divide(a: int, b: int) -> Outcome {
+    if b == 0 {
+        return Outcome.Err
+    }
+    return Outcome.Ok
+}
+
+fn describe_outcome(o: Outcome) -> str {
+    match o {
+        Outcome.Ok    => "Success"
+        Outcome.Err   => "Error"
+        Outcome.Empty => "Empty"
+    }
+}
+
+// -- Token enum (like a real lexer) --------------------------------------------
+
+pub enum Token {
+    Number
+    Plus
+    Minus
+    Star
+    Slash
+    LParen
+    RParen
+    EOF
+}
+
+fn token_name(t: Token) -> str {
+    match t {
+        Token.Number  => "Number"
+        Token.Plus    => "+"
+        Token.Minus   => "-"
+        Token.Star    => "*"
+        Token.Slash   => "/"
+        Token.LParen  => "("
+        Token.RParen  => ")"
+        Token.EOF     => "<EOF>"
+    }
+}
+
+// -- Demo ---------------------------------------------------------------------
+
+fn main() {
+    // Direction demo
+    println("=== Direction ===")
+    let d = Direction.North
+    println("Direction: " + d.to_str())
+    println("Opposite:  " + d.opposite().to_str())
+
+    let delta = d.to_delta()
+    println("Delta:     [" + str(delta[0]) + ", " + str(delta[1]) + "]")
+
+    // Compass walk
+    let dirs = [Direction.North, Direction.East, Direction.East, Direction.South]
+    let x = 0
+    let y = 0
+    let i = 0
+    while i < len(dirs) {
+        let dv = dirs[i].to_delta()
+        x = x + dv[0]
+        y = y + dv[1]
+        i = i + 1
+    }
+    println("After walk: (" + str(x) + ", " + str(y) + ")")
+
+    // Outcome demo
+    println("\n=== Outcome ===")
+    println("10 / 2  → " + describe_outcome(safe_divide(10, 2)))
+    println("10 / 0  → " + describe_outcome(safe_divide(10, 0)))
+
+    // Token stream
+    println("\n=== Token stream ===")
+    let tokens = [
+        Token.Number, Token.Plus, Token.Number,
+        Token.Star,   Token.LParen, Token.Number, Token.RParen, Token.EOF
+    ]
+    let j = 0
+    while j < len(tokens) {
+        print(token_name(tokens[j]) + " ")
+        j = j + 1
+    }
+    println("")
+
+    println("\nAll done!")
+}
+
+main()

--- a/samples/Lateralus/pipeline.ltl
+++ b/samples/Lateralus/pipeline.ltl
@@ -1,0 +1,237 @@
+// -----------------------------------------------------------------------------
+// examples/advanced_pipeline.ltl  –  Multi-stage data pipelines  (v1.1.0)
+// -----------------------------------------------------------------------------
+//
+// Demonstrates:
+//   • Structs and impl blocks to model a data pipeline stage
+//   • Function references (higher-order programming)
+//   • Collections: map / filter / foldl / zip / chunk
+//   • String formatting helpers from stdlib/strings
+//   • Composing multiple pipeline stages with |> (pipe) style calls
+//   • Type aliases for readability
+// -----------------------------------------------------------------------------
+
+from stdlib.strings     import join, pad_left, format_int
+from stdlib.collections import map, filter, foldl, zip, chunk, sort, reverse, enumerate_list
+
+// -- Type aliases -------------------------------------------------------------
+
+pub type Row     = list    // A single CSV row (list of values)
+pub type Table   = list    // A list of rows
+pub type PipelineFn = fn   // fn(Table) -> Table
+
+// -- Pipeline stage ------------------------------------------------------------
+
+pub struct Stage {
+    name:    str
+    process: fn      // fn(Table) -> Table
+}
+
+impl Stage {
+    pub fn new(name: str, process: fn) -> Stage {
+        return Stage { name: name, process: process }
+    }
+
+    pub fn run(self, data: Table) -> Table {
+        println("  [" + self.name + "] rows in: " + str(len(data)))
+        let result = self.process(data)
+        println("  [" + self.name + "] rows out: " + str(len(result)))
+        return result
+    }
+}
+
+// -- Pipeline -----------------------------------------------------------------
+
+pub struct Pipeline {
+    stages: list
+    name:   str
+}
+
+impl Pipeline {
+    pub fn new(name: str) -> Pipeline {
+        return Pipeline { stages: [], name: name }
+    }
+
+    pub fn add_stage(self, stage: Stage) -> Pipeline {
+        return Pipeline {
+            name:   self.name,
+            stages: push(self.stages, stage)
+        }
+    }
+
+    pub fn execute(self, data: Table) -> Table {
+        println("\nPipeline: " + self.name)
+        println("-------------------------------------")
+        let current = data
+        let i = 0
+        while i < len(self.stages) {
+            current = self.stages[i].run(current)
+            i = i + 1
+        }
+        println("-------------------------------------")
+        return current
+    }
+}
+
+// -- Stage implementations -----------------------------------------------------
+
+// Filter rows where column `col` (index) is > threshold.
+fn make_filter_gt(col: int, threshold: any) -> fn {
+    fn stage_fn(data: Table) -> Table {
+        let result = []
+        let i = 0
+        while i < len(data) {
+            let row = data[i]
+            if len(row) > col and row[col] > threshold {
+                result = push(result, row)
+            }
+            i = i + 1
+        }
+        return result
+    }
+    return stage_fn
+}
+
+// Adds a derived column: the product of col_a and col_b at the end of each row.
+fn make_add_product(col_a: int, col_b: int) -> fn {
+    fn stage_fn(data: Table) -> Table {
+        let result = []
+        let i = 0
+        while i < len(data) {
+            let row = data[i]
+            let product = row[col_a] * row[col_b]
+            result = push(result, push(row, product))
+            i = i + 1
+        }
+        return result
+    }
+    return stage_fn
+}
+
+// Sorts the table ascending by the given column index.
+fn make_sort_by_col(col: int) -> fn {
+    fn stage_fn(data: Table) -> Table {
+        // Insertion sort on rows
+        let result = list_copy(data)
+        let n = len(result)
+        let i = 1
+        while i < n {
+            let key = result[i]
+            let j   = i - 1
+            while j >= 0 and result[j][col] > key[col] {
+                result = list_set(result, j + 1, result[j])
+                j = j - 1
+            }
+            result = list_set(result, j + 1, key)
+            i = i + 1
+        }
+        return result
+    }
+    return stage_fn
+}
+
+// Keeps only the top-N rows.
+fn make_top_n(n: int) -> fn {
+    fn stage_fn(data: Table) -> Table {
+        let end = n
+        if end > len(data) { end = len(data) }
+        return slice_list(data, 0, end)
+    }
+    return stage_fn
+}
+
+// -- Pretty-print a table ------------------------------------------------------
+
+fn print_table(headers: list, data: Table) {
+    // Header row
+    let header_line = join(map(headers, fn(h: str) -> str { pad_left(h, 12, " ") }), " | ")
+    println(header_line)
+    println(repeat_str("-", len(header_line)))
+    // Data rows
+    let i = 0
+    while i < len(data) {
+        let row = data[i]
+        let cells = []
+        let j = 0
+        while j < len(row) {
+            cells = push(cells, pad_left(str(row[j]), 12, " "))
+            j = j + 1
+        }
+        println(join(cells, " | "))
+        i = i + 1
+    }
+}
+
+// -- Sales analysis pipeline ---------------------------------------------------
+//
+// Sample dataset: [product_id, units_sold, unit_price]
+
+fn build_sales_data() -> Table {
+    return [
+        [1001, 120,  9],
+        [1002,   5, 99],
+        [1003, 300,  3],
+        [1004,  50, 25],
+        [1005,   0, 15],
+        [1006, 200,  7],
+        [1007,  80, 40],
+        [1008,  15, 60],
+        [1009, 450,  2],
+        [1010,  10, 88]
+    ]
+}
+
+fn main() {
+    let raw = build_sales_data()
+
+    println("=== Raw Sales Data ===")
+    print_table(["product_id", "units_sold", "unit_price"], raw)
+
+    // Build the pipeline
+    let pipeline = Pipeline.new("Sales Analysis")
+        |> add_stage(Stage.new("filter:units>0",    make_filter_gt(1, 0)))
+        |> add_stage(Stage.new("add:revenue",       make_add_product(1, 2)))
+        |> add_stage(Stage.new("filter:revenue>500", make_filter_gt(3, 500)))
+        |> add_stage(Stage.new("sort:revenue_desc", fn(t: Table) -> Table {
+                                                        return reverse(make_sort_by_col(3)(t))
+                                                    }))
+        |> add_stage(Stage.new("top:5",             make_top_n(5)))
+
+    let result = pipeline.execute(raw)
+
+    println("\n=== Top Revenue Products ===")
+    print_table(["product_id", "units_sold", "unit_price", "revenue"], result)
+
+    // Aggregate stats using foldl
+    let total_revenue = foldl(result, 0, fn(acc: int, row: Row) -> int {
+        return acc + row[3]
+    })
+    println("\nTotal revenue (top 5): " + str(total_revenue))
+
+    // Average units sold
+    let total_units = foldl(result, 0, fn(acc: int, row: Row) -> int {
+        return acc + row[1]
+    })
+    let avg_units = total_units / len(result)
+    println("Average units sold:    " + str(avg_units))
+
+    // Chunk into batches for downstream processing
+    let batches = chunk(result, 2)
+    println("\nBatches:")
+    let i = 0
+    while i < len(batches) {
+        let batch = batches[i]
+        let ids = []
+        let j = 0
+        while j < len(batch) {
+            ids = push(ids, str(batch[j][0]))
+            j = j + 1
+        }
+        println("  Batch " + str(i + 1) + ": [" + join(ids, ", ") + "]")
+        i = i + 1
+    }
+
+    println("\nAll done!")
+}
+
+main()


### PR DESCRIPTION
## Add Lateralus

**Language:** Lateralus
**Type:** programming
**File extension:** `.ltl`
**Website / repo:** https://github.com/bad-antics/lateralus-lang
**Playground:** https://lateralus.dev/playground

### What is Lateralus?

Lateralus is a pipeline-native programming language with:
- A native `|>` pipe operator as a first-class language construct
- Full compiler, VM, OS (LateralusOS), and VS Code extension
- Syntax similar to Rust/ML but with distinct pipeline semantics
- Self-hosting bootstrap compiler written in `.ltl` itself

### Why not Rust?

GitHub currently detects `.ltl` files as Rust because the syntax shares keywords (`fn`, `let`, `struct`, `match`). However Lateralus is a distinct language with different semantics, a purpose-built VM, its own type system, and pipeline operators not present in Rust.

### Checklist

- [x] Language has a unique file extension (`.ltl` — not used by any other Linguist language)
- [x] Grammar added: https://github.com/bad-antics/lateralus-textmate-grammar
- [x] 3 sample `.ltl` files added (real-world code from the bootstrap compiler and examples)
- [x] `languages.yml` entry added with color, extensions, tm_scope, language_id
- [x] `grammars.yml` updated to reference the grammar repo
- [x] MIT licensed grammar

### Samples included

- `pipeline.ltl` — multi-stage data pipeline using `|>` operator
- `codegen.ltl` — self-hosting code generator (part of the bootstrap compiler)
- `enum_demo.ltl` — enum and match expression usage