### PR TITLE
Allows custom language to be declared in the .gitattributes

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -4,7 +4,7 @@ Linguist supports a number of different custom override strategies for language 
 
 ## Using gitattributes
 
-Add [a `.gitattributes` file](https://git-scm.com/docs/gitattributes) to your project and use standard git-style path matchers for the files you want to override using the `linguist-documentation`, `linguist-language`, `linguist-vendored`, `linguist-generated`  and `linguist-detectable` attributes.
+Add [a `.gitattributes` file](https://git-scm.com/docs/gitattributes) to your project and use standard git-style path matchers for the files you want to override using the `linguist-documentation`, `linguist-language`, `linguist-vendored`, `linguist-generated` , `linguist-detectable` and `linguist-color` attributes.
 `.gitattributes` will be used to determine language statistics and will be used to syntax highlight files.
 You can also manually set syntax highlighting using [Vim or Emacs modelines](#using-emacs-or-vim-modelines).
 

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -324,10 +324,10 @@ module Linguist
     # Returns a type Symbol or nil.
     attr_reader :type
 
-    # Public: Get color.
+    # Public: Get color or set color.
     #
     # Returns a hex color String.
-    attr_reader :color
+    attr_accessor :color
 
     # Public: Get aliases
     #

--- a/lib/linguist/lazy_blob.rb
+++ b/lib/linguist/lazy_blob.rb
@@ -9,7 +9,8 @@ module Linguist
                 'linguist-language',
                 'linguist-vendored',
                 'linguist-generated',
-                'linguist-detectable']
+                'linguist-detectable',
+                'linguist-color']
 
     # DEPRECATED: use Linguist::Source::RuggedRepository::GIT_ATTR_OPTS instead
     GIT_ATTR_OPTS = Linguist::Source::RuggedRepository::GIT_ATTR_OPTS
@@ -74,6 +75,10 @@ module Linguist
 
       @language = if lang = git_attributes['linguist-language']
         detected_language = Language.find_by_alias(lang) || Language.create(name: lang, type: :programming)
+
+        if color = git_attributes['linguist-color']
+          detected_language.color = color
+        end
 
         # If strategies are being tracked, get the original strategy that would have been used
         if detected_language && Linguist.instrumenter

--- a/lib/linguist/lazy_blob.rb
+++ b/lib/linguist/lazy_blob.rb
@@ -73,7 +73,7 @@ module Linguist
       return @language if defined?(@language)
 
       @language = if lang = git_attributes['linguist-language']
-        detected_language = Language.find_by_alias(lang)
+        detected_language = Language.find_by_alias(lang) || Language.create(name: lang, type: :programming)
 
         # If strategies are being tracked, get the original strategy that would have been used
         if detected_language && Linguist.instrumenter

--- a/lib/linguist/lazy_blob.rb
+++ b/lib/linguist/lazy_blob.rb
@@ -77,7 +77,7 @@ module Linguist
         detected_language = Language.find_by_alias(lang) || Language.create(name: lang, type: :programming)
 
         if color = git_attributes['linguist-color']
-          detected_language.color = color
+          detected_language.color = "##{color}"
         end
 
         # If strategies are being tracked, get the original strategy that would have been used


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
# Allows custom language to be declared in the .gitattributes

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Before the requested changes, adding a language in the .gitattributes which is not supported by linguist make it not appear.

.gitattributes:
`*.lv linguist-language=Lavi`

Running with `bundle exec bin/github-linguist lavi`:
```
96.96%  401776     C++
1.87%   7729       CMake
0.54%   2242       Shell
0.30%   1246       HTML
0.23%   960        Dockerfile
0.07%   303        C
0.01%   54         Ruby
0.01%   54         Python
```

Now with the proposed changes:
```
90.67%  401776     C++
6.49%   28749      Lavi
1.74%   7729       CMake
0.51%   2242       Shell
0.28%   1246       HTML
0.22%   960        Dockerfile
0.07%   303        C
0.01%   54         Ruby
0.01%   54         Python
```

I also had to add support to the `color` attribute to be override:
`*.lv linguist-color=ba5186`
This was needed because the language has a color to be displayed in the Languages section of the repository.

## Checklist:


- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

I will need help with the tests.
Please, tell me if there's any more change needed.