### PR TITLE
Add HlaX64 language (.hla64)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -725,6 +725,9 @@
 [submodule "vendor/grammars/language-haskell"]
 	path = vendor/grammars/language-haskell
 	url = https://github.com/atom-haskell/language-haskell
+[submodule "vendor/grammars/language-hla64"]
+	path = vendor/grammars/language-hla64
+	url = https://github.com/megaalive/language-hla64
 [submodule "vendor/grammars/language-hocon"]
 	path = vendor/grammars/language-hocon
 	url = https://github.com/jacobwgillespie/language-hocon.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -462,6 +462,8 @@ vendor/grammars/haxe-TmLanguage:
 - source.hx.argument
 - source.hx.type
 - source.hxml
+vendor/grammars/language-hla64:
+- source.hla64
 vendor/grammars/holyc.tmbundle:
 - source.hc
 vendor/grammars/hoon-grammar:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3208,6 +3208,14 @@ HiveQL:
   tm_scope: source.hql
   ace_mode: sql
   language_id: 931814087
+HlaX64:
+  type: programming
+  color: "#588858"
+  extensions:
+  - ".hla64"
+  tm_scope: source.hla64
+  ace_mode: assembly_x86
+  language_id: 882654
 HolyC:
   type: programming
   color: "#ffefaf"

--- a/samples/HlaX64/record-param.hla64
+++ b/samples/HlaX64/record-param.hla64
@@ -1,0 +1,30 @@
+// record-param.hla64 — record parameter as hidden pointer (MVP)
+
+program record_param;
+
+#include("stdlib64.hhf")
+
+record Point
+    x: int64;
+    y: int64;
+endrecord;
+
+procedure SumPoint(p: Point); @returns("rax");
+begin SumPoint;
+    mov(p.x, rax);
+    add(p.y, rax);
+end SumPoint;
+
+procedure Demo; @returns("rax");
+var
+    pt: Point;
+begin Demo;
+    mov(3, pt.x);
+    mov(4, pt.y);
+    call SumPoint(&pt);
+end Demo;
+
+begin record_param;
+    call Demo;
+    stdout.put("3+4 = ", rax, nl);
+end record_param;

