### PR TITLE
Add Rail programming language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ test/fixtures/ace_modes.json
 linguist-grammars*
 .venv
 Brewfile.lock.json
+vendor/bundle/

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6481,6 +6481,14 @@ Raku:
   codemirror_mode: perl
   codemirror_mime_type: text/x-perl
   language_id: 283
+Rail:
+  type: programming
+  color: "#2D2D2D"
+  extensions:
+  - ".rr"
+  tm_scope: none
+  ace_mode: text
+  language_id: 103774905
 Rascal:
   type: programming
   color: "#fffaa0"
@@ -7674,7 +7682,7 @@ TMDL:
   extensions:
   - ".tmdl"
   aliases:
-  - "Tabular Model Definition Language"
+  - Tabular Model Definition Language
   tm_scope: source.tmdl
   ace_mode: text
   language_id: 769162295

--- a/samples/Rail/hello.rr
+++ b/samples/Rail/hello.rr
@@ -1,0 +1,3 @@
+pub fn main() {
+    println("Hello, World!");
+}

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -275,6 +275,7 @@ class TestBlob < Minitest::Test
   end
 
   def test_language
+    assert_blob_language "samples/Rail/hello.rr", "Rail"
     allowed_failures = {
       "#{samples_path}/C/rpc.h" => ["C", "C++"],
     }


### PR DESCRIPTION
## Description

Add Rail programming language

- Adds Rail language definition to languages.yml
- Includes minimal sample for detection
- Adds test to validate language recognition

Rail is a systems programming language focused on performance, low-level control, and minimal runtime, using direct syscalls and aggressive optimization.

## Checklist:

- [x] **I am adding a new language.**

- [x] I have included a real-world usage sample for all extensions added in this PR:
  - Sample source(s):
    - https://github.com/code-76/rail
  - Sample license(s):
    - Apache-2.0

- [x] I have added a color
  - Hex value: `#2D2D2D`
  - Rationale: Matches Rail branding (Code-76 visual identity)