### PR TITLE
Add Cobrust language support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1301,6 +1301,17 @@ Clue:
   tm_scope: source.clue
   ace_mode: text
   language_id: 163763508
+Cobrust:
+  type: programming
+  color: "#b45309"
+  extensions:
+  - ".cb"
+  tm_scope: source.cobrust
+  ace_mode: python
+  codemirror_mode: python
+  codemirror_mime_type: text/x-python
+  aliases:
+  - cobrust
 CoNLL-U:
   type: data
   extensions:

--- a/samples/Cobrust/fib.cb
+++ b/samples/Cobrust/fib.cb
@@ -1,0 +1,14 @@
+# Fibonacci — M11.2 example (ADR-0034).
+#
+# Real recursive algorithm. Demonstrates user-defined fn calls via
+# `Constant::FnRef` Call lowering (forward-declaration two-pass per
+# ADR-0034 §"Decision" Option 3). fib(10) = 55.
+fn fib(n: i64) -> i64:
+    if n < 2:
+        return n
+    return fib(n - 1) + fib(n - 2)
+
+fn main() -> i64:
+    print("fib(10) =")
+    print(fib(10))
+    return 0

--- a/samples/Cobrust/fizzbuzz.cb
+++ b/samples/Cobrust/fizzbuzz.cb
@@ -1,0 +1,24 @@
+# FizzBuzz — M11.1 example (ADR-0030).
+#
+# Real algorithm: while loop + if/elif/elif/else + modulo arithmetic.
+# Demonstrates:
+#   - while loop with mutation
+#   - if/elif/elif/else with if as the first statement in the loop body
+#   - modulo operator (%)
+#   - print (polymorphic: string and integer, ADR-0064)
+#
+# The M11 prelude fixes (ADR-0030) enable this after the while-loop-
+# with-leading-if codegen regression was resolved.
+fn main() -> i64:
+    let n: i64 = 1
+    while n <= 15:
+        if n % 15 == 0:
+            print("FizzBuzz")
+        elif n % 3 == 0:
+            print("Fizz")
+        elif n % 5 == 0:
+            print("Buzz")
+        else:
+            print(n)
+        n = n + 1
+    return 0

--- a/samples/Cobrust/hello.cb
+++ b/samples/Cobrust/hello.cb
@@ -1,0 +1,3 @@
+fn main() -> i64:
+    print("hello, world")
+    return 0

--- a/samples/Cobrust/two_sum.cb
+++ b/samples/Cobrust/two_sum.cb
@@ -1,0 +1,31 @@
+# LC-01 Two Sum (ADR-0044 W2 Phase 3).
+#
+# Input  (stdin):
+#   Line 1: N
+#   Lines 2..N+1: one integer each
+#   Line N+2: target
+#
+# Output: indices i j (i < j) with nums[i]+nums[j]==target, one per line.
+#
+# Algorithm: O(N²) brute-force scan.
+
+fn main() -> i64:
+    let n = parse_int(input(""))
+    let nums = list_new(n)
+    let i: i64 = 0
+    while i < n:
+        let v = parse_int(input(""))
+        list_set(nums, i, v)
+        i = i + 1
+    let target = parse_int(input(""))
+    let a: i64 = 0
+    while a < n:
+        let b: i64 = a + 1
+        while b < n:
+            if list_get(nums, a) + list_get(nums, b) == target:
+                print(a)
+                print(b)
+                return 0
+            b = b + 1
+        a = a + 1
+    return 0

