### PR TITLE
Add SwissJS language (.ui, .uix)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1596,3 +1596,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/grammar-swissjs"]
+	path = vendor/grammars/grammar-swissjs
+	url = https://github.com/kibologic/grammar-swissjs.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -440,6 +440,8 @@ vendor/grammars/gradle.tmbundle:
 - source.groovy.gradle
 vendor/grammars/grammar:
 - source.erlang
+vendor/grammars/grammar-swissjs:
+- source.swissjs
 vendor/grammars/graphiql:
 - inline.graphql
 - inline.graphql.markdown.codeblock

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -1002,6 +1002,11 @@ disambiguations:
   - language: Typst
     pattern: '^#(import|show|let|set)'
   - language: XML
+- extensions: ['.ui']
+  rules:
+  - language: SwissJS
+    pattern: '\bcomponent\s+[A-Z][A-Za-z0-9_]*\s*\{'
+  - language: XML
 - extensions: ['.url']
   rules:
   - language: INI

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7650,6 +7650,19 @@ Swift:
   codemirror_mode: swift
   codemirror_mime_type: text/x-swift
   language_id: 362
+SwissJS:
+  type: programming
+  color: "#3b82f6"
+  extensions:
+  - ".ui"
+  - ".uix"
+  tm_scope: source.swissjs
+  ace_mode: text
+  language_id: 1155268642
+  aliases:
+  - swiss
+  - swissjs
+  group: JavaScript
 SystemVerilog:
   type: programming
   color: "#DAE1C2"

--- a/samples/SwissJS/capability.ui
+++ b/samples/SwissJS/capability.ui
@@ -1,0 +1,67 @@
+import { Signal } from '@swissjs/core';
+
+@requires('network', 'analytics')
+component PaymentForm {
+  state {
+    let amount: number = 0;
+    let status: 'idle' | 'processing' | 'success' | 'error' = 'idle';
+    let errorMessage: string = '';
+  }
+
+  props = {
+    currency: String,
+    onSuccess: Function,
+    onError: Function,
+  };
+
+  computed get isValid() {
+    return this.amount > 0 && this.status === 'idle';
+  }
+
+  async mount() {
+    this.trackView();
+  }
+
+  trackView() {
+    analytics.track('payment_form_viewed', { currency: this.currency });
+  }
+
+  async submit() {
+    if (!this.isValid) return;
+    this.status = 'processing';
+    try {
+      const result = await fetch('/api/payment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount: this.amount, currency: this.currency }),
+      });
+      const data = await result.json();
+      this.status = 'success';
+      this.onSuccess(data);
+    } catch (err) {
+      this.status = 'error';
+      this.errorMessage = err instanceof Error ? err.message : 'Payment failed';
+      this.onError(this.errorMessage);
+    }
+  }
+
+  render() {
+    return html`
+      <form class="payment-form" onsubmit="${(e: Event) => { e.preventDefault(); this.submit(); }}">
+        <label>
+          Amount (${this.currency})
+          <input
+            type="number"
+            min="1"
+            v-bind="amount"
+            oninput="${(e: InputEvent) => (this.amount = Number((e.target as HTMLInputElement).value))}"
+          />
+        </label>
+        ${this.status === 'error' ? html`<p class="error">${this.errorMessage}</p>` : ''}
+        <button type="submit" *if="${this.isValid}">
+          ${this.status === 'processing' ? 'Processing...' : 'Pay Now'}
+        </button>
+      </form>
+    `;
+  }
+}

--- a/samples/SwissJS/component.ui
+++ b/samples/SwissJS/component.ui
@@ -1,0 +1,39 @@
+import { Signal } from '@swissjs/core';
+
+component Counter {
+  state {
+    let count: number = 0;
+    let step: number = 1;
+  }
+
+  computed get doubled() {
+    return this.count * 2;
+  }
+
+  mount {
+    console.log('Counter mounted');
+  }
+
+  unmount {
+    console.log('Counter unmounted');
+  }
+
+  increment() {
+    this.count += this.step;
+  }
+
+  decrement() {
+    this.count = Math.max(0, this.count - this.step);
+  }
+
+  render() {
+    return html`
+      <div class="counter">
+        <p>Count: ${this.count}</p>
+        <p>Doubled: ${this.doubled}</p>
+        <button onclick="${() => this.decrement()}">-</button>
+        <button onclick="${() => this.increment()}">+</button>
+      </div>
+    `;
+  }
+}

