### PR TITLE
Add Glide language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1614,3 +1614,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/vscode-glide"]
+	path = vendor/grammars/vscode-glide
+	url = https://github.com/glide-lang/vscode-glide

--- a/grammars.yml
+++ b/grammars.yml
@@ -1291,6 +1291,8 @@ vendor/grammars/vscode-gedcom:
 vendor/grammars/vscode-gleam:
 - markdown.gleam.codeblock
 - source.gleam
+vendor/grammars/vscode-glide:
+- source.glide
 vendor/grammars/vscode-go:
 - go.mod
 - go.sum

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2699,6 +2699,14 @@ Gleam:
   - ".gleam"
   tm_scope: source.gleam
   language_id: 1054258749
+Glide:
+  type: programming
+  color: "#3b5bdb"
+  ace_mode: text
+  extensions:
+  - ".glide"
+  tm_scope: source.glide
+  language_id: 533042855
 Glimmer JS:
   type: programming
   aliases:

--- a/samples/Glide/argparse.glide
+++ b/samples/Glide/argparse.glide
@@ -1,0 +1,425 @@
+// CLI argument parser. Long + short flags, three value types
+// (string / int / bool), positional capture, auto-generated --help.
+//
+// ```glide
+// import stdlib::argparse::*;
+//
+// fn main() -> i32 {
+//     let p: *ArgParser = ArgParser::new("greet", "Say hello to someone");
+//     defer p.free();
+//     p.add_string("name", "n", "world", "who to greet");
+//     p.add_int   ("count", "c", 1,       "number of greetings");
+//     p.add_bool  ("verbose", "v", false, "extra output");
+//
+//     let r: !i32 = p.parse_argv();
+//     if !r.ok { println!("error: ${r.msg}"); return 2; }
+//     if p.help_requested() { p.print_help(); return 0; }
+//
+//     let who: string = p.get_string("name");
+//     let n:   i32    = p.get_int("count");
+//     for let i: i32 = 0; i < n; i++ { println!("hello, ${who}!"); }
+//     return 0;
+// }
+// ```
+//
+// Recognised forms:
+//   --name=value        --name value        (long, value)
+//   --name              -n                  (long/short, bool)
+//   -n value                                (short, value)
+//   --help / -h                             (auto)
+//   --                                      (end-of-flags, rest positional)
+//   anything else                           (positional)
+
+import stdlib::hashmap::*;
+
+pub struct StrFlag { pub default_value: string, pub value: string }
+pub struct IntFlag { pub default_value: i32, pub value: i32 }
+pub struct BoolFlag { pub default_value: bool, pub value: bool }
+
+pub struct ArgParser {
+    prog: string,
+    desc: string,
+
+    str_flags:  *HashMap<*StrFlag>,
+    int_flags:  *HashMap<*IntFlag>,
+    bool_flags: *HashMap<*BoolFlag>,
+
+    shorts:    *HashMap<string>,    // short  -> long
+    short_of:  *HashMap<string>,    // long   -> short ("" if none)
+    types:     *HashMap<string>,    // long   -> "string"/"int"/"bool"
+    helps:     *HashMap<string>,    // long   -> help text
+    order:     *Vector<string>,     // long names in declaration order
+
+    positional: *Vector<string>,
+    help_seen: bool,
+}
+
+impl ArgParser {
+    /// Build an empty parser tagged with `prog` and `desc` (used in
+    /// `--help` output). Add flags via `add_string` / `add_int` / `add_bool`,
+    /// then call `parse_argv()`.
+    ///
+    /// ```glide
+    /// let p: *ArgParser = ArgParser::new("greet", "Say hello");
+    /// defer p.free();
+    /// p.add_string("name", "n", "world", "who to greet");
+    /// p.parse_argv();
+    /// ```
+    pub fn new(prog: string, desc: string) -> *ArgParser {
+        let p: *ArgParser = malloc(sizeof(ArgParser)) as *ArgParser;
+        p.prog = prog;
+        p.desc = desc;
+        // Local lets so the prescan sees concrete T for each HashMap mono.
+        let sf: *HashMap<*StrFlag> = HashMap::new();
+        let ifs: *HashMap<*IntFlag> = HashMap::new();
+        let bf: *HashMap<*BoolFlag> = HashMap::new();
+        let sh: *HashMap<string> = HashMap::new();
+        let so: *HashMap<string> = HashMap::new();
+        let ty: *HashMap<string> = HashMap::new();
+        let hp: *HashMap<string> = HashMap::new();
+        p.str_flags = sf;
+        p.int_flags = ifs;
+        p.bool_flags = bf;
+        p.shorts = sh;
+        p.short_of = so;
+        p.types = ty;
+        p.helps = hp;
+        p.order = Vector::new();
+        p.positional = Vector::new();
+        p.help_seen = false;
+        return p;
+    }
+
+    fn _register(self: *ArgParser, long: string, short: string, ty: string, help: string) {
+        self.order.push(long);
+        self.types.insert(long, ty);
+        self.helps.insert(long, help);
+        self.short_of.insert(long, short);
+        if !short.eq("") { self.shorts.insert(short, long); }
+    }
+
+    /// Declare a string-valued flag. `short` may be `""` if no short
+    /// form is desired.
+    ///
+    /// ```glide
+    /// p.add_string("name", "n", "world", "who to greet");
+    /// // accepts: --name=alice  --name alice  -n alice
+    /// ```
+    pub fn add_string(self: *ArgParser, long: string, short: string,
+                      default_value: string, help: string) {
+        let f: *StrFlag = malloc(sizeof(StrFlag)) as *StrFlag;
+        f.default_value = default_value;
+        f.value = default_value;
+        self.str_flags.insert(long, f);
+        self._register(long, short, "string", help);
+    }
+
+    /// Declare an int-valued flag.
+    ///
+    /// ```glide
+    /// p.add_int("count", "c", 1, "number of greetings");
+    /// // --count=5    --count 5    -c 5
+    /// ```
+    pub fn add_int(self: *ArgParser, long: string, short: string,
+                   default_value: i32, help: string) {
+        let f: *IntFlag = malloc(sizeof(IntFlag)) as *IntFlag;
+        f.default_value = default_value;
+        f.value = default_value;
+        self.int_flags.insert(long, f);
+        self._register(long, short, "int", help);
+    }
+
+    /// Declare a bool flag. Presence of the flag flips it to `true`
+    /// (or to whatever inverts the default — `add_bool(name, "", true, ...)`
+    /// means presence sets it to `false`).
+    ///
+    /// ```glide
+    /// p.add_bool("verbose", "v", false, "extra output");
+    /// // --verbose / -v sets it to true
+    /// ```
+    pub fn add_bool(self: *ArgParser, long: string, short: string,
+                    default_value: bool, help: string) {
+        let f: *BoolFlag = malloc(sizeof(BoolFlag)) as *BoolFlag;
+        f.default_value = default_value;
+        f.value = default_value;
+        self.bool_flags.insert(long, f);
+        self._register(long, short, "bool", help);
+    }
+
+    /// Read a parsed string flag. UB if the flag wasn't declared.
+    ///
+    /// ```glide
+    /// p.parse_argv();
+    /// let who: string = p.get_string("name");
+    /// ```
+    pub fn get_string(self: *ArgParser, long: string) -> string {
+        return self.str_flags.get(long).value;
+    }
+
+    /// Read a parsed int flag.
+    ///
+    /// ```glide
+    /// let n: i32 = p.get_int("count");
+    /// ```
+    pub fn get_int(self: *ArgParser, long: string) -> i32 {
+        return self.int_flags.get(long).value;
+    }
+
+    /// Read a parsed bool flag.
+    ///
+    /// ```glide
+    /// if p.get_bool("verbose") { eprintln("verbose mode on"); }
+    /// ```
+    pub fn get_bool(self: *ArgParser, long: string) -> bool {
+        return self.bool_flags.get(long).value;
+    }
+
+    /// Positional arguments captured after flags. Includes everything
+    /// after a `--` separator and any non-flag tokens before/between.
+    ///
+    /// ```glide
+    /// let files: *Vector<string> = p.positional();
+    /// for let i: i32 = 0; i < files.len(); i++ { fs_read(files.get(i)); }
+    /// ```
+    pub fn positional(self: *ArgParser) -> *Vector<string> {
+        return self.positional;
+    }
+
+    /// `true` if `--help` or `-h` was encountered while parsing.
+    /// `print_help()` is not called automatically — callers decide.
+    ///
+    /// ```glide
+    /// if p.help_requested() { p.print_help(); env_exit(0); }
+    /// ```
+    pub fn help_requested(self: *ArgParser) -> bool {
+        return self.help_seen;
+    }
+
+    fn _set_value(self: *ArgParser, long: string, val: string) -> !i32 {
+        if !self.types.contains(long) {
+            return err("unknown flag: --".concat(long));
+        }
+        let ty: string = self.types.get(long);
+        if ty.eq("string") {
+            self.str_flags.get(long).value = val;
+            return ok(0);
+        }
+        if ty.eq("int") {
+            let r: !i32 = val.try_parse_int();
+            if !r.ok { return err("flag --".concat(long).concat(" expects an integer, got: ").concat(val)); }
+            self.int_flags.get(long).value = r.val;
+            return ok(0);
+        }
+        // Bool: accept "true"/"false"/"1"/"0".
+        if val.eq("true") || val.eq("1") {
+            self.bool_flags.get(long).value = true;
+            return ok(0);
+        }
+        if val.eq("false") || val.eq("0") {
+            self.bool_flags.get(long).value = false;
+            return ok(0);
+        }
+        return err("flag --".concat(long).concat(" expects a bool, got: ").concat(val));
+    }
+
+    /// Parse the process's argv starting at index 1 (index 0 is the
+    /// program path, conventionally skipped). Returns `ok(0)` on
+    /// success or `err(message)` on the first malformed token.
+    ///
+    /// ```glide
+    /// let r: !i32 = p.parse_argv();
+    /// if !r.ok { eprintln(r.err); env_exit(2); }
+    /// ```
+    pub fn parse_argv(self: *ArgParser) -> !i32 {
+        let mut tokens: *Vector<string> = Vector::new();
+        for let i: i32 = 1; i < args_count(); i++ {
+            tokens.push(args_at(i));
+        }
+        return self.parse_tokens(tokens);
+    }
+
+    /// Same as `parse_argv` but consumes an arbitrary token list. Useful
+    /// for tests and for parsing nested commands.
+    ///
+    /// ```glide
+    /// let toks: *Vector<string> = Vector::new();
+    /// toks.push_all!("--name=alice", "--count", "3");
+    /// p.parse_tokens(toks);
+    /// p.get_string("name");   // "alice"
+    /// ```
+    pub fn parse_tokens(self: *ArgParser, tokens: *Vector<string>) -> !i32 {
+        let n: i32 = tokens.len();
+        let mut i: i32 = 0;
+        let mut all_positional: bool = false;
+        while i < n {
+            let tok: string = tokens.get(i);
+            if all_positional {
+                self.positional.push(tok);
+                i = i + 1;
+                continue;
+            }
+            if tok.eq("--") { all_positional = true; i = i + 1; continue; }
+            if tok.eq("--help") || tok.eq("-h") {
+                self.help_seen = true;
+                i = i + 1;
+                continue;
+            }
+            // Long form: --name or --name=value
+            if tok.len() > 2 && tok.at(0).to_int() == 45 && tok.at(1).to_int() == 45 {
+                let body: string = tok.substring(2, tok.len());
+                let eq_pos: i32 = body.index_of("=");
+                if eq_pos >= 0 {
+                    let name: string = body.substring(0, eq_pos);
+                    let val:  string = body.substring(eq_pos + 1, body.len());
+                    let r: !i32 = self._set_value(name, val);
+                    if !r.ok { return err(r.err); }
+                    i = i + 1;
+                    continue;
+                }
+                // No "=" — bare bool flag, or value is next token.
+                if self.bool_flags.contains(body) {
+                    self.bool_flags.get(body).value = !self.bool_flags.get(body).default_value;
+                    i = i + 1;
+                    continue;
+                }
+                if !self.types.contains(body) {
+                    return err("unknown flag: --".concat(body));
+                }
+                if i + 1 >= n {
+                    return err("flag --".concat(body).concat(" requires a value"));
+                }
+                let r: !i32 = self._set_value(body, tokens.get(i + 1));
+                if !r.ok { return err(r.err); }
+                i = i + 2;
+                continue;
+            }
+            // Short form: -x [value] (single char, no combining)
+            if tok.len() >= 2 && tok.at(0).to_int() == 45 {
+                let s: string = tok.substring(1, tok.len());
+                if !self.shorts.contains(s) {
+                    // Not a known short. Could be a negative-number positional
+                    // ("-3"), so treat as positional.
+                    self.positional.push(tok);
+                    i = i + 1;
+                    continue;
+                }
+                let long: string = self.shorts.get(s);
+                if self.bool_flags.contains(long) {
+                    self.bool_flags.get(long).value = !self.bool_flags.get(long).default_value;
+                    i = i + 1;
+                    continue;
+                }
+                if i + 1 >= n {
+                    return err("flag -".concat(s).concat(" requires a value"));
+                }
+                let r: !i32 = self._set_value(long, tokens.get(i + 1));
+                if !r.ok { return err(r.err); }
+                i = i + 2;
+                continue;
+            }
+            // Plain positional.
+            self.positional.push(tok);
+            i = i + 1;
+        }
+        return ok(0);
+    }
+
+    /// Build a human-readable help string. Includes the program name,
+    /// description, and a `--flag (-f)  default=...   help text` line
+    /// per flag in declaration order.
+    ///
+    /// ```glide
+    /// let txt: string = p.format_help();
+    /// // either print or write to a file
+    /// ```
+    pub fn format_help(self: *ArgParser) -> string {
+        let mut out: string = "usage: ".concat(self.prog).concat(" [flags] [positional...]\n");
+        if !self.desc.eq("") {
+            out = out.concat("\n").concat(self.desc).concat("\n");
+        }
+        out = out.concat("\nflags:\n");
+        for let i: i32 = 0; i < self.order.len(); i++ {
+            let name: string = self.order.get(i);
+            let short: string = self.short_of.get(name);
+            let ty: string = self.types.get(name);
+            let help: string = self.helps.get(name);
+            out = out.concat("  --").concat(name);
+            if !short.eq("") { out = out.concat(" (-").concat(short).concat(")"); }
+            out = out.concat("  ");
+            if ty.eq("string") {
+                out = out.concat("[string, default=\"")
+                          .concat(self.str_flags.get(name).default_value)
+                          .concat("\"]");
+            }
+            if ty.eq("int") {
+                out = out.concat("[int, default=")
+                          .concat(int_to_str(self.int_flags.get(name).default_value))
+                          .concat("]");
+            }
+            if ty.eq("bool") {
+                let dv: string = "false";
+                if self.bool_flags.get(name).default_value { dv = "true"; }
+                out = out.concat("[bool, default=").concat(dv).concat("]");
+            }
+            if !help.eq("") { out = out.concat("\n      ").concat(help); }
+            out = out.concat("\n");
+        }
+        out = out.concat("  --help (-h)  show this message\n");
+        return out;
+    }
+
+    /// Print `format_help()` to stdout.
+    ///
+    /// ```glide
+    /// if p.help_requested() { p.print_help(); env_exit(0); }
+    /// ```
+    pub fn print_help(self: *ArgParser) {
+        print!(self.format_help());
+    }
+
+    /// Free every owned struct + hashmap + vector. Pointer is dangling
+    /// after the call. Pair with `defer`.
+    ///
+    /// ```glide
+    /// let p: *ArgParser = ArgParser::new("greet", "Say hello");
+    /// defer p.free();
+    /// ```
+    pub fn free(self: *ArgParser) {
+        // Free per-flag value structs.
+        let snames: *Vector<string> = self.str_flags.keys();
+        for let i: i32 = 0; i < snames.len(); i++ {
+            free(self.str_flags.get(snames.get(i)) as *void);
+        }
+        let inames: *Vector<string> = self.int_flags.keys();
+        for let i: i32 = 0; i < inames.len(); i++ {
+            free(self.int_flags.get(inames.get(i)) as *void);
+        }
+        let bnames: *Vector<string> = self.bool_flags.keys();
+        for let i: i32 = 0; i < bnames.len(); i++ {
+            free(self.bool_flags.get(bnames.get(i)) as *void);
+        }
+        self.str_flags.free();
+        self.int_flags.free();
+        self.bool_flags.free();
+        self.shorts.free();
+        self.short_of.free();
+        self.types.free();
+        self.helps.free();
+        free(self as *void);
+    }
+}
+
+fn int_to_str(n: i32) -> string {
+    if n == 0 { return "0"; }
+    let mut x: i32 = n;
+    let mut neg: bool = false;
+    if x < 0 { neg = true; x = 0 - x; }
+    let mut s: string = "";
+    while x > 0 {
+        let d: i32 = x % 10;
+        s = ((d + 48) as char).to_string().concat(s);
+        x = x / 10;
+    }
+    if neg { s = "-".concat(s); }
+    return s;
+}

