### PR TITLE
Add Javanese Programming Language 

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3505,6 +3505,14 @@ J:
   tm_scope: source.j
   ace_mode: text
   language_id: 172
+Javanese Programming Language:
+  type: programming
+  color: "#8a5103"
+  extensions:
+  - ".jawa"
+  tm_scope: source.jawa
+  ace_mode: text
+  language_id: 67676767
 JAR Manifest:
   type: data
   color: "#b07219"

--- a/samples/Javanese Programming Language/hello.jawa
+++ b/samples/Javanese Programming Language/hello.jawa
@@ -1,0 +1,7 @@
+iki iku name yoiku "World!"
+
+gawe greet(name) terus
+balekno "Hello, " tambah name
+mbari
+
+cetakno(greet(name))


### PR DESCRIPTION
Add support for the Javanese Programming Language (JPL).

## Description
This pull request officially registers and adds syntax highlighting support for the Javanese Programming Language (JPL), which uses the unique `.jawa` file extension. JPL is an independent, interpreted language utilizing its own dedicated parser/interpreter engine. A comprehensive sample containing native variables (`iki iku`, `jarno`), block constructs (`terus`, `mbari`), and functions (`gawe`) has been added to the `samples/` directory to aid the classifier.

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.jawa+iki+iku+terus+mbari+gawe
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/elepepdev/djawa-script
    - Sample license(s): ISC
  - [x] I have included a syntax highlighting grammar: https://github.com/elepepdev/djawa-script
  - [x] I have added a color
    - Hex value: `#b07219`
    - Rationale: A warm, traditional golden-brown / teak wood color palette representing classical Javanese aesthetic tones.