### PR TITLE
Switch Carbon language to upstream grammar.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -392,6 +392,9 @@
 [submodule "vendor/grammars/capnproto.tmbundle"]
 	path = vendor/grammars/capnproto.tmbundle
 	url = https://github.com/textmate/capnproto.tmbundle
+[submodule "vendor/grammars/carbon.tmbundle"]
+	path = vendor/grammars/carbon.tmbundle
+	url = https://github.com/carbon-language/carbon.tmbundle.git
 [submodule "vendor/grammars/carto-atom"]
 	path = vendor/grammars/carto-atom
 	url = https://github.com/yohanboniface/carto-atom

--- a/grammars.yml
+++ b/grammars.yml
@@ -316,10 +316,10 @@ vendor/grammars/c.tmbundle:
 vendor/grammars/cairo-tm-grammar:
 - source.cairo
 - source.cairo0
-vendor/grammars/carbon.tmbundle:
-- source.carbon
 vendor/grammars/capnproto.tmbundle:
 - source.capnp
+vendor/grammars/carbon.tmbundle:
+- source.carbon
 vendor/grammars/carto-atom:
 - source.css.mss
 vendor/grammars/cds-textmate-grammar:

--- a/grammars.yml
+++ b/grammars.yml
@@ -316,6 +316,8 @@ vendor/grammars/c.tmbundle:
 vendor/grammars/cairo-tm-grammar:
 - source.cairo
 - source.cairo0
+vendor/grammars/carbon.tmbundle:
+- source.carbon
 vendor/grammars/capnproto.tmbundle:
 - source.capnp
 vendor/grammars/carto-atom:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1127,10 +1127,8 @@ Carbon:
   color: "#222222"
   extensions:
   - ".carbon"
-  ace_mode: golang
-  codemirror_mode: go
-  codemirror_mime_type: text/x-go
-  tm_scope: source.v
+  ace_mode: text
+  tm_scope: source.carbon
   language_id: 55627273
 CartoCSS:
   type: programming

--- a/samples/Carbon/Shapes.carbon
+++ b/samples/Carbon/Shapes.carbon
@@ -1,73 +1,71 @@
-package Shapes api;
+package Shapes;
 import Math;
 
 // Circle
 
 class Circle {
-    var Radius: f32 = 1;
-    const var Diameter: f32 = self.Radius * 2;
+    var Radius: f32;
+    var Diameter: f32 = self.Radius * 2;
 
-    const var Pi: f32 = Math.Pi;
-
-    fn Area() -> self;
-    fn Circumference() -> self;
+    fn Area(self) -> f32;
+    fn Circumference(self) -> f32;
 }
 