--- a/samples/Glide/iter.glide
+++ b/samples/Glide/iter.glide
@@ -1,0 +1,313 @@
+// stdlib::iter — Iterator trait + eager combinators on `Vector<T>`.
+//
+//   fn double(x: int) -> int { return x * 2; }
+//   fn keep_pos(x: int) -> bool { return x > 0; }
+//
+//   let v: *Vector<int> = iter_range(0 - 3, 5);            // [-3..4]
+//   let m* = iter_map(v, double);
+//   let f* = iter_filter(m, keep_pos);
+//   let total: int = iter_sum_int(f);                      // 2+4+6+8 = 20
+//
+// Each transformer (`map`, `filter`, `take`, `skip`, `take_while`,
+// `skip_while`) returns a fresh `*Vector<U>` — caller owns it (use
+// `let v* = ...` for auto-drop). Reducers (`fold`, `count`, `any`,
+// `all`, `find`, `sum_int`, `max_int`, `min_int`) read the vector and
+// return a value. Constructors (`range`, `range_step`, `repeat`) build
+// new vectors.
+//
+// All combinators take fn pointers, not closures-with-capture (Sprint 3
+// deferred). Define top-level `fn name(...) { ... }` or use anonymous
+// fns without capturing outer vars: `fn(x: int) -> int { return x + 1; }`.
+
+pub trait Iterator {
+    type Item;
+    fn next(self: *Self) -> ?Self::Item;
+}
+
+// Plug VecIter (defined in builtins/vector.glide) into the trait so any
+// `fn f<I: Iterator>(it: *I)` accepts `v.iter()` after this import.
+impl<T> Iterator for VecIter<T> {
+    type Item = T;
+    fn next(self: *VecIter<T>) -> ?T {
+        if self.idx >= self.vec.len { return none(); }
+        let v: T = self.vec.data[self.idx];
+        self.idx = self.idx + 1;
+        return some(v);
+    }
+}
+
+// ============================================================================
+// Transformers (return *Vector<U>; caller owns)
+// ============================================================================
+
+/// Apply `f` to each element, returning a new Vector.
+///
+/// ```glide
+/// fn double(x: i32) -> i32 { return x * 2; }
+/// let v: *Vector<i32> = iter_range(1, 4);     // [1, 2, 3]
+/// let m: *Vector<i32> = iter_map(v, double);  // [2, 4, 6]
+/// ```
+pub fn iter_map<T, U>(v: *Vector<T>, f: fn(T) -> U) -> *Vector<U> {
+    let out: *Vector<U> = Vector::new();
+    for let i: i32 = 0; i < v.len(); i++ {
+        let item: T = v.get(i);
+        out.push(f(item));
+    }
+    return out;
+}
+
+/// Keep only elements where `p` returns true.
+///
+/// ```glide
+/// fn keep_pos(x: i32) -> bool { return x > 0; }
+/// let v: *Vector<i32> = iter_range(-2, 3);          // [-2, -1, 0, 1, 2]
+/// let pos: *Vector<i32> = iter_filter(v, keep_pos); // [1, 2]
+/// ```
+pub fn iter_filter<T>(v: *Vector<T>, p: fn(T) -> bool) -> *Vector<T> {
+    let out: *Vector<T> = Vector::new();
+    for let i: i32 = 0; i < v.len(); i++ {
+        let item: T = v.get(i);
+        if p(item) { out.push(item); }
+    }
+    return out;
+}
+
+/// First `n` elements (or all if `n` exceeds length).
+///
+/// ```glide
+/// let v: *Vector<i32> = iter_range(0, 10);
+/// iter_take(v, 3);    // [0, 1, 2]
+/// iter_take(v, 99);   // entire 10-element vector
+/// ```
+pub fn iter_take<T>(v: *Vector<T>, n: i32) -> *Vector<T> {
+    let out: *Vector<T> = Vector::new();
+    let mut limit: i32 = n;
+    if limit > v.len() { limit = v.len(); }
+    if limit < 0 { limit = 0; }
+    for let i: i32 = 0; i < limit; i++ { out.push(v.get(i)); }
+    return out;
+}
+
+/// Drop first `n` elements; return the rest.
+///
+/// ```glide
+/// let v: *Vector<i32> = iter_range(0, 5);   // [0,1,2,3,4]
+/// iter_skip(v, 2);                          // [2, 3, 4]
+/// ```
+pub fn iter_skip<T>(v: *Vector<T>, n: i32) -> *Vector<T> {
+    let out: *Vector<T> = Vector::new();
+    let mut start: i32 = n;
+    if start < 0 { start = 0; }
+    for let i: i32 = start; i < v.len(); i++ { out.push(v.get(i)); }
+    return out;
+}
+
+/// Take elements until `p` returns false (then stop).
+///
+/// ```glide
+/// fn lt3(x: i32) -> bool { return x < 3; }
+/// let v: *Vector<i32> = iter_range(0, 6);   // [0,1,2,3,4,5]
+/// iter_take_while(v, lt3);                  // [0, 1, 2]
+/// ```
+pub fn iter_take_while<T>(v: *Vector<T>, p: fn(T) -> bool) -> *Vector<T> {
+    let out: *Vector<T> = Vector::new();
+    for let i: i32 = 0; i < v.len(); i++ {
+        let item: T = v.get(i);
+        if !p(item) { return out; }
+        out.push(item);
+    }
+    return out;
+}
+
+/// Skip elements while `p` returns true; keep the rest from first false.
+///
+/// ```glide
+/// fn lt3(x: i32) -> bool { return x < 3; }
+/// let v: *Vector<i32> = iter_range(0, 6);   // [0,1,2,3,4,5]
+/// iter_skip_while(v, lt3);                  // [3, 4, 5]
+/// ```
+pub fn iter_skip_while<T>(v: *Vector<T>, p: fn(T) -> bool) -> *Vector<T> {
+    let out: *Vector<T> = Vector::new();
+    let mut skipping: bool = true;
+    for let i: i32 = 0; i < v.len(); i++ {
+        let item: T = v.get(i);
+        if skipping {
+            if !p(item) { skipping = false; out.push(item); }
+        } else {
+            out.push(item);
+        }
+    }
+    return out;
+}
+
+// ============================================================================
+// Reducers (return value)
+// ============================================================================
+
+/// Fold over the vector. `f(acc, item)` returns the new accumulator.
+///
+/// ```glide
+/// fn add(acc: i32, x: i32) -> i32 { return acc + x; }
+/// let v: *Vector<i32> = iter_range(1, 5);   // [1,2,3,4]
+/// iter_fold(v, 0, add);                     // 10
+/// iter_fold(v, 100, add);                   // 110
+/// ```
+pub fn iter_fold<T, U>(v: *Vector<T>, init: U, f: fn(U, T) -> U) -> U {
+    let mut acc: U = init;
+    for let i: i32 = 0; i < v.len(); i++ {
+        let item: T = v.get(i);
+        acc = f(acc, item);
+    }
+    return acc;
+}
+
+/// Number of elements. Same as `v.len()`; provided for API symmetry.
+///
+/// ```glide
+/// iter_count(iter_range(0, 5));   // 5
+/// ```
+pub fn iter_count<T>(v: *Vector<T>) -> i32 { return v.len(); }
+
+/// `true` if any element matches `p`. Short-circuits on first hit.
+///
+/// ```glide
+/// fn is_neg(x: i32) -> bool { return x < 0; }
+/// let v: *Vector<i32> = iter_range(-1, 3);   // [-1, 0, 1, 2]
+/// iter_any(v, is_neg);                       // true
+/// ```
+pub fn iter_any<T>(v: *Vector<T>, p: fn(T) -> bool) -> bool {
+    for let i: i32 = 0; i < v.len(); i++ {
+        if p(v.get(i)) { return true; }
+    }
+    return false;
+}
+
+/// `true` if all elements match `p`. Short-circuits on first miss.
+/// Empty vector returns `true` (vacuous truth).
+///
+/// ```glide
+/// fn is_pos(x: i32) -> bool { return x > 0; }
+/// let v: *Vector<i32> = iter_range(1, 4);   // [1, 2, 3]
+/// iter_all(v, is_pos);                      // true
+/// ```
+pub fn iter_all<T>(v: *Vector<T>, p: fn(T) -> bool) -> bool {
+    for let i: i32 = 0; i < v.len(); i++ {
+        if !p(v.get(i)) { return false; }
+    }
+    return true;
+}
+
+/// First element matching `p`, or `none` if no match.
+///
+/// ```glide
+/// fn is_even(x: i32) -> bool { return x % 2 == 0; }
+/// let v: *Vector<i32> = iter_range(1, 5);   // [1,2,3,4]
+/// match iter_find(v, is_even) {
+///     some(x) => println!(x),               // 2
+///     none()  => {},
+/// }
+/// ```
+pub fn iter_find<T>(v: *Vector<T>, p: fn(T) -> bool) -> ?T {
+    for let i: i32 = 0; i < v.len(); i++ {
+        let item: T = v.get(i);
+        if p(item) { return some(item); }
+    }
+    return none();
+}
+
+// ============================================================================
+// Type-specific reducers (avoid generic numeric constraints)
+// ============================================================================
+
+/// Sum of `int` elements.
+///
+/// ```glide
+/// let v: *Vector<i32> = iter_range(1, 5);   // [1,2,3,4]
+/// iter_sum_int(v);                          // 10
+/// ```
+pub fn iter_sum_int(v: *Vector<i32>) -> i32 {
+    let mut acc: i32 = 0;
+    for let i: i32 = 0; i < v.len(); i++ { acc = acc + v.get(i); }
+    return acc;
+}
+
+/// Max of `int` elements; `none` for empty vector.
+///
+/// ```glide
+/// let v: *Vector<i32> = Vector::new();  defer v.free();
+/// v.push_all!(3, 7, 2, 9, 4);
+/// iter_max_int(v);   // some(9)
+/// ```
+pub fn iter_max_int(v: *Vector<i32>) -> ?i32 {
+    if v.len() == 0 { return none(); }
+    let mut m: i32 = v.get(0);
+    for let i: i32 = 1; i < v.len(); i++ {
+        let x: i32 = v.get(i);
+        if x > m { m = x; }
+    }
+    return some(m);
+}
+
+/// Min of `int` elements; `none` for empty vector.
+///
+/// ```glide
+/// let v: *Vector<i32> = Vector::new();  defer v.free();
+/// v.push_all!(3, 7, 2, 9, 4);
+/// iter_min_int(v);   // some(2)
+/// ```
+pub fn iter_min_int(v: *Vector<i32>) -> ?i32 {
+    if v.len() == 0 { return none(); }
+    let mut m: i32 = v.get(0);
+    for let i: i32 = 1; i < v.len(); i++ {
+        let x: i32 = v.get(i);
+        if x < m { m = x; }
+    }
+    return some(m);
+}
+
+// ============================================================================
+// Constructors
+// ============================================================================
+
+/// `[start, end)` as a `Vector<int>`. Empty if `end <= start`.
+///
+/// ```glide
+/// iter_range(0, 5);    // [0, 1, 2, 3, 4]
+/// iter_range(3, 3);    // []
+/// iter_range(2, 6);    // [2, 3, 4, 5]
+/// ```
+pub fn iter_range(start: i32, end: i32) -> *Vector<i32> {
+    let out: *Vector<i32> = Vector::new();
+    let mut i: i32 = start;
+    while i < end { out.push(i); i = i + 1; }
+    return out;
+}
+
+/// `[start, start+step, start+2*step, ...)` up to (but not including) `end`.
+/// Returns empty if `step <= 0` or `end <= start`.
+///
+/// ```glide
+/// iter_range_step(0, 10, 2);    // [0, 2, 4, 6, 8]
+/// iter_range_step(10, 0, 1);    // []   (end <= start)
+/// iter_range_step(0, 5, 0);     // []   (step <= 0)
+/// ```
+pub fn iter_range_step(start: i32, end: i32, step: i32) -> *Vector<i32> {
+    let out: *Vector<i32> = Vector::new();
+    if step <= 0 { return out; }
+    let mut i: i32 = start;
+    while i < end { out.push(i); i = i + step; }
+    return out;
+}
+
+/// `n` copies of `value`. Empty if `n <= 0`.
+///
+/// ```glide
+/// iter_repeat(0, 4);            // [0, 0, 0, 0]
+/// iter_repeat("x", 3);          // ["x", "x", "x"]
+/// iter_repeat(true, 0).len();   // 0
+/// ```
+pub fn iter_repeat<T>(value: T, n: i32) -> *Vector<T> {
+    let out: *Vector<T> = Vector::new();
+    for let i: i32 = 0; i < n; i++ { out.push(value); }
+    return out;
+}

