### PR TITLE
Add language support for `pkg-config`

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -596,6 +596,8 @@ vendor/grammars/language-etc:
 - source.futhark
 - source.generic-config
 - source.generic-db
+- source.gimprc
+- source.gimpres
 - source.gitattributes
 - source.gitconfig
 - source.gitignore
@@ -603,6 +605,7 @@ vendor/grammars/language-etc:
 - source.hosts
 - source.ini.npmrc
 - source.inputrc
+- source.interp
 - source.lcov
 - source.m3u
 - source.m4
@@ -613,6 +616,7 @@ vendor/grammars/language-etc:
 - source.odin-ehr
 - source.openbsd-pkg.contents
 - source.opts
+- source.pkgconf
 - source.psl
 - source.record-jar
 - source.sexp
@@ -628,12 +632,16 @@ vendor/grammars/language-etc:
 - source.torrc
 - source.ucd.nameslist
 - source.ucd.unidata
+- source.uri-list
 - source.wgetrc
+- text.cachedir
 - text.checksums
 - text.codeowners
+- text.cookie-jar
 - text.html.ecmarkup
 - text.jira
 - text.lesshst
+- text.mac-tts
 - text.openbsd-pkg.desc
 - text.savane
 - text.xml.svg

--- a/lib/linguist/classifier.rb
+++ b/lib/linguist/classifier.rb
@@ -136,7 +136,8 @@ module Linguist
 
       scores = {}
       languages.each do |language|
-        centroid = @centroids[language]
+        fs_name = Language.find_by_name(language).fs_name
+        centroid = @centroids[fs_name || language]
         score = Classifier.similarity(vec, centroid)
         if score > 0.0
           scores[language] = score

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -637,6 +637,15 @@ disambiguations:
     pattern:
     - '(?i)\bDEFINE\s+(?:VARIABLE|TEMP-TABLE|BUFFER|QUERY|INPUT\s+PARAMETER|OUTPUT\s+PARAMETER)\b'
     - '(?i)\bEND(?:\s+(?:PROCEDURE|FUNCTION|DO|FOR\s+EACH))?\.'
+- extensions: ['.pc']
+  rules:
+  - language: Pro*C
+    pattern: '^\s*EXEC\s+SQL\s'
+  - language: pkg-config
+    and:
+      - pattern: '^Name:[ \t]+\S'
+      - pattern: '^Description:[ \t]+\S'
+      - pattern: '^Version:[ \t]+\S'
 - extensions: ['.php']
   rules:
   - language: Hack

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -60,6 +60,14 @@ module Linguist
       # Language name index
       @index[language.name.downcase] = @name_index[language.name.downcase] = language
 
+      # Index filesystem name if defined
+      if language.fs_name
+        if @name_index.key?(language.fs_name)
+          raise ArgumentError "Duplicate language name: #{language.fs_name}"
+        end
+        @index[language.fs_name.downcase] = @name_index[language.fs_name.downcase] = language
+      end
+
       language.aliases.each do |name|
         # All Language aliases should be unique. Raise if there is a duplicate.
         if @alias_index.key?(name)

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -9259,7 +9259,7 @@ ooc:
   language_id: 418
 pkg-config:
   type: data
-  color: "#75b5aa"
+  color: "#2b5e82"
   aliases:
   - pkgconf
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4562,6 +4562,7 @@ Makefile:
   - Makefile.frag
   - Makefile.in
   - Makefile.inc
+  - Makefile.pc
   - Makefile.wat
   - makefile
   - makefile.sco
@@ -7937,6 +7938,7 @@ Text:
   - README.me
   - README.mysql
   - README.nss
+  - README.pc
   - click.me
   - delete.me
   - keep.me

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5993,6 +5993,17 @@ Prisma:
   tm_scope: source.prisma
   ace_mode: prisma
   language_id: 499933428
+Pro*C:
+  fs_name: ProC
+  color: "#bb8368"
+  type: programming
+  extensions:
+  - ".pc"
+  tm_scope: source.c
+  ace_mode: c_cpp
+  codemirror_mode: clike
+  codemirror_mime_type: text/x-csrc
+  language_id: 991047534
 Processing:
   type: programming
   color: "#0096D8"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -9244,6 +9244,19 @@ ooc:
   tm_scope: source.ooc
   ace_mode: text
   language_id: 418
