### PR TITLE
Add Krypton language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1593,3 +1593,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/Krypton"]
+	path = vendor/grammars/Krypton
+	url = https://github.com/t3m3d/krypton.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -54,6 +54,8 @@ vendor/grammars/Jails:
 - source.jai
 vendor/grammars/K-VSCode:
 - text.k
+vendor/grammars/Krypton:
+- source.krypton
 vendor/grammars/LOLCODE-grammar-vscode:
 - source.lolcode
 vendor/grammars/Ligo-grammar:

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -443,6 +443,12 @@ disambiguations:
   - language: JSON
 - extensions: ['.k']
   rules:
+  - language: Krypton
+    pattern:
+    - '(?m)^\s*just run\s*\{'
+    - '(?m)^func\s+\w+\s*\('
+    - '(?m)^\s*emit\s'
+    - '(?m)^import\s+"k:'
   - language: KCL
     pattern:
       - '^schema [A-Za-z0-9_-]+'
@@ -453,6 +459,19 @@ disambiguations:
     - '^requires\s+"[^"]+"$'
     - '^syntax\s+\w+\s+::=.*'
     - '^endmodule$'
+- extensions: ['.ks']
+  rules:
+  - language: Krypton
+    pattern:
+    - '(?m)^\s*just run\s*\{'
+    - '(?m)^func\s+\w+\s*\('
+    - '(?m)^import\s+"k:'
+    - '(?m)^#!.*\bkr\b'
+  - language: KerboScript
+    pattern:
+    - '(?im)^\s*set\s+\w+\s+to\s'
+    - '(?im)^\s*lock\s+\w+\s+to\s'
+    - '(?im)^\s*(print|wait|stage|toggle)\b.*\.\s*$'
 - extensions: ['.l']
   rules:
   - language: Common Lisp

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3909,16 +3909,6 @@ KRL:
   tm_scope: none
   ace_mode: text
   language_id: 186
-Krypton:
-  type: programming
-  color: "#4F5AA8"
-  tm_scope: source.krypton
-  ace_mode: text
-  extensions:
-  - ".k"
-  filenames: []
-  interpreters: []
-  language_id: 824402198
 Kaitai Struct:
   type: programming
   aliases:
@@ -4034,6 +4024,16 @@ Kotlin:
   codemirror_mode: clike
   codemirror_mime_type: text/x-kotlin
   language_id: 189
+Krypton:
+  type: programming
+  color: "#7722ff"
+  extensions:
+  - ".k"
+  - ".krh"
+  - ".ks"
+  tm_scope: source.krypton
+  ace_mode: text
+  language_id: 824402198
 Kusto:
   type: data
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3909,6 +3909,16 @@ KRL:
   tm_scope: none
   ace_mode: text
   language_id: 186
+Krypton:
+  type: programming
+  color: "#4F5AA8"
+  tm_scope: source.krypton
+  ace_mode: text
+  extensions:
+  - ".k"
+  filenames: []
+  interpreters: []
+  language_id: 824402198
 Kaitai Struct:
   type: programming
   aliases:

--- a/samples/Krypton/conio.krh
+++ b/samples/Krypton/conio.krh
@@ -1,0 +1,29 @@
+// conio.krh — Krypton binding for the MSVCRT console-input functions.
+// Usage: import "head:conio"
+//
+// DLL: msvcrt.dll  (NOT yet IAT-registered in x64.k)
+// Pipeline: C-emit path only today — `kcc.sh --gcc` or a future
+// msvcrt-IAT rewrite.
+//
+// Status: this is the ONE Windows header that doesn't yet route
+// purely through the native IAT pipeline. `_kbhit` and `_getch` live
+// in MSVCRT (the C runtime) which `compiler/windows_x86/x64.k` does
+// not currently import. Until that's wired up, callers should EITHER:
+//
+//   (a) prefer pure-Krypton console APIs via `head:windows`. The
+//       equivalent of `_kbhit` is checking the queue with
+//       `PeekConsoleInputA(stdin, ...)`; the equivalent of `_getch`
+//       is reading one event via `ReadConsoleInputA(stdin, ...)`.
+//       Both live in kernel32.dll which IS in the IAT today; no
+//       msvcrt link required.
+//   (b) compile through `kcc.sh --gcc` if MSVCRT linkage is fine
+//       for the program. This is the deprecated path.
+//
+// `stdlib/terminal.k` currently imports this header. Migrating it to
+// pattern (a) is a follow-up that closes the last Windows-header
+// MSVCRT dependency.
+
+jxt {
+    func _kbhit() -> INT
+    func _getch() -> INT
+}