--- a/samples/Glide/math.glide
+++ b/samples/Glide/math.glide
@@ -1,0 +1,251 @@
+// Basic math.
+//
+// Integer helpers (`min_int`, `max_int`, `gcd`, `ipow`, …) are written
+// in pure Glide so they monomorphize cleanly. Floating-point lives in
+// libm via `extern fn`; link with `-lm` is automatic.
+
+/// Square root. Returns NaN for negative input.
+///
+/// ```glide
+/// sqrt(2.0);    // 1.4142135623730951
+/// sqrt(9.0);    // 3.0
+/// ```
+pub extern fn sqrt(x: f64) -> f64;
+
+/// `x^y` as a float. For integer exponents prefer `ipow` to avoid
+/// floating-point drift.
+///
+/// ```glide
+/// pow(2.0, 10.0);   // 1024.0
+/// pow(3.0, 0.5);    // sqrt(3) = 1.7320508...
+/// ```
+pub extern fn pow(x: f64, y: f64) -> f64;
+
+/// Round toward `-∞`.
+///
+/// ```glide
+/// floor(2.7);     //  2.0
+/// floor(-2.3);    // -3.0
+/// ```
+pub extern fn floor(x: f64) -> f64;
+
+/// Round toward `+∞`.
+///
+/// ```glide
+/// ceil(2.1);     //  3.0
+/// ceil(-2.7);    // -2.0
+/// ```
+pub extern fn ceil(x: f64) -> f64;
+
+/// Round to nearest, ties away from zero.
+///
+/// ```glide
+/// round(2.5);     //  3.0
+/// round(-2.5);    // -3.0
+/// round(2.4);     //  2.0
+/// ```
+pub extern fn round(x: f64) -> f64;
+
+/// Absolute value (float). Use `abs_int` for ints.
+///
+/// ```glide
+/// fabs(-1.5);     // 1.5
+/// fabs(0.0);      // 0.0
+/// ```
+pub extern fn fabs(x: f64) -> f64;
+
+/// Sine. Argument is in radians.
+///
+/// ```glide
+/// sin(0.0);          // 0.0
+/// sin(PI / 2.0);     // 1.0
+/// ```
+pub extern fn sin(x: f64) -> f64;
+
+/// Cosine. Argument is in radians.
+///
+/// ```glide
+/// cos(0.0);     // 1.0
+/// cos(PI);      // -1.0
+/// ```
+pub extern fn cos(x: f64) -> f64;
+
+/// Tangent. Argument is in radians.
+///
+/// ```glide
+/// tan(PI / 4.0);   // 1.0
+/// ```
+pub extern fn tan(x: f64) -> f64;
+
+/// Natural log (base e). Domain `x > 0`.
+///
+/// ```glide
+/// log(E);         // 1.0
+/// log(1.0);       // 0.0
+/// ```
+pub extern fn log(x: f64) -> f64;
+
+/// Log base 2.
+///
+/// ```glide
+/// log2(8.0);      // 3.0
+/// log2(1024.0);   // 10.0
+/// ```
+pub extern fn log2(x: f64) -> f64;
+
+/// Log base 10.
+///
+/// ```glide
+/// log10(1000.0);   // 3.0
+/// log10(1.0);      // 0.0
+/// ```
+pub extern fn log10(x: f64) -> f64;
+
+/// `e^x`.
+///
+/// ```glide
+/// exp(0.0);    // 1.0
+/// exp(1.0);    // E (≈ 2.71828)
+/// ```
+pub extern fn exp(x: f64) -> f64;
+
+/// Two-argument arctangent: full-circle angle of point `(x, y)` in radians.
+/// Use this instead of `atan(y / x)` when you need the right quadrant.
+///
+/// ```glide
+/// atan2(1.0, 0.0);    // PI / 2  (point straight up)
+/// atan2(0.0, 1.0);    // 0       (point along +X)
+/// atan2(0.0, -1.0);   // PI      (point along -X)
+/// ```
+pub extern fn atan2(y: f64, x: f64) -> f64;
+
+pub const PI: f64 = 3.141592653589793;
+pub const E:  f64 = 2.718281828459045;
+
+/// Smaller of two ints.
+///
+/// ```glide
+/// let a: i32 = min_int(7, 3);   // 3
+/// ```
+pub fn min_int(a: i32, b: i32) -> i32 { if a < b { return a; } return b; }
+
+/// Larger of two ints.
+///
+/// ```glide
+/// let a: i32 = max_int(7, 3);   // 7
+/// ```
+pub fn max_int(a: i32, b: i32) -> i32 { if a > b { return a; } return b; }
+
+/// Absolute value for ints. Note: `abs_int(INT_MIN)` overflows on
+/// two's-complement platforms; callers handling user input should clamp.
+///
+/// ```glide
+/// abs_int(-5);   // 5
+/// abs_int(0);    // 0
+/// ```
+pub fn abs_int(a: i32) -> i32 { if a < 0 { return -a; } return a; }
+
+/// Sign of an int: `-1`, `0`, or `+1`.
+///
+/// ```glide
+/// sign_int(-9);  // -1
+/// sign_int(0);   //  0
+/// sign_int(42);  //  1
+/// ```
+pub fn sign_int(a: i32) -> i32 {
+    if a > 0 { return 1; }
+    if a < 0 { return -1; }
+    return 0;
+}
+
+/// Clamp `x` into the inclusive range `[lo, hi]`. Behaviour is undefined
+/// when `lo > hi`; the caller is expected to keep the range well-formed.
+///
+/// ```glide
+/// clamp_int(15, 0, 10);   // 10
+/// clamp_int(-3, 0, 10);   //  0
+/// clamp_int(5,  0, 10);   //  5
+/// ```
+pub fn clamp_int(x: i32, lo: i32, hi: i32) -> i32 {
+    if x < lo { return lo; }
+    if x > hi { return hi; }
+    return x;
+}
+
+/// Smaller of two f64s. NaN behaviour follows libc semantics
+/// (an operand of NaN propagates).
+///
+/// ```glide
+/// min_f64(1.5, 2.5);   // 1.5
+/// ```
+pub fn min_f64(a: f64, b: f64) -> f64 { if a < b { return a; } return b; }
+
+/// Larger of two f64s.
+///
+/// ```glide
+/// max_f64(1.5, 2.5);   // 2.5
+/// ```
+pub fn max_f64(a: f64, b: f64) -> f64 { if a > b { return a; } return b; }
+
+/// f64 clamp into `[lo, hi]`. See `clamp_int` for caveats.
+///
+/// ```glide
+/// clamp_f64(0.5, 0.0, 1.0);   // 0.5
+/// clamp_f64(2.0, 0.0, 1.0);   // 1.0
+/// ```
+pub fn clamp_f64(x: f64, lo: f64, hi: f64) -> f64 {
+    if x < lo { return lo; }
+    if x > hi { return hi; }
+    return x;
+}
+
+/// Integer pow: `a^b` for non-negative `b`, computed by repeated squaring
+/// in O(log b). Wraps on overflow following two's-complement.
+///
+/// ```glide
+/// ipow(2, 10);   // 1024
+/// ipow(3, 4);    // 81
+/// ipow(5, 0);    // 1   (any^0)
+/// ```
+pub fn ipow(a: i32, b: i32) -> i32 {
+    let mut result: i32 = 1;
+    let mut base: i32 = a;
+    let mut exp: i32 = b;
+    while exp > 0 {
+        if exp % 2 == 1 { result = result * base; }
+        base = base * base;
+        exp = exp / 2;
+    }
+    return result;
+}
+
+/// Greatest common divisor via Euclidean algorithm. Always returns
+/// a non-negative value: `gcd(0, 0) == 0`, `gcd(-12, 8) == 4`.
+///
+/// ```glide
+/// gcd(12, 18);   // 6
+/// gcd(100, 75);  // 25
+/// ```
+pub fn gcd(a: i32, b: i32) -> i32 {
+    let mut x: i32 = abs_int(a);
+    let mut y: i32 = abs_int(b);
+    while y != 0 {
+        let t: i32 = y;
+        y = x % y;
+        x = t;
+    }
+    return x;
+}
+
+/// Least common multiple. Returns `0` when either argument is `0`.
+/// Computed as `|a / gcd(a,b) * b|` to reduce overflow risk on the
+/// intermediate product.
+///
+/// ```glide
+/// lcm(4, 6);    // 12
+/// lcm(15, 20);  // 60
+/// ```
+pub fn lcm(a: i32, b: i32) -> i32 {
+    if a == 0 || b == 0 { return 0; }
+    return abs_int(a / gcd(a, b) * b);
+}

