### PR TITLE
Add Logos language samples

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -934,7 +934,7 @@
 	url = https://github.com/whitequark/llvm.tmbundle
 [submodule "vendor/grammars/logos"]
 	path = vendor/grammars/logos
-	url = https://github.com/Cykey/Sublime-Logos
+	url = https://github.com/shammyali/logos-tmlanguage.git
 [submodule "vendor/grammars/logtalk.tmbundle"]
 	path = vendor/grammars/logtalk.tmbundle
 	url = https://github.com/textmate/logtalk.tmbundle

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4334,10 +4334,12 @@ LiveScript:
   language_id: 208
 Logos:
   type: programming
+  color: "#D4AF37"
   extensions:
-  - ".xm"
+  - ".logos"
   - ".x"
   - ".xi"
+  - ".xm"
   ace_mode: text
   tm_scope: source.logos
   language_id: 209

--- a/samples/Logos/classifier.logos
+++ b/samples/Logos/classifier.logos
@@ -1,0 +1,140 @@
+module vryx.canvas.classifier
+
+pub type DocKind =
+  | EmiratesId
+  | DrivingLicense
+  | VehicleMulkiya
+  | Passport
+  | TradeLicense
+  | Invoice
+  | InsurancePolicy
+  | GenericDoc
+
+pub string_length(s: String) -> Int
+pub string_slice(s: String, from: Int, len: Int) -> String
+pub string_contains(haystack: String, needle: String) -> Bool
+pub string_to_lower(s: String) -> String
+
+has(text: String, needle: String) -> Bool =
+  string_contains(text, needle)
+
+is_digit(ch: String) -> Bool =
+  ch == "0" || ch == "1" || ch == "2" || ch == "3" || ch == "4" ||
+  ch == "5" || ch == "6" || ch == "7" || ch == "8" || ch == "9"
+
+char_at(s: String, index: Int) -> String =
+  string_slice(s, index, 1)
+
+eid_at(text: String, i: Int) -> Bool =
+  is_digit(char_at(text, i)) &&
+  is_digit(char_at(text, i + 1)) &&
+  is_digit(char_at(text, i + 2)) &&
+  char_at(text, i + 3) == "-" &&
+  is_digit(char_at(text, i + 4)) &&
+  is_digit(char_at(text, i + 5)) &&
+  is_digit(char_at(text, i + 6)) &&
+  is_digit(char_at(text, i + 7)) &&
+  char_at(text, i + 8) == "-" &&
+  is_digit(char_at(text, i + 9)) &&
+  is_digit(char_at(text, i + 10)) &&
+  is_digit(char_at(text, i + 11)) &&
+  is_digit(char_at(text, i + 12)) &&
+  is_digit(char_at(text, i + 13)) &&
+  is_digit(char_at(text, i + 14)) &&
+  is_digit(char_at(text, i + 15)) &&
+  char_at(text, i + 16) == "-" &&
+  is_digit(char_at(text, i + 17))
+
+eid_scan_from(text: String, i: Int) -> Bool =
+  if i + 18 > string_length(text) then false
+  else if eid_at(text, i) then true
+  else eid_scan_from(text, i + 1)
+
+has_eid_format(text: String) -> Bool =
+  eid_scan_from(text, 0)
+
+has_mrz_passport(text: String) -> Bool =
+  has(text, "p<") &&
+  (has(text, "p<are") || has(text, "p<uae") || has(text, "p<ind") ||
+   has(text, "p<gbr") || has(text, "p<pak") || has(text, "p<qat") ||
+   has(text, "p<sau") || has(text, "p<omn"))
+
+is_eid(text: String) -> Bool =
+  has(text, "resident identity card") ||
+  has(text, "identity & citizenship") ||
+  has(text, "federal authority for identity") ||
+  has_eid_format(text) ||
+  (has(text, "card number") && (has(text, "occupation") || has(text, "employer") || has(text, "sponsor")))
+
+is_driving_license(text: String) -> Bool =
+  has(text, "driving licence") ||
+  has(text, "driving license") ||
+  has(text, "licence no") ||
+  has(text, "license no")
+
+is_vehicle_mulkiya(text: String) -> Bool =
+  has(text, "mulkiya") ||
+  has(text, "vehicle registration") ||
+  has(text, "vehicle license") ||
+  has(text, "vehicle licence") ||
+  has(text, "chassis no") ||
+  has(text, "chassis number") ||
+  has(text, "chasis no") ||
+  has(text, "chasis number") ||
+  has(text, "vch. type") ||
+  has(text, "eng. no") ||
+  has(text, "plate no") ||
+  has(text, "reg. date")
+
+is_passport(text: String) -> Bool =
+  has(text, "passport no") ||
+  has(text, "passport number") ||
+  has_mrz_passport(text)
+
+is_trade_license(text: String) -> Bool =
+  has(text, "trade license") ||
+  has(text, "trade licence") ||
+  has(text, "commercial registration")
+
+is_invoice(text: String) -> Bool =
+  has(text, "tax invoice") ||
+  has(text, "invoice no")
+
+is_insurance_policy(text: String) -> Bool =
+  has(text, "policy schedule") ||
+  has(text, "policy no")
+
+pub classify_doc(text: String) -> DocKind =
+  let lower = string_to_lower(text) in
+  if is_eid(lower) then EmiratesId
+  else if is_driving_license(lower) then DrivingLicense
+  else if is_vehicle_mulkiya(lower) then VehicleMulkiya
+  else if is_passport(lower) then Passport
+  else if is_trade_license(lower) then TradeLicense
+  else if is_invoice(lower) then Invoice
+  else if is_insurance_policy(lower) then InsurancePolicy
+  else GenericDoc
+
+pub doc_kind_tag(kind: DocKind) -> Int =
+  match kind with
+    | EmiratesId => 1
+    | DrivingLicense => 2
+    | VehicleMulkiya => 3
+    | Passport => 4
+    | TradeLicense => 5
+    | Invoice => 6
+    | InsurancePolicy => 7
+    | GenericDoc => 8
+
+pub doc_kind_name(kind: DocKind) -> String =
+  match kind with
+    | EmiratesId => "emirates_id"
+    | DrivingLicense => "driving_license"
+    | VehicleMulkiya => "vehicle_mulkiya"
+    | Passport => "passport"
+    | TradeLicense => "trade_license"
+    | Invoice => "invoice"
+    | InsurancePolicy => "insurance_policy"
+    | GenericDoc => "generic"
+
+main() -> Int = doc_kind_tag(classify_doc("hello")) - 8