+pkg-config:
+  type: data
+  color: "#75b5aa"
+  aliases:
+  - pkgconf
+  extensions:
+  - ".pc"
+  - ".pc.in"
+  tm_scope: source.pkgconf
+  ace_mode: properties
+  codemirror_mode: properties
+  codemirror_mime_type: text/x-properties
+  language_id: 925023573
 q:
   type: programming
   extensions:

--- a/samples/Makefile/filenames/Makefile.pc
+++ b/samples/Makefile/filenames/Makefile.pc
@@ -1,0 +1,149 @@
+# PC makefile for the open-source release of adventure 2.5
+
+# To build with save/resume disabled, pass CCFLAGS="-D ADVENT_NOSAVE"
+
+VERS=$(shell sed -n <NEWS '/^[0-9]/s/:.*//p' | head -1)
+
+.PHONY: debug indent release refresh dist linty html clean
+.PHONY: check coverage
+
+CC?=gcc
+#CCFLAGS+=-std=c99 -D_DEFAULT_SOURCE -DVERSION=\"$(VERS)\" -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-all -Wdeclaration-after-statement
+CCFLAGS+=-std=c99 -D_DEFAULT_SOURCE -DVERSION=\"$(VERS)\" -O0 -D_FORTIFY_SOURCE=2 -fstack-protector-all -Wdeclaration-after-statement -ggdb
+LIBS=$(shell pkg-config --libs libedit)
+INC+=$(shell pkg-config --cflags libedit)
+
+# LLVM/Clang on macOS seems to need -ledit flag for linking
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    LIBS += -ledit
+endif
+
+OBJS=main.o init.o actions1.o actions2.o actions3.o actions4.o actions5.o score.o misc.o saveresume.o
+CHEAT_OBJS=cheat.o init.o actions1.o actions2.o actions3.o actions4.o actions5.o score.o misc.o saveresume.o
+SOURCES=$(OBJS:.o=.c) advent.h adventure.yaml Makefile control make_dungeon_calc.py templates/*.tpl
+
+.c.o:
+	$(CC) $(CCFLAGS) $(INC) $(DBX) -c $<
+
+advent:	$(OBJS) dungeon.o
+	$(CC) $(CCFLAGS) $(DBX) -o advent $(OBJS) dungeon.o $(LDFLAGS) $(LIBS)
+
+main.o:	 	advent.h dungeon.h
+
+init.o:	 	advent.h dungeon.h
+
+actions1.o:	advent.h dungeon.h actions.h
+
+actions2.o:	advent.h dungeon.h actions.h
+
+actions3.o:	advent.h dungeon.h actions.h
+
+actions4.o:	advent.h dungeon.h actions.h
+
+actions5.o:	advent.h dungeon.h actions.h
+
+score.o:	advent.h dungeon.h
+
+misc.o:		advent.h dungeon.h
+
+cheat.o:	advent.h dungeon.h
+
+saveresume.o:	advent.h dungeon.h
+
+dungeon.o:	dungeon.c dungeon.h
+	$(CC) $(CCFLAGS) -Warray-bounds=0 $(DBX) -c dungeon.c
+
+dungeon.c dungeon.h dungeon.bin tests/dungeon.bin dungeon_calculator.bin: make_dungeon.py adventure.yaml adventure_calculator.yaml advent.h templates/*.tpl
+	./make_dungeon.py
+	rm -f tests/dungeon.bin
+	cp dungeon.bin tests/dungeon.bin
+
+clean:
+	rm -f *.o advent cheat *.html *.gcno *.gcda
+	rm -f dungeon.c dungeon.h dungeon.bin tests/dungeon.bin
+	rm -f README advent.6 MANIFEST *.tar.gz
+	rm -f *~
+	rm -f .*~
+	rm -rf coverage advent.info
+	cd tests; $(MAKE) --quiet clean
+
+
+cheat: $(CHEAT_OBJS) dungeon.o
+	$(CC) $(CCFLAGS) $(DBX) -o cheat $(CHEAT_OBJS) dungeon.o $(LDFLAGS) $(LIBS)
+
+check: advent cheat
+	cd tests; $(MAKE) --quiet
+
+coverage: debug
+	cd tests; $(MAKE) coverage --quiet
+
+.SUFFIXES: .adoc .html .6
+
+# Requires asciidoc and xsltproc/docbook stylesheets.
+.adoc.6:
+	a2x --doctype manpage --format manpage $<
+.adoc.html:
+	asciidoc $<
+.adoc:
+	asciidoc $<
+
+html: advent.html history.html hints.html
+
+# README.adoc exists because that filename is magic on GitLab.
+DOCS=COPYING NEWS README.adoc TODO advent.adoc history.adoc notes.adoc hints.adoc advent.6 INSTALL.adoc
+TESTFILES=tests/*.log tests/*.chk tests/README tests/decheck tests/Makefile
+
+# Can't use GNU tar's --transform, needs to build under Alpine Linux.
+# This is a requirement for testing dist in GitLab's CI pipeline
+advent-$(VERS).tar.gz: $(SOURCES) $(DOCS)
+	@find $(SOURCES) $(DOCS) $(TESTFILES) -print | sed s:^:advent-$(VERS)/: >MANIFEST
+	@(ln -s . advent-$(VERS))
+	(tar -T MANIFEST -czvf advent-$(VERS).tar.gz)
+	@(rm advent-$(VERS))
+
+indent:
+	astyle -n -A3 --pad-header --min-conditional-indent=1 --pad-oper *.c
+
+release: advent-$(VERS).tar.gz advent.html history.html hints.html notes.html
+	shipper version=$(VERS) | sh -e -x
+
+refresh: advent.html notes.html history.html
+	shipper -N -w version=$(VERS) | sh -e -x
+
+dist: advent-$(VERS).tar.gz
+
+linty: CCFLAGS += -W
+linty: CCFLAGS += -Wall
+linty: CCFLAGS += -Wextra
+linty: CCGLAGS += -Wpedantic
+linty: CCFLAGS += -Wundef
+linty: CCFLAGS += -Wstrict-prototypes
+linty: CCFLAGS += -Wmissing-prototypes
+linty: CCFLAGS += -Wmissing-declarations
+linty: CCFLAGS += -Wshadow
+linty: CCFLAGS += -Wnull-dereference
+linty: CCFLAGS += -Wjump-misses-init
+linty: CCFLAGS += -Wfloat-equal
+linty: CCFLAGS += -Wcast-align
+linty: CCFLAGS += -Wwrite-strings
+linty: CCFLAGS += -Waggregate-return
+linty: CCFLAGS += -Wcast-qual
+linty: CCFLAGS += -Wswitch-enum
+linty: CCFLAGS += -Wwrite-strings
+linty: CCFLAGS += -Wunreachable-code
+linty: CCFLAGS += -Winit-self
+linty: CCFLAGS += -Wpointer-arith
+linty: advent cheat
+
+debug: CCFLAGS += -O0
+debug: CCFLAGS += --coverage
+debug: CCFLAGS += -ggdb
+debug: CCFLAGS += -U_FORTIFY_SOURCE
+debug: CCFLAGS += -fsanitize=address
+debug: CCFLAGS += -fsanitize=undefined
+debug: linty
+
+CSUPPRESSIONS = --suppress=missingIncludeSystem --suppress=invalidscanf
+cppcheck:
+	cppcheck -I. --template gcc --enable=all $(CSUPPRESSIONS) *.[ch]

--- a/samples/ProC/dbFuncs.pc
+++ b/samples/ProC/dbFuncs.pc
@@ -1,0 +1,225 @@
+#ifndef  ORA_PROC
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#endif
+
+
+#define SQLCA_STORAGE_CLASS extern
+#include <sqlca.h>
+
+
+#include "../../SeisMgr/dbselect/dbDefaults.h"
+
+
+#define BUF_LEN 30
+#define TAB_DNE -942
+#define INDX_DNE -1418
+#define NO_DATA  1403
+#define TOO_MANY -2112
+
+EXEC SQL BEGIN DECLARE SECTION;
+
+static char TheDataBase[50]="";
+static VARCHAR TheSID[20];
+static double NCALPER  = -999.0;
+static double NCALIB   = -999.0;
+static double CALPER   = -999.0;
+static double CALRATIO = -999.0;
+EXEC SQL END DECLARE SECTION;
+
+
+
+
+void getSensorInstrumentCalibInfo(double* ncalper, double* ncalib, double* calper, double* calratio )
+{
+   *ncalper  = NCALPER;
+   *ncalib   = NCALIB;
+   *calper   = CALPER;
+   *calratio = CALRATIO;
+
+   NCALPER  = -999.0;
+   NCALIB   = -999.0;
+   CALPER   = -999.0;
+   CALRATIO = -999.0;
+}
+/* ---------------------------------------------------------- */
+
+
+
+
+
+
+static int ConnectedToOracle(void)
+{
+   int result = 1;
+   EXEC SQL DECLARE TestCursor CURSOR FOR
+      SELECT * FROM SYS.DUAL;
+
+   EXEC SQL OPEN TestCursor;
+   if( sqlca.sqlcode < 0 ) result = 0;
+
+   EXEC SQL CLOSE TestCursor;
+
+   return result;
+}
+/* ---------------------------------------------------------- */
+
+
+
+
+
+void DisconnectFromOracleTransfer(void)
+{
+   if( ! ConnectedToOracle() ) return;
+
+    EXEC SQL COMMIT WORK RELEASE;
+    printf("Disconnected from Oracle.\n");
+}
+/* ---------------------------------------------------------- */
+
+
+
+
+
+static int  ConnectToOracleForResponseInfo(void)
+{
+EXEC SQL BEGIN DECLARE SECTION;
+    VARCHAR     username[BUF_LEN]; 
+    VARCHAR     password[BUF_LEN];
+EXEC SQL END DECLARE SECTION;
+
+ 
+    strcpy( (char*)username.arr, dbGetQueryLogin());
+    username.len = strlen( (char*) username.arr);
+ 
+    strcpy( (char*)password.arr, dbGetQueryPasswd() );
+    password.len = strlen( (char*) password.arr);
+
+    printf("Connecting to database...\n");
+    strcpy((char*)TheSID.arr, Sid());
+    TheSID.len = strlen( (char*)TheSID.arr);
+    EXEC SQL CONNECT :username IDENTIFIED BY :password USING :TheSID; 
+    if(sqlca.sqlcode < 0){
+        printf("%s\n",sqlca.sqlerrm.sqlerrmc);
+        printf("\nCould not connect to Oracle for response information.\n");
+        printf("Connection was attempted using Username: %s\n",(char*)username.arr);
+        return 0;
+    }
+    return 1;
+ }
+/* ---------------------------------------------------------- */
+
+
+
+
+
+
+char *GetFileNameSelectString(char *station, char *component, double EpochTime)
+{
+    char fmt[] = "SELECT DIR, DFILE, RSPTYPE, NCALPER, NCALIB, CALPER, CALRATIO FROM %s I, %s S \n"
+                 "WHERE I.INID = S.INID AND STA = '%s' AND CHAN = '%s' \n"
+                 "AND  %14.3f BETWEEN S.TIME AND S.ENDTIME" ;
+
+    char *CompleteSelect ;
+
+    int length ;
+
+    length  = strlen( fmt ) + 14 + 14 + 1 ;  /* 14s for the floating points,
+						and 1 for terminator */
+    length += strlen( dbGetInstrumentTableName() ) ;
+    length += strlen( dbGetSensorTableName() ) ;
+    length += strlen( station ) ;
+    length += strlen( component ) ;
+
+    CompleteSelect = (char *) malloc( length * sizeof( char ) ) ;
+
+    sprintf( CompleteSelect , fmt , dbGetInstrumentTableName() ,
+             dbGetSensorTableName() , station , component , EpochTime ) ;
+    
+   
+    return CompleteSelect;
+}    
+/* ---------------------------------------------------------- */
+
+
+
+
+char *GetRESPfileNameFromDB(char *station, char *component, char *locid,
+                            double EpochTime , char * rtypeOut )
+{
+   
+   int StatementLen;
+   struct stat status;
+   char *FileName = 0;
+   EXEC SQL BEGIN DECLARE SECTION;
+      char *CompleteSelect;
+      VARCHAR dir[256];
+      VARCHAR dfile[64];
+      VARCHAR rsptype[ 7 ] ;
+   EXEC SQL END DECLARE SECTION;
+
+
+
+   if( !ConnectedToOracle() )
+      if(! ConnectToOracleForResponseInfo() ) return 0;
+
+
+   CompleteSelect = GetFileNameSelectString(station, component, EpochTime);
+
+   EXEC SQL DECLARE S STATEMENT;
+   EXEC SQL PREPARE S FROM :CompleteSelect;
+   EXEC SQL DECLARE RESP_CURSOR CURSOR FOR S;
+   EXEC SQL OPEN RESP_CURSOR;
+
+   while( 1 ) {
+      EXEC SQL FETCH RESP_CURSOR INTO :dir, :dfile, :rsptype, :NCALPER, :NCALIB, :CALPER, :CALRATIO; 
+      if( sqlca.sqlcode == 0 ){
+         char *pDfile = 0 ;
+
+         dir.arr[dir.len] = '\0';
+         dfile.arr[dfile.len] = '\0';
+         rsptype.arr[rsptype.len] = '\0';
+
+         if( locid && *locid && strcmp( locid, "*" ) ) {
+            pDfile = strrchr( (char *) dfile.arr , '.' ) ;
+            if( *( --pDfile ) == '.' )
+               continue ;
+
+            --pDfile ;
+
+            if( strncmp( pDfile, locid, 2 ) )
+               continue ;
+         }
+         
+         
+         FileName = (char *) malloc( dir.len + dfile.len + 2);
+         strcpy(FileName, (char*)dir.arr );
+         strcat(FileName, "/" );
+         strcat(FileName,  (char*)dfile.arr );
+         break ;
+      }
+      else if( sqlca.sqlcode < 0 ){
+         printf("%s\n",sqlca.sqlerrm.sqlerrmc);
+         printf("SQL is:\n %s \n\n", CompleteSelect);
+         break ;
+      }
+      else
+         break ;
+   }
+   
+   EXEC SQL CLOSE RESP_CURSOR;
+   free(CompleteSelect);
+
+   if( ! FileName )return 0;
+
+   if( stat( FileName, &status ) == -1){
+      printf("Problem: Response file: (%s) not found!\n", FileName);
+      free( FileName );
+      FileName = 0;
+   }
+   strcpy ( rtypeOut ,  (char*)rsptype.arr ) ;
+   return FileName;
+ }
+/* ---------------------------------------------------------- */

