### PR TITLE
Update colour for Erlang

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2071,7 +2071,7 @@ EmberScript:
   language_id: 103
 Erlang:
   type: programming
-  color: "#B83998"
+  color: "#a90432"
   extensions:
   - ".erl"
   - ".app"


### PR DESCRIPTION
Change Erlang color from `#B83998` to `#a90432`

## Checklist:
- [x] **I am changing the color associated with a language**
  - [ ] I have obtained agreement from the wider language community on this color change.
  - Hex value: `#a90432`
  - Rationale: the color is picked from [Erlang's logo](https://www.erlang.org/assets/img/erlang-logo.svg)
![Erlang's logo](https://www.erlang.org/assets/img/erlang-logo.svg)