### PR TITLE
Add Krypton language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1593,3 +1593,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/Krypton"]
+	path = vendor/grammars/Krypton
+	url = https://github.com/t3m3d/krypton.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -54,6 +54,8 @@ vendor/grammars/Jails:
 - source.jai
 vendor/grammars/K-VSCode:
 - text.k
+vendor/grammars/Krypton:
+- source.krypton
 vendor/grammars/LOLCODE-grammar-vscode:
 - source.lolcode
 vendor/grammars/Ligo-grammar:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3909,6 +3909,16 @@ KRL:
   tm_scope: none
   ace_mode: text
   language_id: 186
+Krypton:
+  type: programming
+  color: "#4F5AA8"
+  tm_scope: source.krypton
+  ace_mode: text
+  extensions:
+  - ".k"
+  filenames: []
+  interpreters: []
+  language_id: 824402198
 Kaitai Struct:
   type: programming
   aliases:

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -321,6 +321,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **KCL:** [kcl-lang/vscode-kcl](https://github.com/kcl-lang/vscode-kcl)
 - **KDL:** [kdl-org/vscode-kdl](https://github.com/kdl-org/vscode-kdl)
 - **KFramework:** [LucianCumpata/K-VSCode](https://github.com/LucianCumpata/K-VSCode)
+- **Krypton:** [t3m3d/krypton](https://github.com/t3m3d/krypton)
 - **Kaitai Struct:** [atom/language-yaml](https://github.com/atom/language-yaml)
 - **KakouneScript:** [kakoune-editor/language-kak](https://github.com/kakoune-editor/language-kak)
 - **KerboScript:** [KSP-KOS/language-kerboscript](https://github.com/KSP-KOS/language-kerboscript)


### PR DESCRIPTION
## Summary

Add initial GitHub Linguist support for the Krypton programming language.

## Changes

- Added `Krypton` metadata to `lib/linguist/languages.yml`
  - `type: programming`
  - `tm_scope: source.krypton`
  - `extensions: [.k]`
- Registered `source.krypton` in `grammars.yml`
  - maps the scope to `vendor/grammars/Krypton`
- Added `vendor/grammars/Krypton` as a submodule referencing `https://github.com/t3m3d/krypton.git`
- Updated `vendor/README.md` with the Krypton grammar source entry

## Why this matters

Krypton is an existing language ecosystem with working projects that rely on `.k` source files:

- `kcode` — Krypton’s terminal IDE/editor, including a multi-file source tree under `contrib/linguist/samples/kcode/` in the main repo
- `kmon` — a separate Krypton-based network monitor project demonstrating GUI and native integration
- `kryofetch` — Krypton system-info tooling used in the wider ecosystem
- `brew tap t3m3d/krypton && brew install krypton` installs Krypton via Homebrew
- `choco install krypton` installs Krypton via Chocolatey

The Krypton syntax grammar is upstream at `krypton/krypton-lang/syntaxes/krypton.tmLanguage.json`. This PR enables Linguist to classify `.k` files as `source.krypton` so GitHub can syntax highlight Krypton sources properly.

## Notes

- This change only updates Linguist metadata and grammar registration.
- Local Linguist tooling validation is limited in this environment because `lib/linguist/samples.json` is not present.