--- a/samples/Text/filenames/README.pc
+++ b/samples/Text/filenames/README.pc
@@ -1,0 +1,121 @@
+This is the README for GNU awk 4 under Windows32, OS/2, and DOS.
+
+    Gawk has been compiled and tested under OS/2, DOS, and Windows32 using
+the GNU development tools from DJ Delorie (DJGPP; DOS with special
+support for long filenames on Windows), Eberhard Mattes (EMX; OS/2,
+DOS, and Windows32 with rsxnt), and Jan-Jaap van der Heijden and Mumit Khan
+(Mingw32; Windows32).
+
+    The Cygwin environment (http://cygwin.com) may also be used
+to compile and run gawk under Windows.  For Cygwin, building and
+installation is the same as under Unix:
+
+	tar -xvpzf gawk-4.1.x.tar.gz
+	cd gawk-4.1.x
+	./configure && make
+
+The `configure' step takes a long time, but works otherwise.
+
+******************************** N O T E **********************************
+* The `|&' operator only works when gawk is compiled for Cygwin.  Neither *
+* socket support nor two-way pipes work in any other Windows environment! *
+***************************************************************************
+
+Building gawk
+-------------
+
+Copy the files in the `pc' directory (EXCEPT for `ChangeLog') to the
+directory with the rest of the gawk sources.  (The subdirectories of 
+`pc' need not be copied.)  The Makefile contains a configuration 
+section with comments, and may need to be edited in order to work
+with your make utility.
+
+The "prefix" line in the Makefile is used during the install of gawk
+(and in building igawk.bat and igawk.cmd). Since the libraries for
+gawk will be installed under $(prefix)/lib/awk (e.g., /gnu/lib/awk),
+it is convenient to have this directory in DEFPATH of config.h. 
+
+The makefile contains a number of targets for building various DOS and
+OS/2 versions.  A list of targets will be printed if the make command is
+given without a target.  As an example, to build gawk using the djgpp
+tools, enter "make djgpp".
+
+
+Testing and installing gawk
+---------------------------
+
+The command "make test" (and possibly "make install") requires several 
+Unix-like tools, including an sh-like shell, sed, cp, and cmp.  Only 
+dmake and GNU make are known to work on "make test".
+
+There are two methods for the install: Method 1 uses a typical Unix-like 
+approach and requires cat, cp, mkdir, sed, and sh; method 2 uses gawk 
+and batch files. See the configuration section of the makefile.
+
+The file test/Makefile will need some editing (especially for DOS). A
+sample makefile with comments appears in pc/Makefile.tst, and can be
+used to modify test/Makefile for your platform.  In addition, some
+files in the test directory may need to have their end-of-line markers
+converted, as described in Makefile.tst.
+
+As with building gawk, the OS, shell, and long filename issues come into
+play when testing, too.  If you are testing gawk on a LFN aware system with
+some LFN aware tools, you may have problems if the shell that you specify in
+test/Makefile is not LFN aware.  This problem will apply whether or not
+you are building a LFN aware gawk.  See the comments in pc/Makefile.tst
+for more information on this.
+
+It is routine to install by hand, but note that the install target also
+builds igawk.bat and igawk.cmd, which are used to add an include
+facility to gawk (and which require sh).
+
+
+Gawk thanks
+-----------
+
+The DOS maintainers wish to express their thanks to Eli Zaretskii
+<eliz@gnu.org> for his work and for the many conversations concerning
+gawk, make, and djgpp.  His FAQ for djgpp is essential reading, and he
+was always willing to answer our questions (even when we didn't read
+the relevant portions of the FAQ :).
+
+We are indebted to Juan Grigera <juan@biophnet.unlp.edu.ar> for
+additional help on changes for Windows32.
+
+
+----
+If you have any problems with the DOS or OS/2 versions of Gawk, 
+please send bug reports (along with the version and compiler used) to 
+
+   Scott Deifik, scottd.mail@sbcglobal.net (DOS versions)
+or
+   andreas.buening@nexgo.de (OS/2 version)
+
+Support for Windows32 started in gawk-3.0.3.
+
+----
+From: Eric Pement <eric.pement@gmail.com>
+Newsgroups: comp.lang.awk
+Subject: djgpp Gawk ver. 4.0 available
+Date: Tue, 26 Jul 2011 06:42:00 -0700 (PDT)
+MS Windows users:
+
+The DJGPP compilation of GNU awk v4.0.0 is now available here:
+
+   ftp://ftp.delorie.com/pub/djgpp/current/v2gnu/gwk400b.zip
+
+For those who don't know the difference between the DGJPP compile and
+other versions compiled for Windows, the most noticeable to me is that
+it supports Unix-style use of 'single' and "double" quoting. Example:
+
+ [c:\tmp]> :: normal Windows awk requires complex quoting
+ [c:\tmp]> gawk "BEGIN{ print \"hello, world\" }"
+ hello, world
+ [c:\tmp]> :: DJGPP compile of awk permits Unix quoting in CMD
+ [c:\tmp]> djgawk 'BEGIN{ print "hello, world" }'
+ hello, world
+
+Syntactic sugar? Sure. But it makes life easier in a Windows
+environment, and without installing Cygwin ...
+
+Eric P.

--- a/samples/pkg-config/luajit.pc
+++ b/samples/pkg-config/luajit.pc
@@ -1,0 +1,25 @@
+# Package information for LuaJIT to be used by pkg-config.
+majver=2
+minver=1
+relver=0
+version=${majver}.${minver}.${relver}
+abiver=5.1
+
+prefix=~/torch/install
+multilib=lib
+exec_prefix=${prefix}
+libdir=${exec_prefix}/${multilib}
+libname=luajit
+includedir=${prefix}/include -I${prefix}/include/TH
+
+INSTALL_LMOD=${prefix}/share/lua/${abiver}
+INSTALL_CMOD=${prefix}/${multilib}/lua/${abiver}
+
+Name: LuaJIT
+Description: Just-in-time compiler for Lua
+URL: http://luajit.org
+Version: ${version}
+Requires:
+Libs: -L${libdir} -l${libname}
+Libs.private: -Wl,-E -lm -ldl
+Cflags: -I${includedir}

--- a/samples/pkg-config/yaws.pc.in
+++ b/samples/pkg-config/yaws.pc.in
@@ -1,0 +1,15 @@
+##
+##  yaws.pc: pkg-config(1) specification
+##
+
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib/yaws/ebin
+includedir=${prefix}/lib/yaws/include
+
+Name: yaws
+Description: Yet Another Web Server
+Version: @YAWS_VSN@
+URL: https://erlyaws.github.io/
+Libs: -pa ${libdir}
+Cflags: -I${includedir}

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -824,6 +824,13 @@ class TestHeuristics < Minitest::Test
     }, alt_name="test.p")
   end
 
+  def test_pc_by_heuristics
+    assert_heuristics({
+      "pkg-config" => all_fixtures("pkg-config", "*.pc"),
+      "Pro*C" => all_fixtures("ProC", "*.pc"),
+    })
+  end
+
   def test_php_by_heuristics
     assert_heuristics({
       "Hack" => all_fixtures("Hack", "*.php"),

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -493,6 +493,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **PowerShell:** [PowerShell/EditorSyntax](https://github.com/PowerShell/EditorSyntax)
 - **Praat:** [orhunulusahin/praatvscode](https://github.com/orhunulusahin/praatvscode)
 - **Prisma:** [prisma/vscode-prisma](https://github.com/prisma/vscode-prisma)
+- **Pro\*C:** [mikomikotaishi/c.tmbundle](https://github.com/mikomikotaishi/c.tmbundle)
 - **Processing:** [textmate/processing.tmbundle](https://github.com/textmate/processing.tmbundle)
 - **Procfile:** [benspaulding/vscode-procfile](https://github.com/benspaulding/vscode-procfile)
 - **Prolog:** [alnkpa/sublimeprolog](https://github.com/alnkpa/sublimeprolog)

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -741,6 +741,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **nanorc:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **nesC:** [cdwilson/nesC.tmbundle](https://github.com/cdwilson/nesC.tmbundle)
 - **ooc:** [nilium/ooc.tmbundle](https://github.com/nilium/ooc.tmbundle)
+- **pkg-config:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **q:** [komsit37/sublime-q](https://github.com/komsit37/sublime-q)
 - **reStructuredText:** [Lukasa/language-restructuredtext](https://github.com/Lukasa/language-restructuredtext)
 - **robots.txt:** [Nixinova/NovaGrammars](https://github.com/Nixinova/NovaGrammars)

--- a/vendor/licenses/git_submodule/language-etc.dep.yml
+++ b/vendor/licenses/git_submodule/language-etc.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: language-etc
-version: 0e56446ee854416c6cbf68aacdf5d28a3777a229
+version: 1137dbc87f6cfa0abacf18d54e56b9932010a7a0
 type: git_submodule
 homepage: https://github.com/Alhadis/language-etc
 license: isc


### PR DESCRIPTION
This pull-request adds language support for [`pkg-config`][] manifests.

## Description
[`pkg-config`][] (and its successor, [`pkgconf`][]) are build utilities for managing project dependencies, compiler options, and other auxiliary information pertaining to installed software libraries. The file format these tools use is well-established and typically installed to directories like <samp>/usr/local/share/pkgconfig/</samp>.

The `.pc` filename suffix is also used by a number of other filetypes whose usage satisfies Linguist's popularity criteria:

<dl
><dt><samp>makefile.pc</samp></dt
	><dd>Makefiles, typically with rules targeting PC platforms.</dd
><dt><samp>README.pc</samp></dt
	><dd>Project documentation specific to Windows, OS/2 and MS-DOS.</dd
><dt><a href="https://docs.oracle.com/cd/E11882_01/appdev.112/e10825/toc.htm">Oracle Pro&#x2A;C/C++</a></dt
	><dd>A superset of C/C++ with embedded SQL statements that uses <code>.pc</code> as its file extension.</dd
></dl>


## Checklist
-	[x] **I am adding a new language.**
	-	[x] **The extensions of the new language are used in hundreds of repositories:**
		-	`.pc`: [~251k search results](https://github.com/search?q=path%3A%2A%2A%2F%3F%2A.pc&type=code)  
			- Pro\*C: [~1.3k search results](https://github.com/search?q=path%3A%2A%2A%2F%3F%2A.pc+%2F%5B%5E%5C%5C%5D%5Cn%5Ct%2F+-path%3A%2A%2A%2Fmakefile.pc+-path%3A%2A%2A%2Freadme.pc+-repo%3AHalfTough%2FPonyDrinkingCardGame&type=code)
		-	`.pc.in`: [~31.1 search results](https://github.com/search?q=path%3A%2A%2A%2F%3F%2A.pc.in&type=code)
		-	`makefile.pc`: [196 files](https://github.com/search?q=path%3A%2A%2A%2Fmakefile.pc&type=code)
		-	`README.pc`: [324 files](https://github.com/search?q=path%3A%2A%2A%2Freadme.pc&type=code)
	-	[x] **I have included real-world usage samples for each extension:**  
		- `dbFuncs.pc`:  [Source](https://github.com/llnl/SAC2000/blob/c347f4fc367b25b226bc89c6bc62255f508293bc/src/icm/oracle/dbFuncs.pc) | [MIT](https://github.com/llnl/SAC2000/blob/1666a4da3fec109f2321a63b78397b957cb8c761/LICENSE)
		- `luajit.pc`:   [Source](https://github.com/imodpasteur/lutorpy/blob/e2e33fd356681dc9b3199f2cb59ea615a29fb2a6/luajit.pc) | [MIT](https://github.com/imodpasteur/lutorpy/blob/91ba16f6ecedafef06be802ea1950f5bf4108f1f/LICENSE.txt)
		- `makefile.pc`: [Source](https://github.com/drdnar/open-adventure-ce/blob/af366f580a1e932b2e0c7da13112ce5785f968f7/makefile.pc) | [BSD 2-Clause](https://github.com/drdnar/open-adventure-ce/blob/4209b82c5a31fa126eac7f33b0124ae7786685f4/COPYING)
		- `README.pc`:   [Source](https://github.com/Distrotech/gawk/blob/9eb3ed0c70149895f69cd04d6c0880b4d20a0ba1/README_d/README.pc) | [GPL-3.0](https://github.com/Distrotech/gawk/blob/6f3612539c425da2bc1d34db621696e6a273b01c/COPYING)
		- `yaws.pc.in`:  [Source](https://github.com/erlyaws/yaws/blob/0c1d25e59850e5cb7fcc3f9f058af3e3997c0703/yaws.pc.in) | [BSD 3-Clause](https://github.com/erlyaws/yaws/blob/781124719103b96a11de55cfc790911e587bb2b3/LICENSE)
	-	[x] **I have** ~~included~~ **_updated_ a syntax highlighting grammar:**  
		[`Alhadis/language-etc`](https://github.com/Alhadis/language-etc) was bumped to [`1137dbc`](https://github.com/Alhadis/language-etc/commit/1137dbc87f6cfa0abacf18d54e56b9932010a7a0)
	-	[x] **I have added a colour:**
		-	`pkg-config`: ~~`#75b5aa`~~ `#2b5e82`  
			~~This was selected at random, as neither the `pkg-config` nor `pkgconf` projects have dedicated logos or branding from which to source a colour.<br/>~~ **UPDATE:** As per @Nixinova's suggestion, I've changed it to the colour used by [FreeDesktop.org's logo](https://www.freedesktop.org/wiki/logo.png).
		-	Oracle Pro*C: `#bb8368`  
			This was sampled from Larry Ellison's forehead:  
			<img src="https://github.com/user-attachments/assets/606ada13-6c74-4bb3-9bd9-2a6ba08fe38b" width="300"/>
	-	[x] **I have updated the heuristics.**  
		-	`pkg-config`: Manifests are required to include `Name:`, `Description:` and `Version:` fields[^2] (albeit not necessarily in that order).
		-	Pro*C: Embedded SQL statements all start with `EXEC SQL`.[^1]

[^1]: https://docs.oracle.com/cd/E11882_01/appdev.112/e10825/pc_02prc.htm#i10149 <q>The only special requirement for building SQL statements into your host program is that you begin them with the keywords EXEC SQL and end them with a semicolon.</q>

[^2]: https://github.com/pkgconf/pkgconf/blob/32152be3498f0d9c38dec63ab11a7ae59726db90/man/pc.5#L82-L90

<!-- Referenced links -->
[`pkg-config`]: https://freedesktop.org/wiki/Software/pkg-config/
[`pkgconf`]:    https://github.com/pkgconf/pkgconf