--- a/samples/SwissJS/reactive.ui
+++ b/samples/SwissJS/reactive.ui
@@ -1,0 +1,60 @@
+import { Signal } from '@swissjs/core';
+
+component SearchBox {
+  reactive let query: string = '';
+  reactive let results: string[] = [];
+
+  state {
+    let loading: boolean = false;
+    let error: string | null = null;
+  }
+
+  props = {
+    placeholder: String,
+    onSelect: Function,
+  };
+
+  effect {
+    if (this.query.length > 2) {
+      this.fetchResults(this.query);
+    } else {
+      this.results = [];
+    }
+  }
+
+  async mount() {
+    console.log('SearchBox ready');
+  }
+
+  async fetchResults(q: string) {
+    this.loading = true;
+    try {
+      const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+      this.results = await res.json();
+    } catch (e) {
+      this.error = 'Search failed';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  render() {
+    return html`
+      <div class="search-box">
+        <input
+          type="text"
+          placeholder="${this.placeholder}"
+          v-bind="query"
+          oninput="${(e: InputEvent) => (this.query = (e.target as HTMLInputElement).value)}"
+        />
+        ${this.loading ? html`<span class="loading">Searching...</span>` : ''}
+        ${this.error ? html`<span class="error">${this.error}</span>` : ''}
+        <ul>
+          ${this.results.map((r) => html`
+            <li onclick="${() => this.onSelect(r)}">${r}</li>
+          `)}
+        </ul>
+      </div>
+    `;
+  }
+}


### PR DESCRIPTION
## Checklist

- [x] Added language entry to `lib/linguist/languages.yml` (alphabetical after Swift)
- [x] Added grammar submodule to `grammars.yml` and `.gitmodules`
- [x] Added at least three sample files to `samples/SwissJS/`
- [x] Added heuristics to `lib/linguist/heuristics.yml` for `.ui` disambiguation
- [x] `language_id` generated via the `languages.yml` sort order (1155268642)

## Language details

**SwissJS** is a TypeScript-superset component language developed by [Kibologic](https://github.com/kibologic). It compiles `.ui` (template-first) and `.uix` (JSX-first) component files into browser-native JavaScript. The syntax extends TypeScript with declarative constructs:

```typescript
component Counter {
  state {
    let count: number = 0;
  }

  computed get doubled() {
    return this.count * 2;
  }

  mount {
    console.log('mounted');
  }

  render() {
    return html`<button onclick="${() => this.count++}">${this.count}</button>`;
  }
}
```

Key syntax features:
- `component Name {}` — top-level component declaration
- `state {}` — reactive state block
- `reactive let` — individual reactive variable
- `computed get` — derived properties
- `mount` / `unmount` / `effect` — lifecycle hooks
- `@requires('capability')` — capability decorator
- `html\`...\`` / `css\`...\`` — tagged template literals for embedded HTML/CSS

## Evidence of real-world use

The language is actively used across the Kibologic engineering org:

- **Examples repo**: [kibologic/examples](https://github.com/kibologic/examples) — counter app, todo app, fetch demo with async data loading
- **Grammar repo**: [kibologic/grammar-swissjs](https://github.com/kibologic/grammar-swissjs) — TextMate grammar with embedded HTML/CSS language injection
- **npm package**: `@swissjs/swite` (build toolchain, v0.3.0)

## Extension disambiguation

`.ui` files are ambiguous with Qt Designer XML files. The heuristic in `heuristics.yml` detects SwissJS via the `component <PascalCase> {` declaration pattern; all other `.ui` files fall through to XML.

`.uix` is unique to SwissJS and requires no disambiguation.

## Color rationale

`#3b82f6` (Tailwind blue-500) was chosen to differentiate SwissJS from JavaScript (`#f1e05a`) and TypeScript (`#3178c6`) while staying in the blue-tone family that signals TypeScript-adjacent tooling.

## Grammar

The TextMate grammar at [kibologic/grammar-swissjs](https://github.com/kibologic/grammar-swissjs) provides:
- Swiss-specific keyword scopes (`keyword.control.swissjs`, `entity.name.type.component.swissjs`)
- Embedded HTML language injection inside `html\`...\``
- Embedded CSS language injection inside `css\`...\``
- Decorator support for `@requires` and `@capability`