--- a/samples/Logos/fact_types.logos
+++ b/samples/Logos/fact_types.logos
@@ -1,0 +1,13 @@
+module vryx.canvas.state.fact_types
+
+pub type Fact =
+  | ArtifactV1(String, String, String, String, String, Int)
+  | ExtractionV1(String, String, String, Int)
+  | ParsedV1(String, String, String, String, String, String, String, String, String, String, String, Int)
+  | CustomerV1(String, String, String, String, String, String, String, String, String, String, Int, Int)
+  | ContactV1(String, String, String, String, String, Int)
+  | ManualAttachV1(String, String, String, String, String, String, String, Int)
+
+pub type FactList =
+  | NoFacts
+  | FactCons(Fact, FactList)

--- a/samples/Logos/parser_common.logos
+++ b/samples/Logos/parser_common.logos
@@ -1,0 +1,248 @@
+module vryx.canvas.parsers.common
+
+pub type StringList =
+  | Nil
+  | Cons(String, StringList)
+
+pub string_length(s: String) -> Int
+pub string_concat(a: String, b: String) -> String
+pub string_slice(s: String, from: Int, len: Int) -> String
+pub string_contains(haystack: String, needle: String) -> Bool
+pub string_to_lower(s: String) -> String
+
+pub char_at(s: String, i: Int) -> String =
+  string_slice(s, i, 1)
+
+pub has(text: String, needle: String) -> Bool =
+  string_contains(string_to_lower(text), string_to_lower(needle))
+
+pub is_digit(ch: String) -> Bool =
+  ch == "0" || ch == "1" || ch == "2" || ch == "3" || ch == "4" ||
+  ch == "5" || ch == "6" || ch == "7" || ch == "8" || ch == "9"
+
+pub is_upper(ch: String) -> Bool =
+  ch == "A" || ch == "B" || ch == "C" || ch == "D" || ch == "E" ||
+  ch == "F" || ch == "G" || ch == "H" || ch == "I" || ch == "J" ||
+  ch == "K" || ch == "L" || ch == "M" || ch == "N" || ch == "O" ||
+  ch == "P" || ch == "Q" || ch == "R" || ch == "S" || ch == "T" ||
+  ch == "U" || ch == "V" || ch == "W" || ch == "X" || ch == "Y" || ch == "Z"
+
+pub is_lower(ch: String) -> Bool =
+  ch == "a" || ch == "b" || ch == "c" || ch == "d" || ch == "e" ||
+  ch == "f" || ch == "g" || ch == "h" || ch == "i" || ch == "j" ||
+  ch == "k" || ch == "l" || ch == "m" || ch == "n" || ch == "o" ||
+  ch == "p" || ch == "q" || ch == "r" || ch == "s" || ch == "t" ||
+  ch == "u" || ch == "v" || ch == "w" || ch == "x" || ch == "y" || ch == "z"
+
+pub is_alpha(ch: String) -> Bool =
+  is_upper(ch) || is_lower(ch)
+
+pub is_alnum(ch: String) -> Bool =
+  is_alpha(ch) || is_digit(ch)
+
+pub is_sep(ch: String) -> Bool =
+  ch == " " || ch == "\t" || ch == ":" || ch == "." || ch == "," || ch == ";" || ch == "-"
+
+pub is_line_break(ch: String) -> Bool =
+  ch == "\n" || ch == "\r"
+
+pub trim_left(s: String) -> String =
+  if string_length(s) == 0 then s
+  else if is_sep(char_at(s, 0)) then trim_left(string_slice(s, 1, string_length(s) - 1))
+  else s
+
+pub trim_right_len(s: String, n: Int) -> Int =
+  if n <= 0 then 0
+  else if is_sep(char_at(s, n - 1)) || is_line_break(char_at(s, n - 1)) then trim_right_len(s, n - 1)
+  else n
+
+pub trim(s: String) -> String =
+  let left = trim_left(s) in
+  string_slice(left, 0, trim_right_len(left, string_length(left)))
+
+pub first_line(s: String) -> String =
+  first_line_at(s, 0)
+
+pub first_line_at(s: String, i: Int) -> String =
+  if i >= string_length(s) then s
+  else if is_line_break(char_at(s, i)) then string_slice(s, 0, i)
+  else first_line_at(s, i + 1)
+
+pub after_first_line(s: String) -> String =
+  after_first_line_at(s, 0)
+
+pub after_first_line_at(s: String, i: Int) -> String =
+  if i >= string_length(s) then ""
+  else if is_line_break(char_at(s, i)) then string_slice(s, i + 1, string_length(s) - i - 1)
+  else after_first_line_at(s, i + 1)
+
+pub starts_with_at(text: String, needle: String, i: Int, j: Int) -> Bool =
+  if j >= string_length(needle) then true
+  else if i + j >= string_length(text) then false
+  else if char_at(text, i + j) == char_at(needle, j) then starts_with_at(text, needle, i, j + 1)
+  else false
+
+pub index_of_from(text: String, needle: String, i: Int) -> Int =
+  if string_length(needle) == 0 then 0
+  else if i + string_length(needle) > string_length(text) then -1
+  else if starts_with_at(text, needle, i, 0) then i
+  else index_of_from(text, needle, i + 1)
+
+pub index_of(text: String, needle: String) -> Int =
+  index_of_from(text, needle, 0)
+
+pub token_until_sep(s: String, i: Int) -> String =
+  if i >= string_length(s) then s
+  else if is_sep(char_at(s, i)) || is_line_break(char_at(s, i)) then string_slice(s, 0, i)
+  else token_until_sep(s, i + 1)
+
+pub first_word(s: String) -> String =
+  string_to_lower(token_until_sep(trim(s), 0))
+
+pub blocked_word(word: String) -> Bool =
+  word == "vehicle" || word == "nationality" || word == "name" || word == "owner" ||
+  word == "sponsor" || word == "date" || word == "issue" || word == "issuing" ||
+  word == "expiry" || word == "expires" || word == "license" || word == "licence" ||
+  word == "licensing" || word == "driving" || word == "emirates" || word == "identity" ||
+  word == "federal" || word == "resident" || word == "citizenship" || word == "signature" ||
+  word == "place" || word == "passport" || word == "sex" || word == "gender" ||
+  word == "birth" || word == "plate" || word == "chassis" || word == "chasis" ||
+  word == "engine" || word == "model" || word == "make" || word == "origin" ||
+  word == "year" || word == "color" || word == "colour" || word == "category" ||
+  word == "class" || word == "mortgage" || word == "policy" || word == "insurance" ||
+  word == "reg" || word == "registration" || word == "card" || word == "occupation" ||
+  word == "employer" || word == "valid" || word == "traffic" || word == "toyota" ||
+  word == "lexus" || word == "nissan" || word == "honda" || word == "mitsubishi" ||
+  word == "mazda" || word == "ford" || word == "chevrolet" || word == "hyundai" ||
+  word == "kia" || word == "bmw" || word == "mercedes" || word == "audi" ||
+  word == "land" || word == "range" || word == "jeep" || word == "volvo"
+
+pub starts_with_label_word(s: String) -> Bool =
+  blocked_word(first_word(s))
+
+pub month_day_sep_at(s: String, i: Int) -> Bool =
+  char_at(s, i) == "/" || char_at(s, i) == "-"
+
+pub date_at(s: String, i: Int) -> Bool =
+  if i + 8 > string_length(s) then false
+  else
+    is_digit(char_at(s, i)) &&
+    (is_digit(char_at(s, i + 1)) || month_day_sep_at(s, i + 1)) &&
+    (month_day_sep_at(s, i + 1) || month_day_sep_at(s, i + 2)) &&
+    (is_digit(char_at(s, i + 2)) || is_digit(char_at(s, i + 3))) &&
+    (month_day_sep_at(s, i + 3) || month_day_sep_at(s, i + 4) || month_day_sep_at(s, i + 5)) &&
+    (is_digit(char_at(s, i + 4)) || is_digit(char_at(s, i + 5)) || is_digit(char_at(s, i + 6)))
+
+pub date_len_at(s: String, i: Int, n: Int) -> Int =
+  if i + n >= string_length(s) then n
+  else if n >= 10 then n
+  else if is_digit(char_at(s, i + n)) || month_day_sep_at(s, i + n) then date_len_at(s, i, n + 1)
+  else n
+
+pub first_date_from(s: String, i: Int) -> String =
+  if i >= string_length(s) then ""
+  else if date_at(s, i) then string_slice(s, i, date_len_at(s, i, 0))
+  else first_date_from(s, i + 1)
+
+pub date_shape(s: String) -> String =
+  first_date_from(s, 0)
+
+pub word_len_at(s: String, i: Int) -> Int =
+  if i >= string_length(s) then 0
+  else if is_alpha(char_at(s, i)) || char_at(s, i) == "'" || char_at(s, i) == "-" then 1 + word_len_at(s, i + 1)
+  else 0
+
+pub count_name_words(s: String, i: Int, count: Int) -> Int =
+  if i >= string_length(s) then count
+  else if is_sep(char_at(s, i)) then count_name_words(s, i + 1, count)
+  else
+    let len = word_len_at(s, i) in
+    if len >= 2 then count_name_words(s, i + len, count + 1) else -100
+
+pub name_shape(s: String) -> String =
+  let t = trim(s) in
+  let words = count_name_words(t, 0, 0) in
+  if words >= 2 && words <= 8 && not starts_with_label_word(t) then t else ""
+
+pub sex_shape(s: String) -> String =
+  let t = trim(s) in
+  if string_length(t) >= 1 && (char_at(t, 0) == "M" || char_at(t, 0) == "m") then "M"
+  else if string_length(t) >= 1 && (char_at(t, 0) == "F" || char_at(t, 0) == "f") then "F"
+  else ""
+
+pub alnum_token_from(s: String, i: Int, len: Int) -> String =
+  if i + len >= string_length(s) then string_slice(s, i, len)
+  else if is_alnum(char_at(s, i + len)) || char_at(s, i + len) == "-" then alnum_token_from(s, i, len + 1)
+  else string_slice(s, i, len)
+
+pub first_alnum_id_from(s: String, i: Int) -> String =
+  if i >= string_length(s) then ""
+  else if is_alnum(char_at(s, i)) then
+    let tok = alnum_token_from(s, i, 0) in
+    if string_length(tok) >= 4 && string_length(tok) <= 20 then tok else first_alnum_id_from(s, i + 1)
+  else first_alnum_id_from(s, i + 1)
+
+pub alnum_id_shape(s: String) -> String =
+  first_alnum_id_from(s, 0)
+
+pub apply_shape(value: String, shape: String) -> String =
+  if shape == "date" then date_shape(value)
+  else if shape == "name" then name_shape(value)
+  else if shape == "sex" then sex_shape(value)
+  else if shape == "alnum" then alnum_id_shape(value)
+  else trim(value)
+
+pub line_candidate(tail: String, shape: String) -> String =
+  let line = trim(first_line(tail)) in
+  if line == "" then ""
+  else
+    let shaped = apply_shape(line, shape) in
+    if shape != "" then shaped
+    else if starts_with_label_word(line) then "" else shaped
+
+pub next_line_candidate(rest: String, shape: String, depth: Int) -> String =
+  if depth <= 0 || rest == "" then ""
+  else
+    let line = trim(first_line(rest)) in
+    let shaped = apply_shape(line, shape) in
+    let cand = if line == "" then "" else if shape != "" then shaped else if starts_with_label_word(line) then "" else shaped in
+    if cand != "" then cand else next_line_candidate(after_first_line(rest), shape, depth - 1)
+
+pub value_after_one(text: String, label: String, shape: String) -> String =
+  let lower = string_to_lower(text) in
+  let idx = index_of(lower, string_to_lower(label)) in
+  if idx < 0 then ""
+  else
+    let tail = trim_left(string_slice(text, idx + string_length(label), string_length(text) - idx - string_length(label))) in
+    let same = line_candidate(tail, shape) in
+    if same != "" then same else next_line_candidate(after_first_line(tail), shape, 25)
+
+pub value_after_shape(text: String, labels: StringList, shape: String) -> String =
+  match labels with
+    | Nil => ""
+    | Cons(label, rest) =>
+        let value = value_after_one(text, label, shape) in
+        if value != "" then value else value_after_shape(text, rest, shape)
+
+pub value_after(text: String, labels: StringList) -> String =
+  value_after_shape(text, labels, "")
+
+pub eid_at(text: String, i: Int) -> Bool =
+  i + 18 <= string_length(text) &&
+  is_digit(char_at(text, i)) && is_digit(char_at(text, i + 1)) && is_digit(char_at(text, i + 2)) &&
+  char_at(text, i + 3) == "-" &&
+  is_digit(char_at(text, i + 4)) && is_digit(char_at(text, i + 5)) && is_digit(char_at(text, i + 6)) && is_digit(char_at(text, i + 7)) &&
+  char_at(text, i + 8) == "-" &&
+  is_digit(char_at(text, i + 9)) && is_digit(char_at(text, i + 10)) && is_digit(char_at(text, i + 11)) && is_digit(char_at(text, i + 12)) &&
+  is_digit(char_at(text, i + 13)) && is_digit(char_at(text, i + 14)) && is_digit(char_at(text, i + 15)) &&
+  char_at(text, i + 16) == "-" && is_digit(char_at(text, i + 17))
+
+pub first_eid_from(text: String, i: Int) -> String =
+  if i + 18 > string_length(text) then ""
+  else if eid_at(text, i) then string_slice(text, i, 18)
+  else first_eid_from(text, i + 1)
+
+pub first_eid(text: String) -> String =
+  first_eid_from(text, 0)
+
+pub main() -> Int = 0