--- a/samples/Krypton/json.k
+++ b/samples/Krypton/json.k
@@ -1,0 +1,51 @@
+// json.k — Simple JSON builder for Krypton
+// Produces JSON strings from Krypton values
+
+module json
+
+func jsonStr(s) {
+    emit "\"" + replace(replace(s, "\\", "\\\\"), "\"", "\\\"") + "\""
+}
+
+func jsonNum(n) {
+    emit n + ""
+}
+
+func jsonBool(b) {
+    if b == "1" || b == "true" { emit "true" }
+    emit "false"
+}
+
+func jsonNull() {
+    emit "null"
+}
+
+func jsonArray(lst) {
+    if len(lst) == 0 { emit "[]" }
+    let sb = sbNew()
+    sb = sbAppend(sb, "[")
+    let cnt = length(lst)
+    let i = 0
+    for item in lst {
+        if i > 0 { sb = sbAppend(sb, ",") }
+        sb = sbAppend(sb, jsonStr(item))
+        i += 1
+    }
+    sb = sbAppend(sb, "]")
+    emit sbToString(sb)
+}
+
+func jsonObject(map) {
+    let sb = sbNew()
+    sb = sbAppend(sb, "{")
+    let ks = keys(map)
+    let cnt = length(ks)
+    let i = 0
+    for k in ks {
+        if i > 0 { sb = sbAppend(sb, ",") }
+        sb = sbAppend(sb, jsonStr(k) + ":" + jsonStr(mapGet(map, k)))
+        i += 1
+    }
+    sb = sbAppend(sb, "}")
+    emit sbToString(sb)
+}

--- a/samples/Krypton/math_utils.k
+++ b/samples/Krypton/math_utils.k
@@ -1,0 +1,177 @@
+// Math utility functions for Krypton.
+// Builtins to use directly (don't reimplement; the dispatcher routes calls
+// of these names to native machine code regardless of any user definition):
+//   abs(n)   pow(base, exp)
+// This module ships the rest: min, max, factorial, gcd, lcm, isPrime,
+// fibonacci, digitSum, digitCount, clamp, isqrt, sign, sumTo.
+
+module math_utils
+
+
+// Maximum of two values
+func max(a, b) {
+    if a > b {
+        emit a
+    }
+    emit b
+}
+
+// Minimum of two values
+func min(a, b) {
+    if a < b {
+        emit a
+    }
+    emit b
+}
+
+// Power function (base^exp for non-negative exp)
+func power(base, exp) {
+    let result = 1
+    let i = 0
+    while i < exp {
+        result *= base
+        i += 1
+    }
+    emit result
+}
+
+// Factorial
+func factorial(n) {
+    if n <= 1 {
+        emit 1
+    }
+    emit n * factorial(n - 1)
+}
+
+// Greatest common divisor (Euclidean algorithm)
+func gcd(a, b) {
+    let x = abs(a)
+    let y = abs(b)
+    while y != 0 {
+        let temp = y
+        y = x % temp
+        x = temp
+    }
+    emit x
+}
+
+// Least common multiple
+func lcm(a, b) {
+    if a == 0 {
+        emit 0
+    }
+    if b == 0 {
+        emit 0
+    }
+    emit abs(a * b) / gcd(a, b)
+}
+
+// Check if a number is prime
+func isPrime(n) {
+    if n < 2 {
+        emit 0
+    }
+    if n == 2 {
+        emit 1
+    }
+    if n % 2 == 0 {
+        emit 0
+    }
+    let i = 3
+    while i * i <= n {
+        if n % i == 0 {
+            emit 0
+        }
+        i = i + 2
+    }
+    emit 1
+}
+
+// Fibonacci number at position n
+func fibonacci(n) {
+    if n <= 0 {
+        emit 0
+    }
+    if n == 1 {
+        emit 1
+    }
+    let a = 0
+    let b = 1
+    let i = 2
+    while i <= n {
+        let temp = a + b
+        a = b
+        b = temp
+        i += 1
+    }
+    emit b
+}
+
+// Sum of digits
+func digitSum(n) {
+    let num = abs(n)
+    let sum = 0
+    while num > 0 {
+        sum = sum + num % 10
+        num = num / 10
+    }
+    emit sum
+}
+
+// Count digits in a number
+func digitCount(n) {
+    if n == 0 {
+        emit 1
+    }
+    let num = abs(n)
+    let cnt = 0
+    while num > 0 {
+        cnt += 1
+        num = num / 10
+    }
+    emit cnt
+}
+
+// Clamp a value between min and max
+func clamp(val, lo, hi) {
+    if val < lo {
+        emit lo
+    }
+    if val > hi {
+        emit hi
+    }
+    emit val
+}
+
+// Integer square root (floor)
+func isqrt(n) {
+    if n < 0 {
+        emit 0
+    }
+    if n == 0 {
+        emit 0
+    }
+    let x = n
+    let y = (x + 1) / 2
+    while y < x {
+        x = y
+        y = (x + n / x) / 2
+    }
+    emit x
+}
+
+// Sign function: returns -1, 0, or 1
+func sign(n) {
+    if n < 0 {
+        emit 0 - 1
+    }
+    if n > 0 {
+        emit 1
+    }
+    emit 0
+}
+
+// Sum of integers from 1 to n
+func sumTo(n) {
+    emit n * (n + 1) / 2
+}

