### PR TITLE
Add Zeta programming language

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -1443,3 +1443,7 @@ vendor/grammars/zenstack:
 - source.zmodel
 vendor/grammars/zephir-sublime:
 - source.php.zephir
+
+# Zeta language grammar
+vendor/grammars/Zeta.tmLanguage:
+- source.zeta

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -9017,6 +9017,23 @@ Zephir:
   tm_scope: source.php.zephir
   ace_mode: php
   language_id: 410
+
+Zeta:
+  type: programming
+  ace_mode: text
+  codemirror_mode: rust
+  codemirror_mime_type: text/x-rustsrc
+  color: "#EAB308"
+  aliases:
+  - zeta-lang
+  extensions:
+  - ".z"
+  - ".zeta"
+  - ".zorb"
+  interpreters:
+  - zeta
+  language_id: 1234567890
+  tm_scope: source.zeta
 Zig:
   type: programming
   color: "#ec915c"

--- a/samples/Zeta/sample.z
+++ b/samples/Zeta/sample.z
@@ -1,0 +1,43 @@
+// Zeta language sample
+// Used for GitHub language statistics
+
+use std::collections::HashMap;
+
+pub struct Config {
+    pub name: String,
+    pub version: u32,
+    pub debug: bool,
+}
+
+impl Config {
+    pub fn new(name: String) -> Self {
+        Config { name, version: 0, debug: false }
+    }
+
+    pub fn display(&self) {
+        println!("Config: {} v{}", self.name, self.version);
+    }
+}
+
+pub enum Result<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+pub fn parse_config(path: &str) -> Result<Config, String> {
+    if path.is_empty() {
+        return Result::Err("path cannot be empty".to_string());
+    }
+
+    let mut map = HashMap::new();
+    map.insert("key", 42);
+
+    match map.get("key") {
+        Some(val) => Result::Ok(Config::new("test".to_string())),
+        None => Result::Err("not found".to_string()),
+    }
+}
+
+pub const fn add(a: i32, b: i32) -> i32 {
+    a + b
+}

--- a/vendor/grammars/Zeta.tmLanguage/Zeta.tmLanguage.json
+++ b/vendor/grammars/Zeta.tmLanguage/Zeta.tmLanguage.json
@@ -1,0 +1,70 @@
+{
+  "name": "Zeta",
+  "scopeName": "source.zeta",
+  "fileTypes": ["z", "zeta"],
+  "patterns": [
+    { "include": "#keywords" },
+    { "include": "#types" },
+    { "include": "#strings" },
+    { "include": "#comments" },
+    { "include": "#numbers" },
+    { "include": "#functions" },
+    { "include": "#attributes" },
+    { "include": "#macros" },
+    { "include": "#operators" }
+  ],
+  "repository": {
+    "keywords": {
+      "patterns": [
+        {"match": "\\b(fn|let|mut|const|static|struct|enum|trait|impl|concept|use|mod|pub|crate|self|super|return|if|else|match|while|for|in|loop|break|continue|true|false|async|await|unsafe|extern|type|where|move|ref|as|dyn|abstract|virtual|override|private|protected|internal)\\b", "name": "keyword.control.zeta"},
+        {"match": "\\b(if|else|match|while|for|in|loop|break|continue|return)\\b", "name": "keyword.control.zeta"},
+        {"match": "\\b(let|mut|const|static)\\b", "name": "keyword.declaration.zeta"},
+        {"match": "\\b(u8|u16|u32|u64|u128|i8|i16|i32|i64|i128|f32|f64|bool|char|str|String|Vec|Option|Result|Box|Arc|Rc|Cell|RefCell|HashMap|HashSet|Duration|Ordering)\\b", "name": "storage.type.zeta"}
+      ]
+    },
+    "types": {
+      "patterns": [
+        {"match": "\\b[A-Z][a-zA-Z0-9]*\\b", "name": "support.class.zeta"}
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {"begin": "\"", "end": "\"", "name": "string.quoted.double.zeta", "patterns": [{"match": "\\\\[0-7]{1,3}|\\\\[\\\\\"'nrt0]", "name": "constant.character.escape.zeta"}]},
+        {"begin": "'", "end": "'", "name": "string.quoted.single.zeta"}
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {"begin": "///", "end": "$", "name": "comment.line.documentation.zeta"},
+        {"begin": "//!", "end": "$", "name": "comment.line.documentation.zeta"},
+        {"begin": "//", "end": "$", "name": "comment.line.double-slash.zeta"},
+        {"begin": "/\\*", "end": "\\*/", "name": "comment.block.zeta"}
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {"match": "\\b(0x[0-9a-fA-F_]+|0o[0-7_]+|0b[01_]+|[0-9][0-9_]*([.][0-9_]*)?([eE][+-]?[0-9_]+)?)\\b", "name": "constant.numeric.zeta"}
+      ]
+    },
+    "functions": {
+      "patterns": [
+        {"match": "\\b([a-z_][a-zA-Z0-9_]*)\\s*(?=\\()", "name": "support.function.zeta"}
+      ]
+    },
+    "attributes": {
+      "patterns": [
+        {"begin": "#\\[", "end": "\\]", "name": "meta.attribute.zeta"}
+      ]
+    },
+    "macros": {
+      "patterns": [
+        {"match": "\\b([a-z_][a-zA-Z0-9_]*)\\s*!", "name": "support.function.macro.zeta"}
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {"match": "->|=>|::|\\.\\.=|\\?\\.|\\.\\.|\\|\\||&&|<<|>>|==|!=|<=|>=|\\+\\+|--|\\+=|-=|\\*=|/=|%=|&=|\\|=|\\^=", "name": "keyword.operator.zeta"}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Zeta is a systems programming language bootstrapped in Rust, targeting LLVM with AOT and JIT compilation. It uses `.z` and `.zeta` file extensions.

This PR adds:
- `languages.yml` entry for Zeta with #EAB308 color
- TextMate grammar for syntax highlighting
- Sample file for language statistics

See https://github.com/murphsicles/dark-factory for the transpiler that converts Rust crates to Zeta.