### PR TITLE
Mark Julia package manifests (Manifest.toml) as generated

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -93,6 +93,7 @@ module Linguist
       gradle_wrapper? ||
       maven_wrapper? ||
       mise_lock? ||
+      julia_manifest? ||
       generated_go? ||
       generated_protocol_buffer_from_go? ||
       generated_protocol_buffer? ||
@@ -588,6 +589,13 @@ module Linguist
     # Returns true or false.
     def mise_lock?
       !!name.match(/(?:^|\/)mise(?:\.[^\/]+)?\.lock$/)
+    end
+
+    # Internal: Is the blob a Julia Manifest.toml file?
+    #
+    # Returns true or false.
+    def julia_manifest?
+      !!name.match(/(?:^|\/)(Julia)?Manifest(-v\d+\.\d+)?\.toml$/)
     end
 
     # Is the blob a VCR Cassette file?

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -247,6 +247,12 @@ class TestGenerated < Minitest::Test
     generated_sample_without_loading_data("TOML/filenames/mise.local.lock")
     generated_sample_without_loading_data("TOML/filenames/mise.test.lock")
     generated_sample_without_loading_data("TOML/filenames/mise.test.local.lock")
+
+    # Julia package manifests
+    generated_sample_without_loading_data("TOML/filenames/Manifest.toml")
+    generated_sample_without_loading_data("TOML/filenames/JuliaManifest.toml")
+    generated_sample_without_loading_data("TOML/filenames/Manifest-v1.12.toml")
+    generated_sample_without_loading_data("TOML/filenames/JuliaManifest-v1.12.toml")
   end
 
   # We've whitelisted these files on purpose, even though they're machine-generated.


### PR DESCRIPTION
## Description

Resolved package environments for the Julia language are generated by the package manager and captured in TOML files. They can be large and distract from more meaningful changes when reviewing PRs.

Julia's package manager produces a Manifest.toml file when the active project file is called Project.toml, and it produces a JuliaManifest.toml if the project file is called JuliaProject.toml. Manifests resolved with different Julia versions can live alongside one another, differentiated by a versioned suffix. Such files are not produced automatically; a generated manifest must be manually renamed to include a version suffix. In that case, it is still a generated file, despite the manual intervention.

The first line of these files is typically:
```toml
# This file is machine-generated - editing it directly is not advised
```
However, using the filename is much simpler than checking for this text. (Also note that these files would almost certainly never be written by hand.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.