### PR TITLE
Add Zag programming language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1614,3 +1614,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/zag-grammar"]
+	path = vendor/grammars/zag-grammar
+	url = https://github.com/Sylorlabs/zag-grammar.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1467,6 +1467,8 @@ vendor/grammars/xmake-lua.tmbundle:
 vendor/grammars/xml.tmbundle:
 - text.xml
 - text.xml.xsl
+vendor/grammars/zag-grammar:
+- source.zag
 vendor/grammars/zeek-sublime:
 - source.zeek
 vendor/grammars/zenstack:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -9154,6 +9154,16 @@ Zig:
   tm_scope: source.zig
   ace_mode: zig
   language_id: 646424281
+Zag:
+  type: programming
+  color: "#2563eb"
+  extensions:
+  - ".zag"
+  tm_scope: source.zag
+  ace_mode: text
+  codemirror_mode: null
+  codemirror_mime: text/x-zag
+  language_id: 828038249
 Zimpl:
   type: programming
   color: "#d67711"

--- a/samples/Zag/audio_render.zag
+++ b/samples/Zag/audio_render.zag
@@ -1,0 +1,27 @@
+// Ported slice of zenith-daw's audio render path.
+// renderBlock runs ON the realtime audio thread, so it must never allocate, lock,
+// or touch the OS. Today you enforce that by hand (AudioThreadSafeProcessor.cpp).
+// In Zag, @realtime makes the COMPILER prove it.
+
+fn gain(x: f32, g: f32) f32 @realtime {
+    return x * g;
+}
+
+fn renderBlock(buf: []f32, n: i32, freq: f32) void @realtime {
+    let phase: f32 = 0.0;
+    let inc: f32 = freq * 0.0001;
+    let i: i32 = 0;
+    while (i < n) {
+        buf[i] = gain(sinf(phase), 0.5);
+        phase = phase + inc;
+        i = i + 1;
+    }
+}
+
+fn main() i32 {
+    let buf: []f32 = zalloc(8);     // allocating here is fine: main is NOT @realtime
+    renderBlock(buf, 8, 440.0);
+    print_f32(buf[1]);
+    zfree(buf);
+    return 0;
+}

--- a/samples/Zag/numeric.zag
+++ b/samples/Zag/numeric.zag
@@ -1,0 +1,29 @@
+// Real fixed-width integer types, compiled to native code. Integer literals are comptime
+// (like Zig's comptime_int): `1` and `0` below take the type of the slot they flow into, so
+// they become u64 / i64 with no annotation noise. factorial(20) overflows i32 but fits u64.
+
+fn factorial(n: u64) u64 {
+    let acc: u64 = 1;
+    let i: u64 = 1;
+    while (i <= n) {
+        acc = acc * i;
+        i = i + 1;
+    }
+    return acc;
+}
+
+fn triangle(rounds: i64) i64 {
+    let h: i64 = 0;
+    let k: i64 = 0;
+    while (k < rounds) {
+        h = h + k * 2;
+        k = k + 1;
+    }
+    return h;
+}
+
+fn main() i32 {
+    print_u64(factorial(20));     // 2432902008176640000  (does not fit in i32)
+    print_i64(triangle(100));     // sum of 2k, k=0..99 = 9900
+    return 0;
+}

--- a/vendor/licenses/git_submodule/zag-grammar.dep.yml
+++ b/vendor/licenses/git_submodule/zag-grammar.dep.yml
@@ -1,0 +1,5 @@
+---
+name: zag-grammar
+version: 0.1.0
+license: mit
+homepage: https://github.com/Sylorlabs/zag-grammar.git


### PR DESCRIPTION
## Summary

Adds [**Zag**](https://github.com/Sylorlabs/zag), a systems programming language in the Zig lineage whose defining feature is compiler-proven capability annotations (`@realtime`, `@noalloc`, `@pure`, `@total`).

| Field | Value |
|---|---|
| Extension | `.zag` |
| Color | `#2563eb` (blue) |
| Grammar | [Sylorlabs/zag-grammar](https://github.com/Sylorlabs/zag-grammar) (`source.zag`) |
| Upstream compiler | [Sylorlabs/zag](https://github.com/Sylorlabs/zag) |

## Samples

- `samples/Zag/audio_render.zag` — effect/capability proof demo (`@realtime` audio path)
- `samples/Zag/numeric.zag` — core numeric types

Both are from the Sylorlabs/zag repository (MIT).

## In-the-wild usage

GitHub code search for `.zag` sources (primary upstream repository):

https://github.com/search?q=repo%3ASylorlabs%2Fzag+extension%3Azag&type=code

Broader search across public repos:

https://github.com/search?q=extension%3Azag+NOT+is%3Afork&type=code

> **Note:** Zag is a young language; public `.zag` file count may be below the usual 2000-file threshold today. The upstream project is actively developed with 170+ `.zag` files in the primary compiler repository and a self-hosting native toolchain.

## Checklist

- [x] `languages.yml` entry with blue color
- [x] TextMate grammar vendored (`zag-grammar`)
- [x] Real-world samples (not hello-world tutorials)
- [x] MIT-licensed grammar repository