### PR TITLE
Add .MODULE.bazel extension to Starlark

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7500,6 +7500,7 @@ Starlark:
   extensions:
   - ".bzl"
   - ".star"
+  - ".MODULE.bazel"
   filenames:
   - BUCK
   - BUILD

--- a/samples/Starlark/deb.MODULE.bazel
+++ b/samples/Starlark/deb.MODULE.bazel
@@ -1,0 +1,40 @@
+"debian dependencies"
+
+REPOS = [
+    "trixie",
+    "trixie_java",
+    "trixie_adoptium",
+    "trixie_python",
+    "bookworm",
+    "bookworm_python",
+]
+
+apt = use_extension("@rules_distroless//apt:extensions.bzl", "apt")
+
+[
+    apt.install(
+        name = repo,
+        lock = "//private/repos/deb:{}.lock.json".format(repo),
+        manifest = "//private/repos/deb:{}.yaml".format(repo),
+        ## merged usr fs is only enabled on debian13+, remove this line once we remove debian12 builds
+        mergedusr = repo.startswith("trixie"),
+        package_template = "//private/repos/deb:package.BUILD.tmpl",
+        resolve_transitive = False,
+    )
+    for repo in REPOS
+]
+
+use_repo(apt, "bookworm", "bookworm_python", "trixie", "trixie_adoptium", "trixie_java", "trixie_python")
+
+### VERSIONS HUB REPO ###
+version = use_extension("//private/extensions:version.bzl", "version")
+
+[
+    version.from_lock(
+        lock = "//private/repos/deb:{}.lock.json".format(repo),
+        repo_name = repo,
+    )
+    for repo in REPOS
+]
+
+use_repo(version, "versions")


### PR DESCRIPTION
## Description
Bazel, in some circumstances, supports splitting a `MODULE.bazel` file into [multiple `*.MODULE.bazel` files](https://bazel.build/external/faq#why-does-module-bazel-not-support-loads) with an `include()` directive.

## Checklist:
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.MODULE.bazel
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/GoogleContainerTools/distroless/blob/517026aa21cf5ce3a6e27f224cc93265070e3a75/private/repos/deb/deb.MODULE.bazel
    - Sample license(s):
      - [Apache-2.0](https://github.com/GoogleContainerTools/distroless/blob/517026aa21cf5ce3a6e27f224cc93265070e3a75/LICENSE)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