--- a/vendor/licenses/git_submodule/vscode-glide.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-glide.dep.yml
@@ -1,0 +1,31 @@
+---
+name: vscode-glide
+version: 3f170c2cc21fd6051036c507ddceba81d0db81cd
+type: git_submodule
+homepage: https://github.com/glide-lang/vscode-glide.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+    
+    Copyright (c) 2026 Murillo Deolino
+    
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
### Description

Adds [Glide](https://github.com/glide-lang/Glide), a small, self-hosted systems
language that compiles to native code through a C backend (safe memory without a
GC or lifetime annotations, M:N coroutines + typed channels, generics/traits,
and a batteries-included stdlib + toolchain). The compiler is written in Glide
itself.

- **Extension:** `.glide`
- **TM scope:** `source.glide`
- **Grammar:** [`glide-lang/vscode-glide`](https://github.com/glide-lang/vscode-glide) (MIT), added as a submodule under `vendor/grammars/vscode-glide`.
- **Samples:** three real stdlib modules (`math`, `argparse`, `iter`) under `samples/Glide/`.

### Checklist

- [x] The language has its own file extension (`.glide`), distinct from any
  existing entry (no `.glide` collision, so no heuristic needed).
- [x] An open-source TextMate grammar is available (`source.glide`, MIT) and is
  referenced as a submodule, with a license cache entry.
- [x] Real-world sample files are included.

### A note on usage

I know the guideline is to wait until a language is used across many
repositories, and Glide is still early on that front — a code search for
`path:*.glide` (https://github.com/search?q=path%3A*.glide&type=code) is the
honest current picture. Opening this so the entry, grammar and samples are
ready; happy to keep it open until the usage bar is met, or to add more samples
/ adjust anything you'd like in the meantime.