--- a/samples/Krypton/semver.k
+++ b/samples/Krypton/semver.k
@@ -1,0 +1,117 @@
+// stdlib/semver.k — semantic version parse & compare in PURE KRYPTON. No C.
+//
+// Handles MAJOR.MINOR.PATCH with an optional "-prerelease" and "+build". Build
+// metadata is ignored in comparison (per semver.org); a prerelease sorts BEFORE
+// its release ("1.0.0-rc" < "1.0.0").
+//
+//   semverCmp("1.2.0", "1.10.0")  -> -1   (numeric, not lexical)
+//   semverGte("2.1.0", "2.0.9")   -> "1"
+//   semverMajor("1.2.3")          -> 1
+//   semverSatisfiesCaret("^1.2.0", "1.5.0") -> "1"
+
+module semver
+
+// strip a leading "v" and any "+build" metadata.
+func _clean(v) {
+    let s = v
+    if startsWith(s, "v") { s = substring(s, 1, len(s)) }
+    let plus = indexOf(s, "+")
+    if plus >= 0 { s = substring(s, 0, plus) }
+    emit s
+}
+
+func _core(v) {
+    let s = _clean(v)
+    let dash = indexOf(s, "-")
+    if dash >= 0 { emit substring(s, 0, dash) }
+    emit s
+}
+
+func _pre(v) {
+    let s = _clean(v)
+    let dash = indexOf(s, "-")
+    if dash >= 0 { emit substring(s, dash + 1, len(s)) }
+    emit ""
+}
+
+// idx-th dot-separated field of the core, as an int. Avoids list builtins
+// (splitBy lists are unreliable on the native backend) — pure indexOf scan.
+func _part(v, idx) {
+    let c = _core(v)
+    let start = 0
+    let field = 0
+    while field < idx {
+        let rest = substring(c, start, len(c))
+        let dot = indexOf(rest, ".")
+        if dot < 0 { emit 0 }
+        start = start + dot + 1
+        field += 1
+    }
+    let rest = substring(c, start, len(c))
+    let dot = indexOf(rest, ".")
+    if dot >= 0 { emit toInt(substring(rest, 0, dot)) }
+    emit toInt(rest)
+}
+
+func semverMajor(v) { emit _part(v, 0) }
+func semverMinor(v) { emit _part(v, 1) }
+func semverPatch(v) { emit _part(v, 2) }
+
+func _cmpInt(a, b) {
+    if a < b { emit 0 - 1 }
+    if a > b { emit 1 }
+    emit 0
+}
+
+// semverCmp(a, b) -> -1 if a<b, 0 if equal, 1 if a>b.
+func semverCmp(a, b) {
+    let c0 = _cmpInt(semverMajor(a), semverMajor(b))
+    if c0 != 0 { emit c0 }
+    let c1 = _cmpInt(semverMinor(a), semverMinor(b))
+    if c1 != 0 { emit c1 }
+    let c2 = _cmpInt(semverPatch(a), semverPatch(b))
+    if c2 != 0 { emit c2 }
+    // cores equal -> compare prerelease: a release outranks a prerelease.
+    let pa = _pre(a)
+    let pb = _pre(b)
+    if pa == "" {
+        if pb == "" { emit 0 }
+        emit 1                  // a is release, b is prerelease -> a > b
+    }
+    if pb == "" { emit 0 - 1 }  // a prerelease, b release -> a < b
+    // both prerelease: simple lexical compare via charCode
+    let i = 0
+    while i < len(pa) {
+        if i >= len(pb) { emit 1 }
+        let ca = toInt(charCode(pa[i]))
+        let cb = toInt(charCode(pb[i]))
+        if ca < cb { emit 0 - 1 }
+        if ca > cb { emit 1 }
+        i += 1
+    }
+    if len(pb) > len(pa) { emit 0 - 1 }
+    emit 0
+}
+
+func semverEq(a, b)  { if semverCmp(a, b) == 0 { emit "1" } emit "0" }
+func semverLt(a, b)  { if semverCmp(a, b) < 0  { emit "1" } emit "0" }
+func semverGt(a, b)  { if semverCmp(a, b) > 0  { emit "1" } emit "0" }
+func semverLte(a, b) { if semverCmp(a, b) <= 0 { emit "1" } emit "0" }
+func semverGte(a, b) { if semverCmp(a, b) >= 0 { emit "1" } emit "0" }
+
+// semverSatisfiesCaret("^1.2.3", v): same major, and v >= 1.2.3. ("1" / "0")
+func semverSatisfiesCaret(range, v) {
+    let base = range
+    if startsWith(base, "^") { base = substring(base, 1, len(base)) }
+    if semverMajor(v) != semverMajor(base) { emit "0" }
+    emit semverGte(v, base)
+}
+
+// semverSatisfiesTilde("~1.2.3", v): same major+minor, and v >= 1.2.3.
+func semverSatisfiesTilde(range, v) {
+    let base = range
+    if startsWith(base, "~") { base = substring(base, 1, len(base)) }
+    if semverMajor(v) != semverMajor(base) { emit "0" }
+    if semverMinor(v) != semverMinor(base) { emit "0" }
+    emit semverGte(v, base)
+}