-fn Circle.Area() -> self {
-    return Math.Pi * .Radius ^ 2
+fn Circle.Area(self) -> f32 {
+    return Math.Pi * self.Radius * self.Radius;
 }
 
-fn Circle.Circumference() -> self {
-    return 2 * Math.Pi * .Radius
+fn Circle.Circumference(self) -> f32 {
+    return 2 * Math.Pi * self.Radius;
 }
 
 // Rectangle
 
 class Rectangle {
-    var Width: f32 = 3;
-    var Height: f32 = 1;
+    var Width: f32;
+    var Height: f32;
 
-    fn Area() -> self;
+    fn Area(self) -> f32;
 }
 
-fn Rectangle.Area() -> self {
-    return .Width * .Height;
+fn Rectangle.Area(self) -> f32 {
+    return self.Width * self.Height;
 }
 
 // Square (Note: Provides same functions as "Rectangle" class.)
 
 class Square {
-    var Width: f32 = 3;
-    var Height: f32 = 1;
+    var Width: f32;
+    var Height: f32;
 
-    fn Area() -> self;
+    fn Area(self) -> f32;
 }
 
-fn Square.Area() -> self {
-    return .Width * .Height;
+fn Square.Area(self) -> f32 {
+    return self.Width * self.Height;
 }
 
 // Triangle
 
 class Triangle {
-    var Width: f32 = 3;
-    var Height: f32 = 3;
+    var Width: f32;
+    var Height: f32;
 
-    fn Area() -> self;
+    fn Area(self) -> f32;
 }
 
-fn Triangle.Area() -> self {
-    return (.Width * .Height) / 2;
+fn Triangle.Area(self) -> f32 {
+    return (self.Width * self.Height) / 2;
 }
 
 // Hexagon
 
 class Hexagon {
-    var Side: f32 = 5;
+    var Side: f32;
 
-    fn Area() -> self;
+    fn Area(self) -> f32;
 }
 
-fn Hexagon.Area() -> self {
-    return ((3 * 1.732) / 2) * .Side ^ 2
+fn Hexagon.Area(self) -> f32 {
+    return ((3 * 1.732) / 2) * self.Side * self.Side;
 }

--- a/samples/Carbon/main.carbon
+++ b/samples/Carbon/main.carbon
@@ -1,16 +1,18 @@
 // Part of linguist/samples
 
 import Shapes;
-import "some/graphics/library"; // This does not exist (read below)
+import Cpp library "<gtkmm.h>";
 
-fn main() -> i32 {
-  // This sample does not show the usage of a real graphics library since there is no major usable graphics library for Carbon.
-  // As the language grows, some UI library will emerge for it and this sample can be updated.
+alias Optional = Core.Optional;
 
-  var newGraphicRectangle: Shapes.Rectangle = {Width = 500, Height = 1250 };
+fn Run(argc: i32, argv: Optional(char*)*) -> i32 {
+  var app: auto = Cpp.Gtk.Application.create();
 
-  var graphicsWindow: auto = Graphics.Window(newGraphicRectangle, "Window Name");
-  graphicsWindow.Show(true);
+  var rect: Shapes.Rectangle = { .Width = 500, .Height = 1250 };
 
-  return 0;
+  var window: Cpp.Gtk.Window;
+  window.set_title("Window Name");
+  window.set_default_size(rect.Width unsafe as i32, rect.Height unsafe as i32);
+
+  return app.make_window_and_run(Cpp.Gtk.Window, window, argc, argv);
 }

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -106,7 +106,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **CameLIGO:** [pewulfman/Ligo-grammar](https://github.com/pewulfman/Ligo-grammar)
 - **Cangjie:** [Zxilly/playground-cj](https://github.com/Zxilly/playground-cj)
 - **Cap'n Proto:** [textmate/capnproto.tmbundle](https://github.com/textmate/capnproto.tmbundle)
-- **Carbon:** [0x9ef/vscode-vlang](https://github.com/0x9ef/vscode-vlang)
+- **Carbon:** [carbon-language/carbon.tmbundle](https://github.com/carbon-language/carbon.tmbundle)
 - **CartoCSS:** [yohanboniface/carto-atom](https://github.com/yohanboniface/carto-atom)
 - **Ceylon:** [jeancharles-roger/ceylon-sublimetext](https://github.com/jeancharles-roger/ceylon-sublimetext)
 - **Chapel:** [chapel-lang/chapel-tmbundle](https://github.com/chapel-lang/chapel-tmbundle)

--- a/vendor/licenses/git_submodule/carbon.tmbundle.dep.yml
+++ b/vendor/licenses/git_submodule/carbon.tmbundle.dep.yml
@@ -1,0 +1,244 @@
+---
+name: carbon.tmbundle
+version: 1bd49fc7a3656ed6d36b0105b9ccd4d568315dac
+type: git_submodule
+homepage: https://github.com/carbon-language/carbon.tmbundle.git
+license: other
+licenses:
+- sources: LICENSE
+  text: |
+    ==============================================================================
+    The Carbon language is under the Apache License v2.0 with LLVM Exceptions:
+    ==============================================================================
+
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+        TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+        1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+        2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+        3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+        4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+        5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+        6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+        7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+        8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+        9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+
+        END OF TERMS AND CONDITIONS
+
+        APPENDIX: How to apply the Apache License to your work.
+
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "[]"
+          replaced with your own identifying information. (Don't include
+          the brackets!)  The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+
+        Copyright [yyyy] [name of copyright owner]
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+
+
+    ---- LLVM Exceptions to the Apache 2.0 License ----
+
+    As an exception, if, as a result of your compiling your source code, portions
+    of this Software are embedded into an Object form of such source code, you
+    may redistribute such embedded portions in such Object form without complying
+    with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+    In addition, if you combine or link compiled forms of this Software with
+    software that is licensed under the GPLv2 ("Combined Software") and if a
+    court of competent jurisdiction determines that the patent provision (Section
+    3), the indemnity provision (Section 9) or other Section of the License
+    conflicts with the conditions of the GPLv2, you may retroactively and
+    prospectively choose to deem waived or otherwise exclude such Section(s) of
+    the License, but only in their entirety and only with respect to the Combined
+    Software.
+
+    ==============================================================================
+    Software from third parties included in the Carbon language:
+    ==============================================================================
+    The Carbon language contains third party software which is under different
+    license terms. All such code will be identified clearly using at least one of
+    two mechanisms:
+    1) It will be in a separate directory tree with its own `LICENSE.txt` or
+       `LICENSE` file at the top containing the specific license and restrictions
+       which apply to that software, or
+    2) It will contain specific license and restriction terms at the top of every
+       file.
+notices: []

--- a/vendor/licenses/git_submodule/carbon.tmbundle.dep.yml
+++ b/vendor/licenses/git_submodule/carbon.tmbundle.dep.yml
@@ -1,23 +1,20 @@
 ---
 name: carbon.tmbundle
-version: 1bd49fc7a3656ed6d36b0105b9ccd4d568315dac
+version: 1750023cb26e428324895e91531d4730f6f7e9f9
 type: git_submodule
 homepage: https://github.com/carbon-language/carbon.tmbundle.git
-license: other
+license: apache-2.0
 licenses:
 - sources: LICENSE
-  text: |
-    ==============================================================================
-    The Carbon language is under the Apache License v2.0 with LLVM Exceptions:
-    ==============================================================================
+  text: |2
 
                                      Apache License
                                Version 2.0, January 2004
                             http://www.apache.org/licenses/
 
-        TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-        1. Definitions.
+       1. Definitions.
 
           "License" shall mean the terms and conditions for use, reproduction,
           and distribution as defined by Sections 1 through 9 of this document.
@@ -76,14 +73,14 @@ licenses:
           on behalf of whom a Contribution has been received by Licensor and
           subsequently incorporated within the Work.
 
-        2. Grant of Copyright License. Subject to the terms and conditions of
+       2. Grant of Copyright License. Subject to the terms and conditions of
           this License, each Contributor hereby grants to You a perpetual,
           worldwide, non-exclusive, no-charge, royalty-free, irrevocable
           copyright license to reproduce, prepare Derivative Works of,
           publicly display, publicly perform, sublicense, and distribute the
           Work and such Derivative Works in Source or Object form.
 
-        3. Grant of Patent License. Subject to the terms and conditions of
+       3. Grant of Patent License. Subject to the terms and conditions of
           this License, each Contributor hereby grants to You a perpetual,
           worldwide, non-exclusive, no-charge, royalty-free, irrevocable
           (except as stated in this section) patent license to make, have made,
@@ -99,7 +96,7 @@ licenses:
           granted to You under this License for that Work shall terminate
           as of the date such litigation is filed.
 
-        4. Redistribution. You may reproduce and distribute copies of the
+       4. Redistribution. You may reproduce and distribute copies of the
           Work or Derivative Works thereof in any medium, with or without
           modifications, and in Source or Object form, provided that You
           meet the following conditions:
@@ -140,7 +137,7 @@ licenses:
           reproduction, and distribution of the Work otherwise complies with
           the conditions stated in this License.
 
-        5. Submission of Contributions. Unless You explicitly state otherwise,
+       5. Submission of Contributions. Unless You explicitly state otherwise,
           any Contribution intentionally submitted for inclusion in the Work
           by You to the Licensor shall be under the terms and conditions of
           this License, without any additional terms or conditions.
@@ -148,12 +145,12 @@ licenses:
           the terms of any separate license agreement you may have executed
           with Licensor regarding such Contributions.
 
-        6. Trademarks. This License does not grant permission to use the trade
+       6. Trademarks. This License does not grant permission to use the trade
           names, trademarks, service marks, or product names of the Licensor,
           except as required for reasonable and customary use in describing the
           origin of the Work and reproducing the content of the NOTICE file.
 
-        7. Disclaimer of Warranty. Unless required by applicable law or
+       7. Disclaimer of Warranty. Unless required by applicable law or
           agreed to in writing, Licensor provides the Work (and each
           Contributor provides its Contributions) on an "AS IS" BASIS,
           WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
@@ -163,7 +160,7 @@ licenses:
           appropriateness of using or redistributing the Work and assume any
           risks associated with Your exercise of permissions under this License.
 
-        8. Limitation of Liability. In no event and under no legal theory,
+       8. Limitation of Liability. In no event and under no legal theory,
           whether in tort (including negligence), contract, or otherwise,
           unless required by applicable law (such as deliberate and grossly
           negligent acts) or agreed to in writing, shall any Contributor be
@@ -175,7 +172,7 @@ licenses:
           other commercial damages or losses), even if such Contributor
           has been advised of the possibility of such damages.
 
-        9. Accepting Warranty or Additional Liability. While redistributing
+       9. Accepting Warranty or Additional Liability. While redistributing
           the Work or Derivative Works thereof, You may choose to offer,
           and charge a fee for, acceptance of support, warranty, indemnity,
           or other liability obligations and/or rights consistent with this
@@ -186,9 +183,9 @@ licenses:
           incurred by, or claims asserted against, such Contributor by reason
           of your accepting any such warranty or additional liability.
 
-        END OF TERMS AND CONDITIONS
+       END OF TERMS AND CONDITIONS
 
-        APPENDIX: How to apply the Apache License to your work.
+       APPENDIX: How to apply the Apache License to your work.
 
           To apply the Apache License to your work, attach the following
           boilerplate notice, with the fields enclosed by brackets "[]"
@@ -199,46 +196,17 @@ licenses:
           same "printed page" as the copyright notice for easier
           identification within third-party archives.
 
-        Copyright [yyyy] [name of copyright owner]
+       Copyright [yyyy] [name of copyright owner]
 
-        Licensed under the Apache License, Version 2.0 (the "License");
-        you may not use this file except in compliance with the License.
-        You may obtain a copy of the License at
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
 
            http://www.apache.org/licenses/LICENSE-2.0
 
-        Unless required by applicable law or agreed to in writing, software
-        distributed under the License is distributed on an "AS IS" BASIS,
-        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        See the License for the specific language governing permissions and
-        limitations under the License.
-
-
-    ---- LLVM Exceptions to the Apache 2.0 License ----
-
-    As an exception, if, as a result of your compiling your source code, portions
-    of this Software are embedded into an Object form of such source code, you
-    may redistribute such embedded portions in such Object form without complying
-    with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
-
-    In addition, if you combine or link compiled forms of this Software with
-    software that is licensed under the GPLv2 ("Combined Software") and if a
-    court of competent jurisdiction determines that the patent provision (Section
-    3), the indemnity provision (Section 9) or other Section of the License
-    conflicts with the conditions of the GPLv2, you may retroactively and
-    prospectively choose to deem waived or otherwise exclude such Section(s) of
-    the License, but only in their entirety and only with respect to the Combined
-    Software.
-
-    ==============================================================================
-    Software from third parties included in the Carbon language:
-    ==============================================================================
-    The Carbon language contains third party software which is under different
-    license terms. All such code will be identified clearly using at least one of
-    two mechanisms:
-    1) It will be in a separate directory tree with its own `LICENSE.txt` or
-       `LICENSE` file at the top containing the specific license and restrictions
-       which apply to that software, or
-    2) It will contain specific license and restriction terms at the top of every
-       file.
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
 notices: []


### PR DESCRIPTION
Previously it seemingly used a mixture of Go and V grammars!

## Checklist:
- [ ] **I am adding a new extension to a language.**
- [ ] **I am adding a new language.**
- [ ] **I am fixing a misclassified language**
- [x] **I am changing the source of a syntax highlighting grammar**
  - Old: https://github.com/0x9ef/vscode-vlang
  - New: https://github.com/carbon-language/carbon.tmbundle
- [ ] **I am updating a grammar submodule**
- [ ] **I am adding new or changing current functionality**
- [ ] **I am changing the color associated with a language**
