### PR TITLE
Add Semantic language support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6018,9 +6018,9 @@ PostScript:
 Power Query:
   type: programming
   aliases:
-    - powerquery
+  - powerquery
   extensions:
-    - ".pq"
+  - ".pq"
   tm_scope: source.powerquery
   ace_mode: text
   color: "#d38e0d"
@@ -7249,6 +7249,16 @@ Scenic:
   interpreters:
   - scenic
   language_id: 619814037
+Semantic:
+  type: programming
+  color: "#1D4E89"
+  aliases:
+  - Semantic Language
+  extensions:
+  - ".sm"
+  tm_scope: none
+  ace_mode: text
+  language_id: 1046789759
 Scheme:
   type: programming
   color: "#1e4aec"

--- a/samples/Semantic/cli_batch_core.sm
+++ b/samples/Semantic/cli_batch_core.sm
@@ -1,0 +1,26 @@
+fn classify_exit(codes: Sequence(i32)) -> text {
+    let saw_error: bool = false;
+    let saw_retry: bool = false;
+    for code in codes {
+        if code == 9 {
+            saw_error ||= true;
+        }
+        if code == 2 {
+            saw_retry ||= true;
+        }
+    }
+    if saw_error == true {
+        return "error";
+    }
+    if saw_retry == true {
+        return "retry";
+    }
+    return "ok";
+}
+
+fn main() {
+    let argv_like: Sequence(i32) = [2, 1, 0];
+    let mode: text = classify_exit(argv_like);
+    assert(mode == "retry");
+    return;
+}

--- a/samples/Semantic/data_audit_record_iterable.sm
+++ b/samples/Semantic/data_audit_record_iterable.sm
@@ -1,0 +1,60 @@
+trait Iterable {
+    fn next(self: Self, index: i32) -> Option(i32);
+}
+
+record Samples {
+    first: i32,
+    second: i32,
+    third: i32,
+}
+
+record AuditSummary {
+    saw_alert: bool,
+    saw_retry: bool,
+}
+
+impl Iterable for Samples {
+    fn next(self: Self, index: i32) -> Option(i32) {
+        if index == 0 {
+            return Option::Some(self.first);
+        }
+        if index == 1 {
+            return Option::Some(self.second);
+        }
+        if index == 2 {
+            return Option::Some(self.third);
+        }
+        return Option::None;
+    }
+}
+
+fn summarize(samples: Samples) -> AuditSummary {
+    let saw_alert: bool = false;
+    let saw_retry: bool = false;
+    for value in samples {
+        if value == 9 {
+            saw_alert ||= true;
+        }
+        if value == 2 {
+            saw_retry ||= true;
+        }
+    }
+    return AuditSummary {
+        saw_alert: saw_alert,
+        saw_retry: saw_retry,
+    };
+}
+
+fn main() {
+    let samples: Samples = Samples {
+        first: 2,
+        second: 9,
+        third: 4,
+    };
+    let summary: AuditSummary = summarize(samples);
+    let patched: AuditSummary = summary with { saw_retry: false };
+    assert(summary.saw_alert == true);
+    assert(summary.saw_retry == true);
+    assert(patched.saw_retry == false);
+    return;
+}

--- a/samples/Semantic/positive_selected_import.sm
+++ b/samples/Semantic/positive_selected_import.sm
@@ -1,0 +1,7 @@
+Import "helper.sm" { score }
+
+fn main() {
+    let value: i32 = score(2);
+    assert(value == 3);
+    return;
+}

--- a/samples/Semantic/rule_state_decision.sm
+++ b/samples/Semantic/rule_state_decision.sm
@@ -1,0 +1,35 @@
+record DecisionContext {
+    camera: quad,
+    override_state: quad,
+    ready: bool,
+}
+
+fn decide(ctx: DecisionContext) -> Result(quad, quad) {
+    if ctx.override_state == T {
+        return Result::Ok(T);
+    }
+    if ctx.override_state == F {
+        return Result::Ok(F);
+    }
+    if ctx.camera == N {
+        return Result::Err(N);
+    }
+    if ctx.ready == true {
+        return Result::Ok(T);
+    }
+    return Result::Err(S);
+}
+
+fn main() {
+    let ctx: DecisionContext = DecisionContext {
+        camera: T,
+        override_state: S,
+        ready: true,
+    };
+    let verdict: quad = match decide(ctx) {
+        Result::Ok(value) => { value }
+        Result::Err(code) => { code }
+    };
+    assert(verdict == T);
+    return;
+}

--- a/samples/Semantic/wave2_local_helper_import.sm
+++ b/samples/Semantic/wave2_local_helper_import.sm
@@ -1,0 +1,7 @@
+Import "helper.sm"
+
+fn main() {
+    let value: i32 = score(1);
+    assert(value == 1);
+    return;
+}

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -171,6 +171,7 @@ class TestLanguage < Minitest::Test
   def test_find_by_extension
     assert_equal [], Language.find_by_extension('.factor-rc')
     assert_equal [Language['Limbo'], Language['M'], Language['MATLAB'], Language['MUF'], Language['Mercury'], Language['Objective-C'], Language['Wolfram Language']], Language.find_by_extension('foo.m')
+    assert_equal [Language['Semantic']], Language.find_by_extension('foo.sm')
     assert_equal [Language['Ruby']], Language.find_by_extension('foo.rb')
     assert_equal [Language['Ruby']], Language.find_by_extension('foo/bar.rb')
     assert_equal [Language['Ruby']], Language.find_by_extension('PKGBUILD.rb')


### PR DESCRIPTION
Adds Linguist support for Semantic source files (`.sm`).

What changed:
- adds `Semantic` to `lib/linguist/languages.yml`
- adds canonical Semantic samples under `samples/Semantic/`
- adds a regression test for `.sm` extension lookup in `test/test_language.rb`

Validation:
- `bundle exec ruby -Itest test/test_language.rb -n /test_find_by_extension/`
- `bundle exec ruby -Itest test/test_language.rb -n /test_all_languages_have_a_language_id_set/`
- `bundle exec ruby -Itest test/test_language.rb -n /test_all_languages_have_grammars/`
- `bundle exec ruby -Itest test/test_classifier.rb`