--- a/samples/Krypton/stack.k
+++ b/samples/Krypton/stack.k
@@ -1,0 +1,91 @@
+// Stack data structure for Krypton
+// Stack is represented as a comma-separated string with count
+
+module stack
+
+
+// Create new empty stack
+func stackNew() {
+    emit ""
+}
+
+// Push a value onto the stack
+func stackPush(stk, val) {
+    if stk == "" {
+        emit val
+    }
+    emit stk + "," + val
+}
+
+// Peek at the top value without removing
+func stackPeek(stk) {
+    let size = count(stk)
+    emit split(stk, size - 1)
+}
+
+// Pop the top value, returns pair of "value,newStack"
+func stackPop(stk) {
+    let size = count(stk)
+    if size <= 1 {
+        emit stk + ","
+    }
+    // Get the top value
+    let top = split(stk, size - 1)
+    // Rebuild without last
+    let sb = sbNew()
+    let i = 0
+    while i < size - 1 {
+        if i > 0 {
+            sb = sbAppend(sb, ",")
+        }
+        sb = sbAppend(sb, split(stk, i))
+        i += 1
+    }
+    emit top + "|" + sbToString(sb)
+}
+
+// Get stack size
+func stackSize(stk) {
+    if stk == "" {
+        emit 0
+    }
+    emit count(stk)
+}
+
+// Check if stack is empty
+func stackEmpty(stk) {
+    if stk == "" {
+        emit 1
+    }
+    emit 0
+}
+
+// Print all stack elements (top to bottom)
+func stackPrint(stk) {
+    let size = count(stk)
+    kp("--- Stack (top to bottom) ---")
+    let i = size - 1
+    while i >= 0 {
+        kp("  " + split(stk, i))
+        i -= 1
+    }
+    kp("-----------------------------")
+}
+
+// Clear the stack
+func stackClear() {
+    emit ""
+}
+
+// Check if value exists in stack
+func stackContains(stk, val) {
+    let size = count(stk)
+    let i = 0
+    while i < size {
+        if split(stk, i) == val {
+            emit 1
+        }
+        i += 1
+    }
+    emit 0
+}