--- a/samples/Cobrust/valid_anagram.cb
+++ b/samples/Cobrust/valid_anagram.cb
@@ -1,0 +1,37 @@
+# LC-022 hashmap-valid-anagram (ADR-0047 LC-100 Tier A bucket B1).
+#
+# Input  (stdin): Line 1: string s; Line 2: string t
+# Output: "true" if s and t are anagrams, else "false"
+# Algorithm: 26-slot frequency count; increment for s, decrement for t
+
+fn main() -> i64:
+    let s = input("")
+    let t = input("")
+    let sn = str_len(&s)
+    let tn = str_len(&t)
+    if sn != tn:
+        print("false")
+        return 0
+    let freq = list_new(26)
+    let i: i64 = 0
+    while i < 26:
+        list_set(freq, i, 0)
+        i = i + 1
+    let j: i64 = 0
+    while j < sn:
+        let code = str_ord(str_at(&s, j)) - 97
+        list_set(freq, code, list_get(freq, code) + 1)
+        j = j + 1
+    let k: i64 = 0
+    while k < tn:
+        let code2 = str_ord(str_at(&t, k)) - 97
+        list_set(freq, code2, list_get(freq, code2) - 1)
+        k = k + 1
+    let m: i64 = 0
+    while m < 26:
+        if list_get(freq, m) != 0:
+            print("false")
+            return 0
+        m = m + 1
+    print("true")
+    return 0


### PR DESCRIPTION
## Description

Add support for Cobrust (`.cb` extension), an AI-first statically-typed
language with Python syntax + Rust ownership semantics. Compiles to native
binaries via Cranelift / LLVM.

- Project: https://github.com/Cobrust-lang/cobrust
- License (compiler + samples): Apache-2.0 OR MIT dual
- **Current release: v0.5.2** (2026-05-22)
- Sample license: Apache-2.0 OR MIT dual (same as compiler)

## Checklist

- [x] `languages.yml` entry added (no `language_id` per CONTRIBUTING — will be assigned by `script/update-ids`)
- [x] `samples/Cobrust/` populated with 5 programs (4 of 5 are non-trivial algorithms: fib, fizzbuzz, two_sum, valid_anagram)
- [x] Color hex `#b45309` (warm amber/copper) — no collision with existing hexes in current `languages.yml`
- [x] `.cb` extension not currently claimed (nearest are `.cbl` COBOL and `.cbx` CryptoBox — distinct)
- [x] **TextMate grammar published** at https://github.com/Cobrust-lang/cobrust-tmlanguage (scope `source.cobrust`, 314 LOC, dual Apache-2.0 OR MIT)
- [x] License: Apache-2.0 OR MIT dual

## Grammar submodule

The TextMate grammar lives in a dedicated repo so it can be added as a
vendor submodule via `script/add-grammar`:

```
script/add-grammar https://github.com/Cobrust-lang/cobrust-tmlanguage
```

I am happy to push the grammars.yml + submodule entry as an additional
commit on this PR once a maintainer indicates the languages.yml + samples
approach is OK; or run `script/add-grammar` locally and amend this PR
in a single revision — whichever the maintainer prefers.

## Usage scope (honest)

`.cb` files are concentrated in the project organisation:

- `Cobrust-lang/cobrust` main repo: ~158 `.cb` files across `examples/`,
  `examples/leetcode/` (100-problem LC-100 stress corpus), `tests/cb_fixtures/`
- VSCode/Cursor extension `cobrust-lang.cobrust` published 2026-05-22 on
  Open VSX: https://open-vsx.org/extension/cobrust-lang/cobrust

External repo adoption is currently nascent (released 5 days ago).
Primary users are project authors and AI agents writing/translating
Cobrust source via the project's LLM-translation subsystem. Maintainers
are welcome to apply usage-gate policy as they see fit; this PR
provides the language definition + grammar so the option is available
when adoption grows.

## Cross-references

- Cobrust v0.5.2 release: https://github.com/Cobrust-lang/cobrust/releases/tag/v0.5.2
- VSCode/Cursor extension: https://open-vsx.org/extension/cobrust-lang/cobrust
- TextMate grammar: https://github.com/Cobrust-lang/cobrust-tmlanguage
- Design philosophy (LLM-first): see `CLAUDE.md` §2.5 in the main repo