--- a/samples/Logos/reducer.logos
+++ b/samples/Logos/reducer.logos
@@ -1,0 +1,85 @@
+module vryx.canvas.state.reducer
+
+import customer_card
+import fact_types
+import customer_match
+import customer_attach
+
+pub update_customer(list: CustomerList, id: String, replacement: CustomerCard) -> CustomerList =
+  match list with
+    | NoCustomers => NoCustomers
+    | CustomerCons(head, tail) =>
+        if head.customer_fact_id == id then CustomerCons(replacement, tail)
+        else CustomerCons(head, update_customer(tail, id, replacement))
+
+pub find_customer(list: CustomerList, id: String) -> CustomerCard =
+  match list with
+    | NoCustomers => empty_customer("", 0)
+    | CustomerCons(head, tail) => if head.customer_fact_id == id then head else find_customer(tail, id)
+
+pub add_customer(set: CustomerSet, c: CustomerCard) -> CustomerSet =
+  if set.count >= max_customers() then set
+  else CustomerSet { customers: CustomerCons(c, set.customers), count: set.count + 1, orphan_artifacts: set.orphan_artifacts }
+
+pub replace_customer(set: CustomerSet, id: String, c: CustomerCard) -> CustomerSet =
+  CustomerSet { customers: update_customer(set.customers, id, c), count: set.count, orphan_artifacts: set.orphan_artifacts }
+
+pub apply_parsed_eid(set: CustomerSet, fact_id: String, artifact_id: String, extraction_id: String, side: String, name: String, eid: String, dob: String, nat: String, sex: String, expiry: String, ts_ms: Int) -> CustomerSet =
+  let eid_match = index_for_eid(set, eid) in
+  let name_match = if eid_match == "" then index_for_name(set, name) else eid_match in
+  let target = if name_match == "" then fact_id else name_match in
+  let base = if name_match == "" then empty_customer(fact_id, ts_ms) else find_customer(set.customers, name_match) in
+  let enriched = with_identity(update_side(base, side), artifact_id, fact_id, name, eid, dob, nat, sex, ts_ms) in
+  let attached = attach_dedup(enriched, AttachedDoc { fact_id: fact_id, filename: "", doc_kind: "emirates_id", doc_side: side, expiry: expiry }) in
+  if name_match == "" then add_customer(set, attached) else replace_customer(set, target, attached)
+
+pub apply_parsed_other(set: CustomerSet, fact_id: String, artifact_id: String, doc_kind: String, side: String, name: String, expiry: String) -> CustomerSet =
+  let target = index_for_name(set, name) in
+  if target == "" then set
+  else
+    let base = find_customer(set.customers, target) in
+    let attached = attach_dedup(base, AttachedDoc { fact_id: fact_id, filename: "", doc_kind: doc_kind, doc_side: side, expiry: expiry }) in
+    replace_customer(set, target, attached)
+
+pub apply_customer_fact(set: CustomerSet, fact_id: String, source_parsed: String, source_artifact: String, name: String, eid: String, dob: String, nat: String, sex: String, side: String, face: String, age: Int, ts_ms: Int) -> CustomerSet =
+  let by_id = index_for_customer_id(set, fact_id) in
+  let by_eid = if by_id == "" then index_for_eid(set, eid) else by_id in
+  if by_eid == "" then
+    if set.count >= max_customers() then set
+    else add_customer(set, overwrite_customer(empty_customer(fact_id, ts_ms), fact_id, source_parsed, source_artifact, name, eid, dob, nat, sex, side, face, age, ts_ms))
+  else
+    replace_customer(set, by_eid, overwrite_customer(find_customer(set.customers, by_eid), fact_id, source_parsed, source_artifact, name, eid, dob, nat, sex, side, face, age, ts_ms))
+
+pub apply_contact_fact(set: CustomerSet, fact_id: String, customer_id: String, phone: String, email: String, address: String, ts_ms: Int) -> CustomerSet =
+  let target = index_for_customer_id(set, customer_id) in
+  if target == "" then set
+  else replace_customer(set, target, apply_contact(find_customer(set.customers, target), fact_id, phone, email, address, ts_ms))
+
+pub apply_manual_attach_fact(set: CustomerSet, fact_id: String, customer_id: String, artifact_id: String, doc_kind: String, side: String, filename: String, expiry: String) -> CustomerSet =
+  let target = index_for_customer_id(set, customer_id) in
+  if target == "" then set
+  else if not orphan_exists(set.orphan_artifacts, artifact_id) then set
+  else
+    let base = find_customer(set.customers, target) in
+    let attached = attach_dedup(base, AttachedDoc { fact_id: fact_id, filename: filename, doc_kind: doc_kind, doc_side: side, expiry: expiry }) in
+    replace_customer(set, target, attached)
+
+pub apply_fact(set: CustomerSet, fact: Fact) -> CustomerSet =
+  match fact with
+    | ArtifactV1(fid, hash, filename, mime, path, ts) =>
+        CustomerSet { customers: set.customers, count: set.count, orphan_artifacts: add_orphan(set.orphan_artifacts, OrphanArtifact { fact_id: fid, content_hash: hash, filename: filename, mime_hint: mime, path: path, ts_ms: ts }) }
+    | ExtractionV1(_, _, _, _) => set
+    | ParsedV1(fid, artifact, extraction, kind, side, name, eid, dob, nat, sex, expiry, ts) =>
+        if kind == "emirates_id" then apply_parsed_eid(set, fid, artifact, extraction, side, name, eid, dob, nat, sex, expiry, ts)
+        else apply_parsed_other(set, fid, artifact, kind, side, name, expiry)
+    | CustomerV1(fid, source_parsed, source_artifact, name, eid, dob, nat, sex, side, face, age, ts) =>
+        apply_customer_fact(set, fid, source_parsed, source_artifact, name, eid, dob, nat, sex, side, face, age, ts)
+    | ContactV1(fid, customer_id, phone, email, address, ts) =>
+        apply_contact_fact(set, fid, customer_id, phone, email, address, ts)
+    | ManualAttachV1(fid, customer_id, artifact_id, kind, side, filename, expiry, _) =>
+        apply_manual_attach_fact(set, fid, customer_id, artifact_id, kind, side, filename, expiry)
+
+pub fold_facts(set: CustomerSet, facts: FactList) -> CustomerSet =
+  match facts with
+    | NoFacts => set
+    | FactCons(head, tail) => fold_facts(apply_fact(set, head), tail)

