### PR TITLE
Add SpiceDB Schema language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1166,6 +1166,9 @@
 [submodule "vendor/grammars/sourcepawn-vscode"]
 	path = vendor/grammars/sourcepawn-vscode
 	url = https://github.com/Sarrus1/sourcepawn-vscode.git
+[submodule "vendor/grammars/spicedb-vscode"]
+	path = vendor/grammars/spicedb-vscode
+	url = https://github.com/authzed/spicedb-vscode.git
 [submodule "vendor/grammars/sprocket-vscode"]
 	path = vendor/grammars/sprocket-vscode
 	url = https://github.com/stjude-rust-labs/sprocket-vscode.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1061,6 +1061,9 @@ vendor/grammars/sourcepawn-vscode:
 - sp-jsdoc.injection
 - text.valve-cfg
 - text.valve-kv
+vendor/grammars/spicedb-vscode:
+- source.cel
+- source.spicedb
 vendor/grammars/sprocket-vscode:
 - source.wdl
 vendor/grammars/sql.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7450,6 +7450,14 @@ SourcePawn:
   tm_scope: source.sourcepawn
   ace_mode: text
   language_id: 354
+SpiceDB Schema:
+  type: data
+  color: "#a5318a"
+  extensions:
+  - ".zed"
+  tm_scope: source.spicedb
+  ace_mode: text
+  language_id: 864005057
 Spline Font Database:
   type: data
   extensions:

