### PR TITLE
Change the C# colour to purple

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -848,7 +848,7 @@ C#:
   codemirror_mode: clike
   codemirror_mime_type: text/x-csharp
   tm_scope: source.cs
-  color: "#178600"
+  color: "#7355dd"
   aliases:
   - csharp
   - cake


### PR DESCRIPTION
## Description
This PR would change the colour associated with the C# programming language away from the old green to a shade of purple (`#7355dd`) from the logo that Microsoft has used for the language for many years at this point. This exact change to Linguist was proposed last autumn but seemingly did not go anywhere despite there even having been a vote in accordance with the [contributing guidelines](https://github.com/github-linguist/linguist/blob/main/CONTRIBUTING.md#changing-the-color-associated-with-a-language) confirming the change. See https://github.com/dotnet/csharplang/discussions/9657. Therefore reopening this with the support of the results of the vote.

## Checklist:
- [X] **I am changing the colour associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [X] I have obtained agreement from the wider language community on this color change.
    - [Vote from last autumn where the colour purple won by 78%](https://github.com/dotnet/csharplang/discussions/9657)
    - A logo of this colour has been officially used by Microsoft for years, for example [here](https://learn.microsoft.com/en-us/dotnet/csharp/).