--- a/samples/HlaX64/wc.hla64
+++ b/samples/HlaX64/wc.hla64
@@ -1,0 +1,96 @@
+// wc.hla64 - count lines, words, and bytes in a file (argv[1]).
+//
+// Stress: argv runtime, file read loop, byte classification, multiple counters,
+// multi-value stdout.put, while+if nesting.
+
+program wc;
+
+#include("stdlib64.hhf")
+
+extern procedure hlax_argv_init(): int64;
+extern procedure hlax_argv_count(): int64;
+extern procedure hlax_argv_get(index:int64): ptr;
+
+extern procedure CreateFileA(lpFileName: cstring; dwDesiredAccess: uint64; dwShareMode: uint64; lpSecurityAttributes: ptr; dwCreationDisposition: uint64; dwFlagsAndAttributes: uint64; hTemplateFile: uint64): int64 from "kernel32.dll";
+extern procedure ReadFile(hFile: int64; lpBuffer: ptr; nNumberOfBytesToRead: uint64; lpNumberOfBytesRead: ptr; lpOverlapped: ptr): int32 from "kernel32.dll";
+extern procedure CloseHandle(hObject: int64): int32 from "kernel32.dll";
+
+static
+    buffer: byte[256];
+    bytesRead: int64;
+endstatic;
+
+procedure IsSpace(b: int64); @returns("rax");
+begin IsSpace;
+    mov(0, rax);
+    if(b = 32) then mov(1, rax); endif;
+    if(b = 9) then mov(1, rax); endif;
+    if(b = 10) then mov(1, rax); endif;
+    if(b = 13) then mov(1, rax); endif;
+end IsSpace;
+
+procedure CountBuffer(n: int64); @returns("rax");
+begin CountBuffer;
+    mov(0, r11);
+    mov(0, r12);
+    mov(0, r13);
+    mov(n, r15);
+    mov(&buffer, r14);
+    mov(r14, r10);
+    add(r15, r10);
+
+    while(r14 < r10) do
+        mov([r14].byte, r9);
+
+        if(r9 = 10) then
+            add(1, r11);
+        endif;
+
+        call IsSpace(r9);
+        if(rax = 0) then
+            if(r13 = 0) then
+                add(1, r12);
+                mov(1, r13);
+            endif;
+        else
+            mov(0, r13);
+        endif;
+
+        add(1, r14);
+    endwhile;
+
+    stdout.put("lines=", r11, " words=", r12, " bytes=", r15, nl);
+    mov(0, rax);
+end CountBuffer;
+
+begin wc;
+    call hlax_argv_init();
+    call hlax_argv_count();
+
+    if(rax < 2) then
+        stdout.put("usage: wc <file>", nl);
+        mov(1, rbx);
+    else
+        call hlax_argv_get(1);
+        mov(rax, r12);
+        call CreateFileA(r12, 2147483648, 1, 0, 3, 128, 0);
+
+        if(rax = -1) then
+            stdout.put("open failed", nl);
+            mov(1, rbx);
+        else
+            mov(rax, r15);
+            call ReadFile(r15, &buffer, 256, &bytesRead, 0);
+            if(rax = 0) then
+                stdout.put("read failed", nl);
+                call CloseHandle(r15);
+                mov(1, rbx);
+            else
+                mov(bytesRead, r10);
+                call CountBuffer(r10);
+                call CloseHandle(r15);
+                mov(0, rbx);
+            endif;
+        endif;
+    endif;
+end wc;

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -273,6 +273,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Haskell:** [atom-haskell/language-haskell](https://github.com/atom-haskell/language-haskell)
 - **Haxe:** [vshaxe/haxe-TmLanguage](https://github.com/vshaxe/haxe-TmLanguage)
 - **HiveQL:** [adidonato/language-hql](https://github.com/adidonato/language-hql)
+- **HlaX64:** [megaalive/language-hla64](https://github.com/megaalive/language-hla64)
 - **HolyC:** [codingdandy/holyc.tmbundle](https://github.com/codingdandy/holyc.tmbundle)
 - **Hosts File:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **Hurl:** [nikeee/language-hurl](https://github.com/nikeee/language-hurl)

--- a/vendor/licenses/git_submodule/language-hla64.dep.yml
+++ b/vendor/licenses/git_submodule/language-hla64.dep.yml
@@ -1,0 +1,29 @@
+---
+name: language-hla64
+version: d58c6c1f95e0b176b1a219914bece5ec7739fb14
+type: git_submodule
+homepage: https://github.com/megaalive/language-hla64
+license: mit
+licenses:
+- sources: Auto-generated MIT license text
+  text: |
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
## Description

Adds [HlaX64](https://github.com/megaalive/hlax64), a high-level x64 assembly language inspired by Randall Hyde's HLA, with the `.hla64` file extension.

HlaX64 combines structured high-level constructs (`program`, `procedure`, `record`, `if`/`while`, typed variables) with inline x64 instructions (`mov`, `call`, `lea`, etc.) and targets Windows and Linux via NASM.

## Checklist

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=extension%3Ahla64+NOT+is%3Afork
      - https://github.com/search?type=code&q=extension%3Ahla64+NOT+is%3Afork+program+begin
    - **Usage note:** GitHub code search currently reports **237** indexed `.hla64` files (excluding forks), which meets the 200-file threshold for extensions expected once per repository. Usage is concentrated in the [megaalive/hlax64](https://github.com/megaalive/hlax64) project (compiler, curriculum, examples, and tests); the language is actively developed and public.
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/megaalive/hlax64/blob/main/examples/tools/10-windows/wc/wc.hla64 (`wc.hla64` — word/line/byte counter using Win32 file I/O)
      - https://github.com/megaalive/hlax64/blob/main/examples/curriculum/06-abi/record-param.hla64 (`record-param.hla64` — records, procedures, and ABI)
    - Sample license(s): MIT License (same as https://github.com/megaalive/hlax64)
  - [x] I have included a syntax highlighting grammar: https://github.com/megaalive/language-hla64
  - [x] I have added a color
    - Hex value: `#588858`
    - Rationale: A muted green distinct from Assembly (`#6E4C13`) while suggesting low-level/systems code.
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.
    - N/A — `.hla64` is not used by any other language in Linguist.

## Grammar

TextMate grammar submodule: [megaalive/language-hla64](https://github.com/megaalive/language-hla64) (`source.hla64`), derived from the VS Code extension in the hlax64 monorepo.

## Test plan

- [ ] CI (`bundle exec rake test`) passes
- [ ] Classifier recognizes `.hla64` samples as HlaX64