--- a/samples/SpiceDB Schema/oviva.zed
+++ b/samples/SpiceDB Schema/oviva.zed
@@ -1,0 +1,404 @@
+/** user represents a user within our system, this is usually the subject when checking permissions */
+definition user {}
+
+/** platform represents an entire system deployment.
+ * There is exactly one platform per system deployment
+ */
+definition platform {
+	relation administrator: user
+
+	relation data_subject_request_administrator: user
+	relation content_administrator: user
+	relation document_category_administrator: user
+	relation tech_ops_administrator: user
+	relation clinical_case_report_administrator: user
+
+	permission data_subject_request_admin = data_subject_request_administrator
+	permission document_category_admin = document_category_administrator
+	permission clinical_case_report_admin = clinical_case_report_administrator + administrator
+}
+
+/** tenant represents a tenant within the permission graph.
+ * Our common roles have direct relationships to tenants and a lot of permissions
+ * are defined on the tenant level.
+ */
+definition tenant {
+	relation platform: platform
+
+	// DEPRECATED: the parent of the current tenant, allowing for inheritance of permissions
+	relation parent: tenant
+
+	// our common roles
+	relation administrator: user
+	relation coach: user
+	relation patient: user
+	relation agent: user
+
+	// write or read data from a patient's electronic health record (ehr)
+	relation ehr_writer: user
+
+	// hcs-gb roles
+	relation hcs_gb_administrator: user
+	relation hcs_gb_ppc: user
+	relation hcs_gb_case_creator: user
+
+	// pathway roles
+	relation pathway_administrator: user
+
+	// document admin
+	relation document_administrator: user
+
+	// hcs-de roles
+	relation hcs_de_administrator: user
+	relation hcs_de_supervisor: user
+
+	// hcs-ch roles
+	relation hcs_ch_administrator: user
+
+	// profit center roles
+	relation profit_center_administrator: user
+
+	// task admin
+	relation task_administrator: user
+
+	//--- permissions
+	permission write_ehr_local = ehr_writer
+	permission write_ehr = write_ehr_local + parent->write_ehr
+	permission read_ehr = write_ehr
+
+	permission administer_local = administrator
+	permission administer = administer_local + parent->administer
+
+	permission read_note_templates = coach + administer
+
+	permission platform_data_subject_request_admin = platform->data_subject_request_administrator
+
+	permission platform_tech_ops_admin = platform->tech_ops_administrator
+
+	// clinical pathways permissions
+	permission pathway_admin_local = pathway_administrator
+	permission pathway_admin = pathway_admin_local + parent->pathway_admin
+	permission create_pathway = pathway_admin
+	permission write_pathway = pathway_admin
+	permission read_pathway = pathway_admin
+	permission create_pathway_state = pathway_admin
+	permission write_pathway_state = pathway_admin
+	permission read_pathway_state = pathway_admin
+
+	permission administer_content = platform->content_administrator
+	permission read_articles = administer_content
+	permission create_article = administer_content
+
+	// profit center permissions
+	permission write_profit_center_local = profit_center_administrator
+	permission write_profit_center = write_profit_center_local + parent->write_profit_center
+
+	permission hcs_gb_case_administrator = hcs_gb_administrator
+	permission hcs_gb_case_editor = hcs_gb_ppc + hcs_gb_administrator
+	permission hcs_gb_create_case = hcs_gb_case_creator
+	permission hcs_gb_case_admin = hcs_gb_case_administrator
+	permission hcs_gb_case_admin_ppc = hcs_gb_case_editor
+	permission hcs_gb_tech_ops_admin = platform_tech_ops_admin
+	permission read_hcs_gb_contracts = hcs_gb_case_admin_ppc + coach
+	permission write_hcs_gb_contracts = hcs_gb_case_admin & write_profit_center
+	permission read_hcs_gb_programs = hcs_gb_case_admin_ppc + coach
+
+	// document permissions
+	permission platform_document_category_admin = platform->document_category_admin
+
+	permission document_administrator_local = document_administrator
+	permission document_admin = document_administrator_local + parent->document_admin
+
+	permission document_category_read_local = coach + administrator + document_administrator + platform_document_category_admin
+	permission document_category_read = document_category_read_local + parent->document_category_read
+
+	permission document_create_upload_url = coach + administer
+
+	// hcs-de permissions
+	permission hcs_de_case_administrator = hcs_de_administrator + hcs_de_supervisor
+	permission hcs_de_case_editor = hcs_de_case_administrator + coach
+	permission hcs_de_coach_employment_rate_admin = hcs_de_supervisor
+	permission hcs_de_programme_admin = hcs_de_supervisor
+	permission hcs_de_tech_ops_admin = platform_tech_ops_admin
+	permission hcs_de_coach_teams_admin = hcs_de_administrator + hcs_de_supervisor
+
+	// hcs-ch permissions
+	permission hcs_ch_case_administrator = hcs_ch_administrator
+	permission hcs_ch_case_editor = hcs_ch_case_administrator + coach
+	permission hcs_ch_insurance_reader = hcs_ch_case_administrator + coach
+	permission hcs_ch_health_care_professional_reader = hcs_ch_case_administrator + coach
+	permission hcs_ch_tech_ops_admin = platform_tech_ops_admin
+	permission hcs_ch_coach_teams_admin = hcs_ch_administrator
+
+	permission write_clinical_case_report_template = platform->clinical_case_report_admin
+	permission read_clinical_case_report_template = coach + write_clinical_case_report_template
+
+	//task permissions
+	permission create_task = task_administrator
+}
+
+/** coach represents the attributes of a user which is a coach */
+definition coach {
+	relation self: user
+	relation tenant: tenant
+
+	permission admin_write_document = (tenant->administer & tenant->document_admin & tenant->write_ehr)
+	permission admin_read_document = admin_write_document
+
+	permission write_document = self + admin_write_document
+	permission read_document = write_document
+
+	permission admin_create_document = admin_write_document
+	permission admin_list_documents = admin_read_document
+
+	permission create_document = write_document
+	permission list_documents = read_document
+
+	permission hcs_de_administer_employment_rate = tenant->hcs_de_coach_employment_rate_admin
+}
+
+/** agent represents the attributes of a user which is a agent */
+definition agent {
+	relation self: user
+	relation tenant: tenant
+}
+
+/** admin represents the attributes of a user which is a administrator */
+definition administrator {
+	relation self: user
+	relation tenant: tenant
+}
+
+/** patient represents the attributes of a user which is a patient */
+definition patient {
+	relation self: user
+	relation coacher: user
+	relation tenant: tenant
+	permission coach = coacher
+
+	// synthetic relations so we can refer to the tenants permissions further down
+	permission tenant_write_ehr = tenant->write_ehr
+	permission tenant_read_ehr = tenant->read_ehr
+	permission tenant_administer = tenant->administer
+	permission tenant_document_admin = tenant->document_admin
+	permission tenant_hcs_gb_case_administrator = tenant->hcs_gb_case_administrator
+	permission tenant_hcs_gb_case_editor = tenant->hcs_gb_case_editor
+	permission tenant_hcs_gb_create_case = tenant->hcs_gb_create_case
+	permission tenant_create_pathway_state = tenant->create_pathway_state
+	permission tenant_write_pathway_state = tenant->write_pathway_state
+	permission tenant_read_pathway_state = tenant->read_pathway_state
+	permission tenant_hcs_de_case_administrator = tenant->hcs_de_case_administrator
+	permission tenant_hcs_de_case_editor = tenant->hcs_de_case_editor
+	permission tenant_hcs_ch_case_administrator = tenant->hcs_ch_case_administrator
+	permission tenant_hcs_ch_case_editor = tenant->hcs_ch_case_editor
+	permission tenant_task_administrator = tenant->task_administrator
+
+	// document permissions
+	permission admin_write_document = (tenant_administer & tenant_document_admin & tenant_write_ehr)
+	permission admin_read_document = admin_write_document
+
+	permission write_document = (tenant_write_ehr & coacher) + admin_write_document
+	permission read_document = write_document
+
+	permission admin_list_documents = admin_read_document
+	permission admin_create_document = admin_write_document
+
+	permission create_document = write_document + admin_create_document
+	permission list_documents = read_document + admin_list_documents
+
+	// clinical pathways
+	permission read_pathway_states = coacher + tenant_read_pathway_state
+	permission write_pathway_states = coacher + tenant_write_pathway_state
+	permission create_pathway_states = tenant_create_pathway_state
+
+	// data subject request permissions
+	permission data_subject_request_create = self + tenant->platform_data_subject_request_admin
+	permission tenant_data_subject_request_admin = tenant->platform_data_subject_request_admin
+
+	permission read_hcs_gb_cases = tenant_hcs_gb_case_editor + coacher
+	permission create_hcs_gb_case = tenant_hcs_gb_case_editor + coacher + tenant_hcs_gb_create_case
+
+	// hcs-de permissions
+	permission read_hcs_de_cases = tenant_hcs_de_case_administrator + tenant_hcs_de_case_editor + coacher
+	permission create_hcs_de_case = tenant_hcs_de_case_administrator + tenant_hcs_de_case_editor + coacher
+
+	// hcs-ch permissions
+	permission read_hcs_ch_cases = tenant_hcs_ch_case_administrator + tenant_hcs_ch_case_editor + coacher
+	permission create_hcs_ch_case = tenant_hcs_ch_case_administrator + tenant_hcs_ch_case_editor + coacher
+
+	// task permissions
+	permission create_task = tenant_task_administrator + coacher
+
+	// marketing cloud data
+	permission read_marketing_cloud_data = tenant_hcs_ch_case_administrator + tenant_hcs_de_case_administrator + tenant_hcs_gb_case_editor
+
+	// devices permissions
+	permission write_device = (tenant_administer & tenant_write_ehr) + coacher
+	permission list_devices = (tenant_administer & tenant_read_ehr) + coacher
+}
+
+/** electronic_health_record (ehr for short) represents the record of medical data of a patient.
+* It contains attributes such as `diagnosis`, `date_of_birth`. Furthermore there are a lot
+* of related entities which are considered part of an electronic_health_record.
+*/
+definition electronic_health_record {
+	relation owner: patient
+
+	permission write = (owner->tenant_write_ehr & owner->coach) + (owner->tenant_write_ehr & owner->tenant_administer)
+	permission read = (owner->tenant_read_ehr & owner->coach) + (owner->tenant_read_ehr & owner->tenant_administer) + write
+
+	permission create_patient_note = write
+	permission read_patient_notes = read
+
+	permission create_clinical_case_report = write
+	permission list_clinical_case_report = read
+}
+
+/** patient_note represents a structured note which is part of a patients electronic health record */
+definition patient_note {
+	relation author: user
+	relation ehr: electronic_health_record
+
+	permission write = ehr->write + author
+	permission read = write + ehr->read
+}
+
+/**
+ * data_subject_request represents the request raised by the patient/admin to act on patient data.
+ * For example, It may be a request to ERASE the patient data.
+ */
+definition data_subject_request {
+	relation owner: patient
+
+	permission write = owner->tenant_data_subject_request_admin + owner->self
+	permission read = write
+}
+
+/**
+ * article represents a piece of content known to the content-engine
+ */
+definition article {
+	relation tenant: tenant
+
+	permission write = tenant->administer_content
+	permission read = write
+}
+
+
+/**
+ * hcs_gb_case represents a hcs gb case relating to a patient
+ */
+definition hcs_gb_case {
+	relation owner: patient
+
+	permission owner_coacher = owner->coacher
+	permission owner_tenant_hcs_gb_case_administrator = owner->tenant_hcs_gb_case_administrator
+
+	permission write = owner->tenant_hcs_gb_case_editor + owner_coacher
+	permission read = write
+	permission administer = owner_tenant_hcs_gb_case_administrator
+}
+
+/**
+ * pathway represents a clinical pathway
+ */
+definition pathway {
+	relation tenant: tenant
+
+	permission write = tenant->write_pathway + tenant->create_pathway
+	permission read = write + tenant->read_pathway
+}
+
+/**
+ * pathway_state represents the state of a clinical pathway
+ */
+definition pathway_state {
+	relation owner: patient
+
+	permission write = owner->write_pathway_states
+	permission read = write + owner->read_pathway_states
+}
+
+/** document represents a document known to the document-service */
+definition document {
+	relation owner: coach | patient
+
+	permission admin_only_write = owner->admin_write_document
+	permission admin_only_read = admin_only_write
+
+	permission write = owner->write_document
+	permission read = write
+}
+
+/**
+ * hcs_de_case represents a hcs de case relating to a patient
+ */
+definition hcs_de_p43_case {
+	relation owner: patient
+
+	permission owner_coacher = owner->coacher
+	permission owner_tenant_hcs_de_case_administrator = owner->tenant_hcs_de_case_administrator
+	permission owner_tenant_hcs_de_case_editor = owner->tenant_hcs_de_case_editor
+
+	permission write = owner_tenant_hcs_de_case_editor + owner_coacher
+	permission read = write
+	permission administer = owner_tenant_hcs_de_case_administrator
+}
+
+definition hcs_de_p20_case {
+	relation owner: patient
+
+	permission owner_coacher = owner->coacher
+	permission owner_tenant_hcs_de_case_administrator = owner->tenant_hcs_de_case_administrator
+	permission owner_tenant_hcs_de_case_editor = owner->tenant_hcs_de_case_editor
+
+	permission write = owner_tenant_hcs_de_case_editor + owner_coacher
+	permission read = write
+	permission administer = owner_tenant_hcs_de_case_administrator
+}
+
+/**
+ * hcs_ch_case represents a hcs ch case relating to a patient
+ */
+definition hcs_ch_case {
+	relation owner: patient
+
+	permission owner_coacher = owner->coacher
+	permission owner_tenant_hcs_ch_case_administrator = owner->tenant_hcs_ch_case_administrator
+	permission owner_tenant_hcs_ch_case_editor = owner->tenant_hcs_ch_case_editor
+
+	permission write = owner_tenant_hcs_ch_case_editor + owner_coacher
+	permission read = write
+	permission administer = owner_tenant_hcs_ch_case_administrator
+}
+
+definition clinical_case_report {
+	relation ehr: electronic_health_record
+
+	permission write = ehr->write
+	permission read = write + ehr->read
+}
+
+definition clinical_case_report_template {
+	relation tenant: tenant
+
+	permission write = tenant->write_clinical_case_report_template
+	permission read = tenant->read_clinical_case_report_template
+}
+
+definition task {
+	relation owner: patient
+
+	permission write = owner->tenant_task_administrator + owner->coacher
+	permission read = write
+
+	permission write_comments = owner->tenant_task_administrator + owner->coacher
+	permission read_comments = write_comments
+}
+
+definition analysis {
+	relation owner: electronic_health_record
+
+	permission read = owner->read
+
+}