--- a/samples/Krypton/test_rle.ks
+++ b/samples/Krypton/test_rle.ks
@@ -1,0 +1,101 @@
+#!/usr/bin/env kr
+// kr lsp/test_rle.ks
+// Replaces lsp/test_rle.js. Sends documentSymbol against
+// algorithms/run_length_encoding.k and prints the result.
+import "k:proc"
+import "k:fs"
+
+func frame(body) {
+    emit "Content-Length: " + len(body) + "\r\n\r\n" + body
+}
+
+func _bodyStart(buf) {
+    let i = 0
+    while i + 3 < len(buf) {
+        if buf[i] == "\r" && buf[i + 1] == "\n" && buf[i + 2] == "\r" && buf[i + 3] == "\n" {
+            emit i + 4
+        }
+        i += 1
+    }
+    emit -1
+}
+
+func _cLen(headers) {
+    let p = indexOf(headers, "Content-Length:")
+    if p < 0 { emit 0 }
+    let i = p + 15
+    while i < len(headers) && (headers[i] == " " || headers[i] == "\t") { i += 1 }
+    let sb = sbNew()
+    while i < len(headers) && headers[i] >= "0" && headers[i] <= "9" {
+        sb = sbAppend(sb, headers[i])
+        i += 1
+    }
+    emit toInt(sbToString(sb))
+}
+
+// JSON string-escape a Krypton string for embedding in a request body.
+func _jstr(s) {
+    let out = sbNew()
+    out = sbAppend(out, "\"")
+    let i = 0
+    while i < len(s) {
+        let c = s[i]
+        if c == "\\"      { out = sbAppend(out, "\\\\") }
+        else if c == "\"" { out = sbAppend(out, "\\\"") }
+        else if c == "\n" { out = sbAppend(out, "\\n") }
+        else if c == "\r" { out = sbAppend(out, "\\r") }
+        else if c == "\t" { out = sbAppend(out, "\\t") }
+        else { out = sbAppend(out, c) }
+        i += 1
+    }
+    out = sbAppend(out, "\"")
+    emit sbToString(out)
+}
+
+just run {
+    let filePath = "algorithms/run_length_encoding.k"
+    if fsFileExists(filePath) != "1" {
+        kp("FAIL: " + filePath + " not found (run from repo root)")
+        exit("1")
+    }
+    let text = readFile(filePath)
+    let uri = "file:///" + filePath
+
+    let klsPath = "C:\\krypton\\kls.exe"
+    if fsFileExists(klsPath) != "1" { klsPath = "kls.exe" }
+
+    let p = procSpawn(klsPath, "")
+    if p == "0" {
+        kp("FAIL: kls.exe not found")
+        exit("1")
+    }
+
+    procWrite(p, frame("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"processId\":0,\"rootUri\":null,\"capabilities\":{}}}"))
+    procWrite(p, frame("{\"jsonrpc\":\"2.0\",\"method\":\"initialized\",\"params\":{}}"))
+    procWrite(p, frame("{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didOpen\",\"params\":{\"textDocument\":{\"uri\":" + _jstr(uri) + ",\"languageId\":\"krypton\",\"version\":1,\"text\":" + _jstr(text) + "}}}"))
+    procWrite(p, frame("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"textDocument/documentSymbol\",\"params\":{\"textDocument\":{\"uri\":" + _jstr(uri) + "}}}"))
+    procWrite(p, frame("{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"shutdown\"}"))
+    procWrite(p, frame("{\"jsonrpc\":\"2.0\",\"method\":\"exit\"}"))
+
+    procSleep(500)
+    let buf = procRead(p, 65536)
+
+    kp("DOCUMENT SYMBOLS:")
+    let pos = 0
+    let nf = 0
+    while pos < len(buf) {
+        let tail = substring(buf, pos, len(buf))
+        let off = _bodyStart(tail)
+        if off < 0 { pos = len(buf) }
+        else {
+            let body = substring(tail, off, off + _cLen(substring(tail, 0, off - 4)))
+            if contains(body, "\"id\":2") {
+                kp(body)
+                nf += 1
+            }
+            pos = pos + off + _cLen(substring(tail, 0, off - 4))
+        }
+    }
+    if nf == 0 { kp("(no documentSymbol response received)") }
+    procClose(p)
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -321,6 +321,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **KCL:** [kcl-lang/vscode-kcl](https://github.com/kcl-lang/vscode-kcl)
 - **KDL:** [kdl-org/vscode-kdl](https://github.com/kdl-org/vscode-kdl)
 - **KFramework:** [LucianCumpata/K-VSCode](https://github.com/LucianCumpata/K-VSCode)
+- **Krypton:** [t3m3d/krypton](https://github.com/t3m3d/krypton)
 - **Kaitai Struct:** [atom/language-yaml](https://github.com/atom/language-yaml)
 - **KakouneScript:** [kakoune-editor/language-kak](https://github.com/kakoune-editor/language-kak)
 - **KerboScript:** [KSP-KOS/language-kerboscript](https://github.com/KSP-KOS/language-kerboscript)


### PR DESCRIPTION
## Description

Adds [**Krypton**](https://krypton-lang.org) — an open-source, self-hosting programming language whose compiler is written in Krypton and emits native ELF / PE / Mach-O directly (no C toolchain, no LLVM). Source: https://github.com/t3m3d/krypton (MIT).

Surface syntax: `func name(args) { ... }`, `let`, `match`, `emit`, `just run { ... }`, `import "k:module"`, brace blocks, no semicolons.

## What's in this PR

- **`languages.yml`**: `Krypton` (type `programming`, color `#7722ff`, extensions `.k` / `.krh` / `.ks`, `tm_scope: source.krypton`, `ace_mode: text`), placed alphabetically (Kotlin → Krypton → Kusto).
- **`heuristics.yml`**: disambiguators for the shared extensions —
  - `.k`: Krypton vs **KCL** / **KFramework**
  - `.ks`: Krypton vs **KerboScript**
  
  keyed on Krypton-only markers (`just run {`, `func NAME(`, `emit `, `import "k:`). Verified these do **not** match the existing KCL / KerboScript samples, and that the Krypton samples match.
- **Grammar**: TextMate grammar (`source.krypton`, MIT) added as the `vendor/grammars/Krypton` submodule (→ `t3m3d/krypton`), with `grammars.yml` + `vendor/README.md` entries.
- **`samples/Krypton/`**: `json.k`, `stack.k`, `semver.k`, `math_utils.k` (library `.k`), `test_rle.ks` (script), `conio.krh` (header).

## Checklist

- [x] Not already present in `languages.yml`.
- [x] Shared extensions (`.k`, `.ks`) disambiguated via `heuristics.yml`; checked against existing samples.
- [x] TextMate grammar added as a submodule with a license (MIT).
- [x] Samples added.

## On the usage bar — upfront

I know the contributing guidelines ask that a language be **in use across many repositories** before it's added. Krypton is still young: it's used today across the language's own ecosystem repos (`t3m3d/krypton`, `homebrew-krypton`, `kweb`, plus downstream projects) and is growing, but it's not yet at "hundreds of repos." I'm opening this so the entry is review-ready and to ask: **what adoption bar would you want to see before this can be merged**, and is there anything about the entry/heuristics/grammar you'd want changed in the meantime? Happy to hold it open until usage gets there.