--- a/samples/Logos/serialize.logos
+++ b/samples/Logos/serialize.logos
@@ -1,0 +1,76 @@
+module vryx.canvas.parsers.fields_serialize
+
+import common
+import emirates_id
+import driving_license
+import vehicle_mulkiya
+import passport
+
+pub append_field(acc: String, key: String, value: String) -> String =
+  if value == "" then acc
+  else if acc == "" then string_concat(key, string_concat("=", value))
+  else string_concat(acc, string_concat(";", string_concat(key, string_concat("=", value))))
+
+pub serialize_eid(f: EidFields) -> String =
+  append_field(
+  append_field(
+  append_field(
+  append_field(
+  append_field(
+  append_field(
+  append_field(
+  append_field("", "date_of_birth", f.date_of_birth),
+    "doc_side", f.doc_side),
+    "eid_number", f.eid_number),
+    "expiry_date", f.expiry_date),
+    "full_name", f.full_name),
+    "issuing_date", f.issuing_date),
+    "nationality", f.nationality),
+    "sex", f.sex)
+
+pub serialize_dl(f: DlFields) -> String =
+  append_field(
+  append_field(
+  append_field(
+  append_field(
+  append_field(
+  append_field(
+  append_field("", "date_of_birth", f.date_of_birth),
+    "expiry_date", f.expiry_date),
+    "full_name", f.full_name),
+    "issue_date", f.issue_date),
+    "license_class", f.license_class),
+    "license_number", f.license_number),
+    "nationality", f.nationality)
+
+pub serialize_mulkiya(f: MulkiyaFields) -> String =
+  append_field(
+  append_field(
+  append_field(
+  append_field(
+  append_field(
+  append_field(
+  append_field(
+  append_field(
+  append_field("", "chassis_number", f.chassis_number),
+    "engine_number", f.engine_number),
+    "make", f.make),
+    "model", f.model),
+    "nationality", f.nationality),
+    "owner_name", f.owner_name),
+    "plate_number", f.plate_number),
+    "registration_expiry", f.registration_expiry),
+    "year", f.year)
+
+pub serialize_passport(f: PassportFields) -> String =
+  append_field(
+  append_field(
+  append_field(
+  append_field(
+  append_field("", "date_of_birth", f.date_of_birth),
+    "expiry_date", f.expiry_date),
+    "full_name", f.full_name),
+    "nationality", f.nationality),
+    "passport_number", f.passport_number)
+
+pub main() -> Int = 0

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -359,7 +359,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Literate Haskell:** [atom-haskell/language-haskell](https://github.com/atom-haskell/language-haskell)
 - **LiveCode Script:** [Ferruslogic/vscode-livecodescript](https://github.com/Ferruslogic/vscode-livecodescript)
 - **LiveScript:** [sharktide/livescript-vscode](https://github.com/sharktide/livescript-vscode)
-- **Logos:** [Cykey/Sublime-Logos](https://github.com/Cykey/Sublime-Logos)
+- **Logos:** [shammyali/logos-tmlanguage](https://github.com/shammyali/logos-tmlanguage)
 - **Logtalk:** [textmate/logtalk.tmbundle](https://github.com/textmate/logtalk.tmbundle)
 - **LookML:** [atom/language-yaml](https://github.com/atom/language-yaml)
 - **LoomScript:** [ambethia/Sublime-Loom](https://github.com/ambethia/Sublime-Loom)

--- a/vendor/licenses/git_submodule/logos.dep.yml
+++ b/vendor/licenses/git_submodule/logos.dep.yml
@@ -1,15 +1,15 @@
 ---
 name: logos
-version: b939d35bc8d4da2ff70cb76b3321a37d573d29f7
+version: 4cc04b86ede2cfdb81a0fb6f0f67e9cde96a69ca
 type: git_submodule
-homepage: https://github.com/Cykey/Sublime-Logos
+homepage: https://github.com/shammyali/logos-tmlanguage.git
 license: mit
 licenses:
-- sources: LICENSE.txt
+- sources: LICENSE
   text: |
-    The MIT License (MIT)
+    MIT License
 
-    Copyright (c) 2016 David Murray
+    Copyright (c) 2026 Logos Technologies LLC
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Adds support for `.logos` source files under Linguist's existing `Logos` language entry.

Linguist already has a `Logos` language key for the Theos/Objective-C Logos syntax (`.x`, `.xi`, `.xm`) with `tm_scope: source.logos`, so this PR does not add a duplicate language name. It extends the existing visible language name with the Logos compiler extension and points the `source.logos` grammar slot at a new TextMate grammar for the Logos language.

**Language status:**
- Open-source compiler (Apache 2.0) at https://github.com/shammyali/logos
- TextMate grammar at https://github.com/shammyali/logos-tmlanguage
- Real samples copied from Vryx: classifier, parser common, reducer, fact types, serializer
- ML-family syntax with records, sum types, pattern matching, pure-by-default execution, and proof/refinement syntax

**Adoption note:** Logos is new and currently below Linguist's normal public-repo adoption bar. Opening this proactively so the grammar and samples are ready; happy to defer merge per project policy.

Local note: in this macOS checkout, `bundle exec rake test` currently reaches the suite but fails two pre-existing case-sensitive heuristic samples unrelated to this PR (`samples/Assembly/3D_PRG.I` and `samples/Unix Assembly/support.S`). Focused Logos detection passes for `samples/Logos/parser_common.logos => Logos`.

Closes nothing (language extension/samples).