--- a/samples/SpiceDB Schema/schema.zed
+++ b/samples/SpiceDB Schema/schema.zed
@@ -1,0 +1,482 @@
+definition hbi/host {
+	permission update = t_workspace->inventory_host_update
+	permission view = t_workspace->inventory_host_view
+	permission workspace = t_workspace
+	relation t_workspace: rbac/workspace
+}
+
+definition notifications/integration {
+	permission delete = t_workspace->notifications_integration_delete
+	permission disable = t_workspace->notifications_integration_disable
+	permission edit = t_workspace->notifications_integration_edit
+	permission enable = t_workspace->notifications_integration_enable
+	permission test = t_workspace->notifications_integration_test
+	permission view = t_workspace->notifications_integration_view
+	permission view_history = t_workspace->notifications_integration_view_history
+	permission workspace = t_workspace
+	relation t_workspace: rbac/workspace
+}
+
+definition rbac/group {
+	permission member = t_member
+	relation t_member: rbac/principal | rbac/group#member
+	permission owner = t_owner
+	relation t_owner: rbac/tenant
+}
+
+definition rbac/platform {
+	permission binding = t_binding
+	relation t_binding: rbac/role_binding
+	permission inventory_host_update = t_binding->inventory_host_update
+	permission inventory_host_view = t_binding->inventory_host_view
+	permission notifications_applications_view = t_binding->notifications_applications_view
+	permission notifications_behavior_groups_edit = t_binding->notifications_behavior_groups_edit
+	permission notifications_behavior_groups_view = t_binding->notifications_behavior_groups_view
+	permission notifications_bundles_view = t_binding->notifications_bundles_view
+	permission notifications_daily_digest_preference_edit = t_binding->notifications_daily_digest_preference_edit
+	permission notifications_daily_digest_preference_view = t_binding->notifications_daily_digest_preference_view
+	permission notifications_event_log_view = t_binding->notifications_event_log_view
+	permission notifications_event_types_view = t_binding->notifications_event_types_view
+	permission notifications_integration_create = t_binding->notifications_integration_create
+	permission notifications_integration_delete = t_binding->notifications_integration_delete
+	permission notifications_integration_disable = t_binding->notifications_integration_disable
+	permission notifications_integration_edit = t_binding->notifications_integration_edit
+	permission notifications_integration_enable = t_binding->notifications_integration_enable
+	permission notifications_integration_subscribe_drawer = t_binding->notifications_integration_subscribe_drawer
+	permission notifications_integration_subscribe_email = t_binding->notifications_integration_subscribe_email
+	permission notifications_integration_test = t_binding->notifications_integration_test
+	permission notifications_integration_view = t_binding->notifications_integration_view
+	permission notifications_integration_view_history = t_binding->notifications_integration_view_history
+}
+
+definition rbac/principal {}
+
+definition rbac/role {
+	permission advisor_all_all = t_advisor_all_all
+	relation t_advisor_all_all: rbac/principal:*
+	permission advisor_all_read = t_advisor_all_read
+	relation t_advisor_all_read: rbac/principal:*
+	permission advisor_disable_recommendations_write = t_advisor_disable_recommendations_write
+	relation t_advisor_disable_recommendations_write: rbac/principal:*
+	permission advisor_exports_read = t_advisor_exports_read
+	relation t_advisor_exports_read: rbac/principal:*
+	permission advisor_recommendation_results_read = t_advisor_recommendation_results_read
+	relation t_advisor_recommendation_results_read: rbac/principal:*
+	permission advisor_weekly_email_read = t_advisor_weekly_email_read
+	relation t_advisor_weekly_email_read: rbac/principal:*
+	permission all_all_all = t_all_all_all
+	relation t_all_all_all: rbac/principal:*
+	permission ansible_wisdom_admin_dashboard_chart_active_users_read = t_ansible_wisdom_admin_dashboard_chart_active_users_read
+	relation t_ansible_wisdom_admin_dashboard_chart_active_users_read: rbac/principal:*
+	permission ansible_wisdom_admin_dashboard_chart_module_usage_read = t_ansible_wisdom_admin_dashboard_chart_module_usage_read
+	relation t_ansible_wisdom_admin_dashboard_chart_module_usage_read: rbac/principal:*
+	permission ansible_wisdom_admin_dashboard_chart_recommendations_read = t_ansible_wisdom_admin_dashboard_chart_recommendations_read
+	relation t_ansible_wisdom_admin_dashboard_chart_recommendations_read: rbac/principal:*
+	permission ansible_wisdom_admin_dashboard_chart_user_sentiment_read = t_ansible_wisdom_admin_dashboard_chart_user_sentiment_read
+	relation t_ansible_wisdom_admin_dashboard_chart_user_sentiment_read: rbac/principal:*
+	permission automation_analytics_all_all = t_automation_analytics_all_all
+	relation t_automation_analytics_all_all: rbac/principal:*
+	permission automation_analytics_all_read = t_automation_analytics_all_read
+	relation t_automation_analytics_all_read: rbac/principal:*
+	permission automation_analytics_all_write = t_automation_analytics_all_write
+	relation t_automation_analytics_all_write: rbac/principal:*
+	permission child = t_child
+	relation t_child: rbac/role
+	permission compliance_all_all = t_compliance_all_all
+	relation t_compliance_all_all: rbac/principal:*
+	permission compliance_policy_create = t_compliance_policy_create
+	relation t_compliance_policy_create: rbac/principal:*
+	permission compliance_policy_delete = t_compliance_policy_delete
+	relation t_compliance_policy_delete: rbac/principal:*
+	permission compliance_policy_read = t_compliance_policy_read
+	relation t_compliance_policy_read: rbac/principal:*
+	permission compliance_policy_update = t_compliance_policy_update
+	relation t_compliance_policy_update: rbac/principal:*
+	permission compliance_policy_write = t_compliance_policy_write
+	relation t_compliance_policy_write: rbac/principal:*
+	permission compliance_report_delete = t_compliance_report_delete
+	relation t_compliance_report_delete: rbac/principal:*
+	permission compliance_report_read = t_compliance_report_read
+	relation t_compliance_report_read: rbac/principal:*
+	permission compliance_system_read = t_compliance_system_read
+	relation t_compliance_system_read: rbac/principal:*
+	permission config_manager_activation_keys_all = t_config_manager_activation_keys_all
+	relation t_config_manager_activation_keys_all: rbac/principal:*
+	permission config_manager_activation_keys_read = t_config_manager_activation_keys_read
+	relation t_config_manager_activation_keys_read: rbac/principal:*
+	permission config_manager_activation_keys_write = t_config_manager_activation_keys_write
+	relation t_config_manager_activation_keys_write: rbac/principal:*
+	permission config_manager_state_changes_read = t_config_manager_state_changes_read
+	relation t_config_manager_state_changes_read: rbac/principal:*
+	permission config_manager_state_read = t_config_manager_state_read
+	relation t_config_manager_state_read: rbac/principal:*
+	permission config_manager_state_write = t_config_manager_state_write
+	relation t_config_manager_state_write: rbac/principal:*
+	permission content_sources_all_all = t_content_sources_all_all
+	relation t_content_sources_all_all: rbac/principal:*
+	permission content_sources_repositories_read = t_content_sources_repositories_read
+	relation t_content_sources_repositories_read: rbac/principal:*
+	permission content_sources_repositories_upload = t_content_sources_repositories_upload
+	relation t_content_sources_repositories_upload: rbac/principal:*
+	permission content_sources_repositories_write = t_content_sources_repositories_write
+	relation t_content_sources_repositories_write: rbac/principal:*
+	permission content_sources_templates_read = t_content_sources_templates_read
+	relation t_content_sources_templates_read: rbac/principal:*
+	permission content_sources_templates_write = t_content_sources_templates_write
+	relation t_content_sources_templates_write: rbac/principal:*
+	permission cost_management_all_all = t_cost_management_all_all
+	relation t_cost_management_all_all: rbac/principal:*
+	permission cost_management_aws_account_all = t_cost_management_aws_account_all
+	relation t_cost_management_aws_account_all: rbac/principal:*
+	permission cost_management_aws_account_read = t_cost_management_aws_account_read
+	relation t_cost_management_aws_account_read: rbac/principal:*
+	permission cost_management_aws_organizational_unit_all = t_cost_management_aws_organizational_unit_all
+	relation t_cost_management_aws_organizational_unit_all: rbac/principal:*
+	permission cost_management_aws_organizational_unit_read = t_cost_management_aws_organizational_unit_read
+	relation t_cost_management_aws_organizational_unit_read: rbac/principal:*
+	permission cost_management_azure_subscription_guid_all = t_cost_management_azure_subscription_guid_all
+	relation t_cost_management_azure_subscription_guid_all: rbac/principal:*
+	permission cost_management_azure_subscription_guid_read = t_cost_management_azure_subscription_guid_read
+	relation t_cost_management_azure_subscription_guid_read: rbac/principal:*
+	permission cost_management_cost_model_all = t_cost_management_cost_model_all
+	relation t_cost_management_cost_model_all: rbac/principal:*
+	permission cost_management_cost_model_read = t_cost_management_cost_model_read
+	relation t_cost_management_cost_model_read: rbac/principal:*
+	permission cost_management_cost_model_write = t_cost_management_cost_model_write
+	relation t_cost_management_cost_model_write: rbac/principal:*
+	permission cost_management_gcp_account_all = t_cost_management_gcp_account_all
+	relation t_cost_management_gcp_account_all: rbac/principal:*
+	permission cost_management_gcp_account_read = t_cost_management_gcp_account_read
+	relation t_cost_management_gcp_account_read: rbac/principal:*
+	permission cost_management_gcp_project_all = t_cost_management_gcp_project_all
+	relation t_cost_management_gcp_project_all: rbac/principal:*
+	permission cost_management_gcp_project_read = t_cost_management_gcp_project_read
+	relation t_cost_management_gcp_project_read: rbac/principal:*
+	permission cost_management_oci_payer_tenant_id_all = t_cost_management_oci_payer_tenant_id_all
+	relation t_cost_management_oci_payer_tenant_id_all: rbac/principal:*
+	permission cost_management_oci_payer_tenant_id_read = t_cost_management_oci_payer_tenant_id_read
+	relation t_cost_management_oci_payer_tenant_id_read: rbac/principal:*
+	permission cost_management_openshift_cluster_all = t_cost_management_openshift_cluster_all
+	relation t_cost_management_openshift_cluster_all: rbac/principal:*
+	permission cost_management_openshift_cluster_read = t_cost_management_openshift_cluster_read
+	relation t_cost_management_openshift_cluster_read: rbac/principal:*
+	permission cost_management_openshift_node_all = t_cost_management_openshift_node_all
+	relation t_cost_management_openshift_node_all: rbac/principal:*
+	permission cost_management_openshift_node_read = t_cost_management_openshift_node_read
+	relation t_cost_management_openshift_node_read: rbac/principal:*
+	permission cost_management_openshift_project_all = t_cost_management_openshift_project_all
+	relation t_cost_management_openshift_project_all: rbac/principal:*
+	permission cost_management_openshift_project_read = t_cost_management_openshift_project_read
+	relation t_cost_management_openshift_project_read: rbac/principal:*
+	permission cost_management_settings_all = t_cost_management_settings_all
+	relation t_cost_management_settings_all: rbac/principal:*
+	permission cost_management_settings_read = t_cost_management_settings_read
+	relation t_cost_management_settings_read: rbac/principal:*
+	permission cost_management_settings_write = t_cost_management_settings_write
+	relation t_cost_management_settings_write: rbac/principal:*
+	permission hybrid_committed_spend_reports_read = t_hybrid_committed_spend_reports_read
+	relation t_hybrid_committed_spend_reports_read: rbac/principal:*
+	permission idmsvc_all_all = t_idmsvc_all_all
+	relation t_idmsvc_all_all: rbac/principal:*
+	permission idmsvc_domains_create = t_idmsvc_domains_create
+	relation t_idmsvc_domains_create: rbac/principal:*
+	permission idmsvc_domains_delete = t_idmsvc_domains_delete
+	relation t_idmsvc_domains_delete: rbac/principal:*
+	permission idmsvc_domains_list = t_idmsvc_domains_list
+	relation t_idmsvc_domains_list: rbac/principal:*
+	permission idmsvc_domains_read = t_idmsvc_domains_read
+	relation t_idmsvc_domains_read: rbac/principal:*
+	permission idmsvc_domains_update = t_idmsvc_domains_update
+	relation t_idmsvc_domains_update: rbac/principal:*
+	permission idmsvc_token_create = t_idmsvc_token_create
+	relation t_idmsvc_token_create: rbac/principal:*
+	permission integrations_all_all = t_integrations_all_all
+	relation t_integrations_all_all: rbac/principal:*
+	permission integrations_all_read = t_integrations_all_read
+	relation t_integrations_all_read: rbac/principal:*
+	permission integrations_all_write = t_integrations_all_write
+	relation t_integrations_all_write: rbac/principal:*
+	permission integrations_endpoints_all = t_integrations_endpoints_all
+	relation t_integrations_endpoints_all: rbac/principal:*
+	permission integrations_endpoints_read = t_integrations_endpoints_read
+	relation t_integrations_endpoints_read: rbac/principal:*
+	permission integrations_endpoints_write = t_integrations_endpoints_write
+	relation t_integrations_endpoints_write: rbac/principal:*
+	permission inventory_all_all = t_inventory_all_all
+	relation t_inventory_all_all: rbac/principal:*
+	permission inventory_all_read = t_inventory_all_read
+	relation t_inventory_all_read: rbac/principal:*
+	permission inventory_all_write = t_inventory_all_write
+	relation t_inventory_all_write: rbac/principal:*
+	permission inventory_groups_all = t_inventory_groups_all
+	relation t_inventory_groups_all: rbac/principal:*
+	permission inventory_groups_read = t_inventory_groups_read
+	relation t_inventory_groups_read: rbac/principal:*
+	permission inventory_groups_write = t_inventory_groups_write
+	relation t_inventory_groups_write: rbac/principal:*
+	permission inventory_host_update = inventory_hosts_write + inventory_hosts_all + inventory_all_write + inventory_all_all + all_all_all + t_child->inventory_host_update
+	permission inventory_host_view = inventory_hosts_read + inventory_hosts_all + inventory_all_read + inventory_all_all + all_all_all + t_child->inventory_host_view
+	permission inventory_hosts_all = t_inventory_hosts_all
+	relation t_inventory_hosts_all: rbac/principal:*
+	permission inventory_hosts_read = t_inventory_hosts_read
+	relation t_inventory_hosts_read: rbac/principal:*
+	permission inventory_hosts_write = t_inventory_hosts_write
+	relation t_inventory_hosts_write: rbac/principal:*
+	permission malware_detection_acknowledgements_write = t_malware_detection_acknowledgements_write
+	relation t_malware_detection_acknowledgements_write: rbac/principal:*
+	permission malware_detection_all_all = t_malware_detection_all_all
+	relation t_malware_detection_all_all: rbac/principal:*
+	permission malware_detection_all_read = t_malware_detection_all_read
+	relation t_malware_detection_all_read: rbac/principal:*
+	permission notifications_all_all = t_notifications_all_all
+	relation t_notifications_all_all: rbac/principal:*
+	permission notifications_all_read = t_notifications_all_read
+	relation t_notifications_all_read: rbac/principal:*
+	permission notifications_all_write = t_notifications_all_write
+	relation t_notifications_all_write: rbac/principal:*
+	permission notifications_applications_view = notifications_notifications_read + notifications_notifications_all + notifications_all_read + notifications_all_all + all_all_all + t_child->notifications_applications_view
+	permission notifications_behavior_groups_edit = notifications_notifications_write + notifications_notifications_all + notifications_all_write + notifications_all_all + all_all_all + t_child->notifications_behavior_groups_edit
+	permission notifications_behavior_groups_view = notifications_notifications_read + notifications_notifications_all + notifications_all_read + notifications_all_all + all_all_all + t_child->notifications_behavior_groups_view
+	permission notifications_bundles_view = notifications_notifications_read + notifications_notifications_all + notifications_all_read + notifications_all_all + all_all_all + t_child->notifications_bundles_view
+	permission notifications_daily_digest_preference_edit = notifications_notifications_write + notifications_notifications_all + notifications_all_write + notifications_all_all + all_all_all + t_child->notifications_daily_digest_preference_edit
+	permission notifications_daily_digest_preference_view = notifications_notifications_read + notifications_notifications_all + notifications_all_read + notifications_all_all + all_all_all + t_child->notifications_daily_digest_preference_view
+	permission notifications_event_log_view = notifications_events_read + notifications_events_all + notifications_all_read + notifications_all_all + all_all_all + t_child->notifications_event_log_view
+	permission notifications_event_types_view = notifications_notifications_read + notifications_notifications_all + notifications_all_read + notifications_all_all + all_all_all + t_child->notifications_event_types_view
+	permission notifications_events_all = t_notifications_events_all
+	relation t_notifications_events_all: rbac/principal:*
+	permission notifications_events_read = t_notifications_events_read
+	relation t_notifications_events_read: rbac/principal:*
+	permission notifications_integration_create = integrations_endpoints_write + integrations_endpoints_all + integrations_all_write + integrations_all_all + all_all_all + t_child->notifications_integration_create
+	permission notifications_integration_delete = integrations_endpoints_write + integrations_endpoints_all + integrations_all_write + integrations_all_all + all_all_all + t_child->notifications_integration_delete
+	permission notifications_integration_disable = integrations_endpoints_write + integrations_endpoints_all + integrations_all_write + integrations_all_all + all_all_all + t_child->notifications_integration_disable
+	permission notifications_integration_edit = integrations_endpoints_write + integrations_endpoints_all + integrations_all_write + integrations_all_all + all_all_all + t_child->notifications_integration_edit
+	permission notifications_integration_enable = integrations_endpoints_write + integrations_endpoints_all + integrations_all_write + integrations_all_all + all_all_all + t_child->notifications_integration_enable
+	permission notifications_integration_subscribe_drawer = integrations_endpoints_read + integrations_endpoints_all + integrations_all_read + integrations_all_all + all_all_all + t_child->notifications_integration_subscribe_drawer
+	permission notifications_integration_subscribe_email = integrations_endpoints_read + integrations_endpoints_all + integrations_all_read + integrations_all_all + all_all_all + t_child->notifications_integration_subscribe_email
+	permission notifications_integration_test = integrations_endpoints_write + integrations_endpoints_all + integrations_all_write + integrations_all_all + all_all_all + t_child->notifications_integration_test
+	permission notifications_integration_view = integrations_endpoints_read + integrations_endpoints_all + integrations_all_read + integrations_all_all + all_all_all + t_child->notifications_integration_view
+	permission notifications_integration_view_history = integrations_endpoints_read + integrations_endpoints_all + integrations_all_read + integrations_all_all + all_all_all + t_child->notifications_integration_view_history
+	permission notifications_notifications_all = t_notifications_notifications_all
+	relation t_notifications_notifications_all: rbac/principal:*
+	permission notifications_notifications_read = t_notifications_notifications_read
+	relation t_notifications_notifications_read: rbac/principal:*
+	permission notifications_notifications_write = t_notifications_notifications_write
+	relation t_notifications_notifications_write: rbac/principal:*
+	permission ocp_advisor_all_all = t_ocp_advisor_all_all
+	relation t_ocp_advisor_all_all: rbac/principal:*
+	permission ocp_advisor_exports_read = t_ocp_advisor_exports_read
+	relation t_ocp_advisor_exports_read: rbac/principal:*
+	permission ocp_advisor_recommendation_results_read = t_ocp_advisor_recommendation_results_read
+	relation t_ocp_advisor_recommendation_results_read: rbac/principal:*
+	permission ocp_advisor_toggle_recommendations_write = t_ocp_advisor_toggle_recommendations_write
+	relation t_ocp_advisor_toggle_recommendations_write: rbac/principal:*
+	permission patch_all_all = t_patch_all_all
+	relation t_patch_all_all: rbac/principal:*
+	permission patch_all_read = t_patch_all_read
+	relation t_patch_all_read: rbac/principal:*
+	permission patch_all_write = t_patch_all_write
+	relation t_patch_all_write: rbac/principal:*
+	permission patch_system_write = t_patch_system_write
+	relation t_patch_system_write: rbac/principal:*
+	permission patch_template_write = t_patch_template_write
+	relation t_patch_template_write: rbac/principal:*
+	permission playbook_dispatcher_run_read = t_playbook_dispatcher_run_read
+	relation t_playbook_dispatcher_run_read: rbac/principal:*
+	permission playbook_dispatcher_run_write = t_playbook_dispatcher_run_write
+	relation t_playbook_dispatcher_run_write: rbac/principal:*
+	permission policies_all_all = t_policies_all_all
+	relation t_policies_all_all: rbac/principal:*
+	permission policies_policies_read = t_policies_policies_read
+	relation t_policies_policies_read: rbac/principal:*
+	permission policies_policies_write = t_policies_policies_write
+	relation t_policies_policies_write: rbac/principal:*
+	permission provisioning_all_all = t_provisioning_all_all
+	relation t_provisioning_all_all: rbac/principal:*
+	permission provisioning_pubkey_all = t_provisioning_pubkey_all
+	relation t_provisioning_pubkey_all: rbac/principal:*
+	permission provisioning_pubkey_read = t_provisioning_pubkey_read
+	relation t_provisioning_pubkey_read: rbac/principal:*
+	permission provisioning_pubkey_write = t_provisioning_pubkey_write
+	relation t_provisioning_pubkey_write: rbac/principal:*
+	permission provisioning_reservation_all = t_provisioning_reservation_all
+	relation t_provisioning_reservation_all: rbac/principal:*
+	permission provisioning_reservation_aws_all = t_provisioning_reservation_aws_all
+	relation t_provisioning_reservation_aws_all: rbac/principal:*
+	permission provisioning_reservation_aws_read = t_provisioning_reservation_aws_read
+	relation t_provisioning_reservation_aws_read: rbac/principal:*
+	permission provisioning_reservation_aws_write = t_provisioning_reservation_aws_write
+	relation t_provisioning_reservation_aws_write: rbac/principal:*
+	permission provisioning_reservation_azure_all = t_provisioning_reservation_azure_all
+	relation t_provisioning_reservation_azure_all: rbac/principal:*
+	permission provisioning_reservation_azure_read = t_provisioning_reservation_azure_read
+	relation t_provisioning_reservation_azure_read: rbac/principal:*
+	permission provisioning_reservation_azure_write = t_provisioning_reservation_azure_write
+	relation t_provisioning_reservation_azure_write: rbac/principal:*
+	permission provisioning_reservation_gcp_all = t_provisioning_reservation_gcp_all
+	relation t_provisioning_reservation_gcp_all: rbac/principal:*
+	permission provisioning_reservation_gcp_read = t_provisioning_reservation_gcp_read
+	relation t_provisioning_reservation_gcp_read: rbac/principal:*
+	permission provisioning_reservation_gcp_write = t_provisioning_reservation_gcp_write
+	relation t_provisioning_reservation_gcp_write: rbac/principal:*
+	permission provisioning_reservation_read = t_provisioning_reservation_read
+	relation t_provisioning_reservation_read: rbac/principal:*
+	permission provisioning_reservation_write = t_provisioning_reservation_write
+	relation t_provisioning_reservation_write: rbac/principal:*
+	permission provisioning_source_all = t_provisioning_source_all
+	relation t_provisioning_source_all: rbac/principal:*
+	permission provisioning_source_read = t_provisioning_source_read
+	relation t_provisioning_source_read: rbac/principal:*
+	permission rbac_all_all = t_rbac_all_all
+	relation t_rbac_all_all: rbac/principal:*
+	permission rbac_principal_read = t_rbac_principal_read
+	relation t_rbac_principal_read: rbac/principal:*
+	permission remediations_all_all = t_remediations_all_all
+	relation t_remediations_all_all: rbac/principal:*
+	permission remediations_all_read = t_remediations_all_read
+	relation t_remediations_all_read: rbac/principal:*
+	permission remediations_all_write = t_remediations_all_write
+	relation t_remediations_all_write: rbac/principal:*
+	permission remediations_remediation_execute = t_remediations_remediation_execute
+	relation t_remediations_remediation_execute: rbac/principal:*
+	permission remediations_remediation_read = t_remediations_remediation_read
+	relation t_remediations_remediation_read: rbac/principal:*
+	permission remediations_remediation_write = t_remediations_remediation_write
+	relation t_remediations_remediation_write: rbac/principal:*
+	permission ros_all_all = t_ros_all_all
+	relation t_ros_all_all: rbac/principal:*
+	permission ros_all_read = t_ros_all_read
+	relation t_ros_all_read: rbac/principal:*
+	permission sources_all_all = t_sources_all_all
+	relation t_sources_all_all: rbac/principal:*
+	permission staleness_staleness_all = t_staleness_staleness_all
+	relation t_staleness_staleness_all: rbac/principal:*
+	permission staleness_staleness_read = t_staleness_staleness_read
+	relation t_staleness_staleness_read: rbac/principal:*
+	permission staleness_staleness_write = t_staleness_staleness_write
+	relation t_staleness_staleness_write: rbac/principal:*
+	permission subscriptions_all_all = t_subscriptions_all_all
+	relation t_subscriptions_all_all: rbac/principal:*
+	permission subscriptions_cloud_access_read = t_subscriptions_cloud_access_read
+	relation t_subscriptions_cloud_access_read: rbac/principal:*
+	permission subscriptions_cloud_access_write = t_subscriptions_cloud_access_write
+	relation t_subscriptions_cloud_access_write: rbac/principal:*
+	permission subscriptions_manifests_read = t_subscriptions_manifests_read
+	relation t_subscriptions_manifests_read: rbac/principal:*
+	permission subscriptions_manifests_write = t_subscriptions_manifests_write
+	relation t_subscriptions_manifests_write: rbac/principal:*
+	permission subscriptions_organization_read = t_subscriptions_organization_read
+	relation t_subscriptions_organization_read: rbac/principal:*
+	permission subscriptions_organization_write = t_subscriptions_organization_write
+	relation t_subscriptions_organization_write: rbac/principal:*
+	permission subscriptions_products_read = t_subscriptions_products_read
+	relation t_subscriptions_products_read: rbac/principal:*
+	permission subscriptions_products_write = t_subscriptions_products_write
+	relation t_subscriptions_products_write: rbac/principal:*
+	permission subscriptions_reports_read = t_subscriptions_reports_read
+	relation t_subscriptions_reports_read: rbac/principal:*
+	permission tasks_all_all = t_tasks_all_all
+	relation t_tasks_all_all: rbac/principal:*
+	permission vulnerability_advanced_report_read = t_vulnerability_advanced_report_read
+	relation t_vulnerability_advanced_report_read: rbac/principal:*
+	permission vulnerability_all_all = t_vulnerability_all_all
+	relation t_vulnerability_all_all: rbac/principal:*
+	permission vulnerability_all_read = t_vulnerability_all_read
+	relation t_vulnerability_all_read: rbac/principal:*
+	permission vulnerability_all_write = t_vulnerability_all_write
+	relation t_vulnerability_all_write: rbac/principal:*
+	permission vulnerability_cve_business_risk_and_status_write = t_vulnerability_cve_business_risk_and_status_write
+	relation t_vulnerability_cve_business_risk_and_status_write: rbac/principal:*
+	permission vulnerability_report_and_export_read = t_vulnerability_report_and_export_read
+	relation t_vulnerability_report_and_export_read: rbac/principal:*
+	permission vulnerability_system_cve_status_write = t_vulnerability_system_cve_status_write
+	relation t_vulnerability_system_cve_status_write: rbac/principal:*
+	permission vulnerability_system_opt_out_read = t_vulnerability_system_opt_out_read
+	relation t_vulnerability_system_opt_out_read: rbac/principal:*
+	permission vulnerability_system_opt_out_write = t_vulnerability_system_opt_out_write
+	relation t_vulnerability_system_opt_out_write: rbac/principal:*
+	permission vulnerability_toggle_cves_without_errata_write = t_vulnerability_toggle_cves_without_errata_write
+	relation t_vulnerability_toggle_cves_without_errata_write: rbac/principal:*
+	permission vulnerability_vulnerability_results_read = t_vulnerability_vulnerability_results_read
+	relation t_vulnerability_vulnerability_results_read: rbac/principal:*
+}
+
+definition rbac/role_binding {
+	permission inventory_host_update = (subject & t_role->inventory_host_update)
+	permission inventory_host_view = (subject & t_role->inventory_host_view)
+	permission notifications_applications_view = (subject & t_role->notifications_applications_view)
+	permission notifications_behavior_groups_edit = (subject & t_role->notifications_behavior_groups_edit)
+	permission notifications_behavior_groups_view = (subject & t_role->notifications_behavior_groups_view)
+	permission notifications_bundles_view = (subject & t_role->notifications_bundles_view)
+	permission notifications_daily_digest_preference_edit = (subject & t_role->notifications_daily_digest_preference_edit)
+	permission notifications_daily_digest_preference_view = (subject & t_role->notifications_daily_digest_preference_view)
+	permission notifications_event_log_view = (subject & t_role->notifications_event_log_view)
+	permission notifications_event_types_view = (subject & t_role->notifications_event_types_view)
+	permission notifications_integration_create = (subject & t_role->notifications_integration_create)
+	permission notifications_integration_delete = (subject & t_role->notifications_integration_delete)
+	permission notifications_integration_disable = (subject & t_role->notifications_integration_disable)
+	permission notifications_integration_edit = (subject & t_role->notifications_integration_edit)
+	permission notifications_integration_enable = (subject & t_role->notifications_integration_enable)
+	permission notifications_integration_subscribe_drawer = (subject & t_role->notifications_integration_subscribe_drawer)
+	permission notifications_integration_subscribe_email = (subject & t_role->notifications_integration_subscribe_email)
+	permission notifications_integration_test = (subject & t_role->notifications_integration_test)
+	permission notifications_integration_view = (subject & t_role->notifications_integration_view)
+	permission notifications_integration_view_history = (subject & t_role->notifications_integration_view_history)
+	permission role = t_role
+	relation t_role: rbac/role
+	permission subject = t_subject
+	relation t_subject: rbac/principal | rbac/group#member
+}
+
+definition rbac/tenant {
+	permission binding = t_binding
+	relation t_binding: rbac/role_binding
+	permission inventory_host_update = t_binding->inventory_host_update + t_platform->inventory_host_update
+	permission inventory_host_view = t_binding->inventory_host_view + t_platform->inventory_host_view
+	permission notifications_applications_view = t_binding->notifications_applications_view + t_platform->notifications_applications_view
+	permission notifications_behavior_groups_edit = t_binding->notifications_behavior_groups_edit + t_platform->notifications_behavior_groups_edit
+	permission notifications_behavior_groups_view = t_binding->notifications_behavior_groups_view + t_platform->notifications_behavior_groups_view
+	permission notifications_bundles_view = t_binding->notifications_bundles_view + t_platform->notifications_bundles_view
+	permission notifications_daily_digest_preference_edit = t_binding->notifications_daily_digest_preference_edit + t_platform->notifications_daily_digest_preference_edit
+	permission notifications_daily_digest_preference_view = t_binding->notifications_daily_digest_preference_view + t_platform->notifications_daily_digest_preference_view
+	permission notifications_event_log_view = t_binding->notifications_event_log_view + t_platform->notifications_event_log_view
+	permission notifications_event_types_view = t_binding->notifications_event_types_view + t_platform->notifications_event_types_view
+	permission notifications_integration_create = t_binding->notifications_integration_create + t_platform->notifications_integration_create
+	permission notifications_integration_delete = t_binding->notifications_integration_delete + t_platform->notifications_integration_delete
+	permission notifications_integration_disable = t_binding->notifications_integration_disable + t_platform->notifications_integration_disable
+	permission notifications_integration_edit = t_binding->notifications_integration_edit + t_platform->notifications_integration_edit
+	permission notifications_integration_enable = t_binding->notifications_integration_enable + t_platform->notifications_integration_enable
+	permission notifications_integration_subscribe_drawer = t_binding->notifications_integration_subscribe_drawer + t_platform->notifications_integration_subscribe_drawer
+	permission notifications_integration_subscribe_email = t_binding->notifications_integration_subscribe_email + t_platform->notifications_integration_subscribe_email
+	permission notifications_integration_test = t_binding->notifications_integration_test + t_platform->notifications_integration_test
+	permission notifications_integration_view = t_binding->notifications_integration_view + t_platform->notifications_integration_view
+	permission notifications_integration_view_history = t_binding->notifications_integration_view_history + t_platform->notifications_integration_view_history
+	permission platform = t_platform
+	relation t_platform: rbac/platform
+}
+
+definition rbac/workspace {
+	permission binding = t_binding
+	relation t_binding: rbac/role_binding
+	permission inventory_host_update = t_binding->inventory_host_update + t_parent->inventory_host_update
+	permission inventory_host_view = t_binding->inventory_host_view + t_parent->inventory_host_view
+	permission notifications_applications_view = t_binding->notifications_applications_view + t_parent->notifications_applications_view
+	permission notifications_behavior_groups_edit = t_binding->notifications_behavior_groups_edit + t_parent->notifications_behavior_groups_edit
+	permission notifications_behavior_groups_view = t_binding->notifications_behavior_groups_view + t_parent->notifications_behavior_groups_view
+	permission notifications_bundles_view = t_binding->notifications_bundles_view + t_parent->notifications_bundles_view
+	permission notifications_daily_digest_preference_edit = t_binding->notifications_daily_digest_preference_edit + t_parent->notifications_daily_digest_preference_edit
+	permission notifications_daily_digest_preference_view = t_binding->notifications_daily_digest_preference_view + t_parent->notifications_daily_digest_preference_view
+	permission notifications_event_log_view = t_binding->notifications_event_log_view + t_parent->notifications_event_log_view
+	permission notifications_event_types_view = t_binding->notifications_event_types_view + t_parent->notifications_event_types_view
+	permission notifications_integration_create = t_binding->notifications_integration_create + t_parent->notifications_integration_create
+	permission notifications_integration_delete = t_binding->notifications_integration_delete + t_parent->notifications_integration_delete
+	permission notifications_integration_disable = t_binding->notifications_integration_disable + t_parent->notifications_integration_disable
+	permission notifications_integration_edit = t_binding->notifications_integration_edit + t_parent->notifications_integration_edit
+	permission notifications_integration_enable = t_binding->notifications_integration_enable + t_parent->notifications_integration_enable
+	permission notifications_integration_subscribe_drawer = t_binding->notifications_integration_subscribe_drawer + t_parent->notifications_integration_subscribe_drawer
+	permission notifications_integration_subscribe_email = t_binding->notifications_integration_subscribe_email + t_parent->notifications_integration_subscribe_email
+	permission notifications_integration_test = t_binding->notifications_integration_test + t_parent->notifications_integration_test
+	permission notifications_integration_view = t_binding->notifications_integration_view + t_parent->notifications_integration_view
+	permission notifications_integration_view_history = t_binding->notifications_integration_view_history + t_parent->notifications_integration_view_history
+	permission parent = t_parent
+	relation t_parent: rbac/workspace | rbac/tenant
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -598,6 +598,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Solidity:** [davidhq/SublimeEthereum](https://github.com/davidhq/SublimeEthereum)
 - **Soong:** [flimberger/android-system-tools](https://github.com/flimberger/android-system-tools)
 - **SourcePawn:** [Sarrus1/sourcepawn-vscode](https://github.com/Sarrus1/sourcepawn-vscode)
+- **SpiceDB Schema:** [authzed/spicedb-vscode](https://github.com/authzed/spicedb-vscode)
 - **Spline Font Database:** [Alhadis/language-fontforge](https://github.com/Alhadis/language-fontforge)
 - **Squirrel:** [mathewmariani/squirrel-language](https://github.com/mathewmariani/squirrel-language)
 - **Stan:** [stan-dev/atom-language-stan](https://github.com/stan-dev/atom-language-stan)

--- a/vendor/licenses/git_submodule/spicedb-vscode.dep.yml
+++ b/vendor/licenses/git_submodule/spicedb-vscode.dep.yml
@@ -1,0 +1,218 @@
+---
+name: spicedb-vscode
+version: 1b3f6dbe5a9ef47da8779b6c36bcb31b11b551a5
+type: git_submodule
+homepage: https://github.com/authzed/spicedb-vscode.git
+license: apache-2.0
+licenses:
+- sources: LICENSE
+  text: |2
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+
+       END OF TERMS AND CONDITIONS
+
+       APPENDIX: How to apply the Apache License to your work.
+
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "[]"
+          replaced with your own identifying information. (Don't include
+          the brackets!)  The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+
+       Copyright [yyyy] [name of copyright owner]
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+notices:
+- sources: NOTICE
+  text: |-
+    SpiceDB
+    Copyright 2024 Authzed, Inc
+
+    This product includes software developed at
+    Authzed, Inc. (https://www.authzed.com/).


### PR DESCRIPTION
## Description

Add [SpiceDB Schema](https://authzed.com/docs/spicedb/concepts/schema) (`.zed`) as a new data language.

SpiceDB is an open-source permissions database. The schema describes object types, the relations between them, and the permissions derived from those relations, plus CEL-based caveats for contextual constraints. Used by teams at Red Hat, Oviva, Raystack, and others (see the repo list below for specifics).

Two things worth flagging up front:

1. The submodule is pinned to `1b3f6db` instead of the `v1.1.1` tag because that commit ([authzed/spicedb-vscode#65](https://github.com/authzed/spicedb-vscode/pull/65)) fixes a regex that wasn't valid PCRE, which linguist's grammar-compiler needs. Will be in a future upstream release.
2. `grammars.yml` lists two scopes (`source.cel` and `source.spicedb`) for one new language. CEL is embedded inside SpiceDB caveats, so the upstream grammar ships both `cel.tmGrammar.json` and `spicedb.tmGrammar.json`. CEL isn't added to `languages.yml`; the second scope just registers the bundled grammar file. Nothing else in `grammars.yml` claims either scope.

`.zed` is also used by Brim Data's [Zed](https://zed.brimdata.io/) shape language, which isn't currently in linguist. If it's added later, the `definition`/`permission`/`relation`/`caveat` keywords should be enough to disambiguate.

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - REST API cross-check (`gh api /search/code?q=extension:zed+definition`): **307 SpiceDB-flavored files** (one `.zed` schema per repo is the norm, so this also approximates the unique-repo count).
      - Example users: Red Hat (Project Kessel and the Insights RBAC config), Oviva, Raystack Frontier, Magistrala, Inkeep, SchoolAI, France-Nuage.
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - `oviva.zed`: https://github.com/oviva-ag/spicegen/blob/main/parser/fixtures/oviva.zed
      - `schema.zed`: https://github.com/project-kessel/relations-api/blob/main/deploy/hbi/schema.zed
    - Sample license(s):
      - `oviva.zed`: [Apache-2.0](https://github.com/oviva-ag/spicegen/blob/main/LICENSE)
      - `schema.zed`: [Apache-2.0](https://github.com/project-kessel/relations-api/blob/main/LICENSE)
  - [x] I have included a syntax highlighting grammar: https://github.com/authzed/spicedb-vscode (Apache-2.0)
  - [x] I have added a color
    - Hex value: `#a5318a`
    - Rationale: `Magenta 600` from the official AuthZed brand palette at https://authzed.com/brand (alongside `Red 500 #f0566d` and `Sand 300 #ffb370`). The 600 step is designed to clear contrast checks on light backgrounds, which matches how GitHub renders language-color dots. Visually distinct from existing linguist entries.
  - `.zed` isn't currently mapped to any language in linguist, so no heuristic is needed (see the Brim Zed note above for what to do if that changes).

## Some `.zed` repos for context

| Repository | Stars | Description |
|---|---|---|
| [absmach/magistrala](https://github.com/absmach/magistrala) | 2,584 ⭐ | IoT platform |
| [inkeep/agents](https://github.com/inkeep/agents) | 1,116 ⭐ | Inkeep agent platform |
| [raystack/frontier](https://github.com/raystack/frontier) | 331 ⭐ | Identity & access platform built on SpiceDB |
| [France-Nuage/plateforme](https://github.com/France-Nuage/plateforme) | 54 ⭐ | France-Nuage cloud platform |
| [oviva-ag/spicegen](https://github.com/oviva-ag/spicegen) | 11 ⭐ | Oviva (digital health), SpiceDB Java client generator. Source of `samples/SpiceDB Schema/oviva.zed`. |
| [project-kessel/relations-api](https://github.com/project-kessel/relations-api) | 10 ⭐ | Red Hat Project Kessel relations API. Source of `samples/SpiceDB Schema/schema.zed`. |
| [RedHatInsights/rbac-config](https://github.com/RedHatInsights/rbac-config) | 5 ⭐ | Red Hat Hybrid Cloud Console RBAC config |
| [SchoolAI/spicedb-zed-schema-parser](https://github.com/SchoolAI/spicedb-zed-schema-parser) | 3 ⭐ | Open-source `.zed` schema parser |
| [project-kessel/inventory-api](https://github.com/project-kessel/inventory-api) | 2 ⭐ | Red Hat Project Kessel inventory API |


