### PR TITLE
Add Lox Language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1593,3 +1593,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/lox-language"]
+	path = vendor/grammars/lox-language
+	url = https://github.com/danman113/lox-language.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -888,6 +888,8 @@ vendor/grammars/logos:
 - source.logos
 vendor/grammars/logtalk.tmbundle:
 - source.logtalk
+vendor/grammars/lox-language:
+- source.lox
 vendor/grammars/lua.tmbundle:
 - source.lua
 vendor/grammars/m3:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4357,6 +4357,14 @@ LoomScript:
   tm_scope: source.loomscript
   ace_mode: text
   language_id: 212
+Lox:
+  type: programming
+  extensions:
+  - ".lox"
+  tm_scope: source.lox
+  ace_mode: text
+  color: "#f1ead7"
+  language_id: 640917978
 Lua:
   type: programming
   tm_scope: source.lua
@@ -7682,7 +7690,7 @@ TMDL:
   extensions:
   - ".tmdl"
   aliases:
-  - "Tabular Model Definition Language"
+  - Tabular Model Definition Language
   tm_scope: source.tmdl
   ace_mode: text
   language_id: 769162295

--- a/samples/Lox/fibonacci_numbers.lox
+++ b/samples/Lox/fibonacci_numbers.lox
@@ -1,0 +1,11 @@
+// Amount of digits
+var n = 10;
+
+var a = 0;
+var b = 1;
+for (var i = 0; i < n; i = i + 1) {
+    print a;
+    var temp = a;
+    a = b;
+    b = temp + b;
+}

--- a/samples/Lox/inherited_method.lox
+++ b/samples/Lox/inherited_method.lox
@@ -1,0 +1,22 @@
+class Foo {
+  inFoo() {
+    print "in foo";
+  }
+}
+
+class Bar < Foo {
+  inBar() {
+    print "in bar";
+  }
+}
+
+class Baz < Bar {
+  inBaz() {
+    print "in baz";
+  }
+}
+
+var baz = Baz();
+baz.inFoo(); // expect: in foo
+baz.inBar(); // expect: in bar
+baz.inBaz(); // expect: in baz


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Add the [Lox programming language](https://github.com/munificent/craftinginterpreters). The Lox programming language is a learning language made for the book *Crafting Interpreters* demonstrating how to create an object-oriented, interpreted programming language in Java, then C.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am adding a new extension to a language.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.FOOBAR+KEYWORDS
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.lox
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - fibonacci_numbers.lox: I made this.
      - inherited_method.lox: https://github.com/munificent/craftinginterpreters
    - Sample license(s):
      - inherited_method.lox is licensed MIT License owned by Robert Nystrom
      - fibonacci_numbers.lox lacks a high degree of creative expression and many people have created it; therefore placing it in the public domain.
  - [x] I have included a syntax highlighting grammar: https://github.com/danman113/lox-language
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#f1ead7`
    - Rationale: This color was chosen because it is the color used in the background of the cover on the book *Crafting Interpreters*. That book is where this language originated.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  - Old: [URL to grammar repo]
  - New: [URL to grammar repo]

- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

- [ ] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [URL to public discussion]
    - [Optional: URL to official branding guidelines for the language]
