### PR TITLE
Add Krypton language

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -1443,3 +1443,7 @@ vendor/grammars/zenstack:
 - source.zmodel
 vendor/grammars/zephir-sublime:
 - source.php.zephir
+- language: "Krypton"
+  scope: source.krypton
+  repo: t3m3d/krypton
+  path: krypton/krypton-lang/syntaxes/krypton.tmLanguage.json

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -9319,3 +9319,13 @@ xBase:
   tm_scope: source.harbour
   ace_mode: text
   language_id: 421
+# Krypton language
+Krypton:
+  type: programming
+  color: "#4F5AA8"
+  tm_scope: source.krypton
+  ace_mode: krypton
+  extensions:
+    - .k
+  filenames: []
+  interpreters: []


### PR DESCRIPTION
Proposed PR: Add Krypton language support

Summary
- Adds `Krypton` as a programming language to Linguist with a TextMate grammar mapping.

Details
- Language name: Krypton
- File extension: `.k`
- TextMate scope: `source.krypton`
- Grammar source: https://github.com/<your-organization>/krypton (the PR should reference the Krypton repo and the grammar file at `krypton-lang/syntaxes/krypton.tmLanguage.json`).

Why
- Krypton is an actively-developed systems language with a complete TextMate grammar in the repository. GitHub currently auto-detects `.k` as KCL for some repositories; adding Krypton ensures correct language attribution for this ecosystem.

Notes for maintainers
- The grammar is included in the Krypton repo under `krypton-lang/syntaxes/krypton.tmLanguage.json`.
- `.gitattributes` in the Krypton repo already contains `*.k linguist-language=Krypton` to force detection when the repo is present.
- If you prefer a different `repo` identifier or path layout, update the `grammars.yml` entry accordingly.

Checklist
- [ ] Add entry to `lib/linguist/languages.yml` (snippet attached).
- [ ] Add mapping to `grammars.yml` (snippet attached).
- [ ] Confirm `tm_scope` and `fileTypes` match the TextMate grammar.
