### PR TITLE
Add Teko language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1614,3 +1614,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/teko-tmlanguage"]
+	path = vendor/grammars/teko-tmlanguage
+	url = https://github.com/schivei/teko-tmlanguage

--- a/grammars.yml
+++ b/grammars.yml
@@ -1196,6 +1196,8 @@ vendor/grammars/tact-sublime:
 vendor/grammars/tcl.tmbundle:
 - source.tcl
 - text.html.tcl
+vendor/grammars/teko-tmlanguage:
+- source.teko
 vendor/grammars/templ-vscode:
 - source.templ
 vendor/grammars/textMate-baml:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7817,6 +7817,7 @@ TOML:
   color: "#9c4221"
   extensions:
   - ".toml"
+  - ".tkp"
   - ".toml.example"
   filenames:
   - Cargo.lock
@@ -7982,6 +7983,15 @@ Teal:
   interpreters:
   - tl
   language_id: 719038619
+Teko:
+  type: programming
+  color: "#E62E23"
+  extensions:
+  - ".tks"
+  - ".tkt"
+  tm_scope: source.teko
+  ace_mode: text
+  language_id: 1882423431
 Terra:
   type: programming
   extensions:

--- a/samples/Teko/dog.tks
+++ b/samples/Teko/dog.tks
@@ -1,0 +1,20 @@
+// (W10b.CLASS increment 1) a basic sealed class: a static factory + an instance method,
+// exactly the sealed/no-inheritance/no-arena shape increment 1 covers.
+// (W10b.CLASS residual -- intern visibility) class members default to PRIVATE; anything
+// called/read from OUTSIDE the class (like main.tks below) must be marked `pub`.
+type Dog = class {
+    pub name: str
+    pub age: i64
+
+    pub fn make(n: str, a: i64) -> Dog {
+        Dog { name = n; age = a }
+    }
+
+    pub fn bark(self) -> str {
+        self.name
+    }
+
+    pub fn is_puppy(self) -> bool {
+        self.age < 1
+    }
+}

--- a/samples/Teko/generics_test.tkt
+++ b/samples/Teko/generics_test.tkt
@@ -1,0 +1,146 @@
+// src/checker/generics_test.tkt — (S4b) end-to-end generics coverage. Generic functions whose
+// bodies span varied expression / statement kinds, called at several distinct instantiations, so
+// the monomorph pass (typer → monomorphize) is exercised broadly: it stamps idg__g__i64 /
+// idg__g__str / pickg__g__i64 / wrapg__g__i64 / firstg__g__i64 / … , rewrites the calls, and
+// drives the Phase-2 fixpoint (a generic fn that calls another generic fn → transitive insts).
+// Runs on the VM in BOTH engines (the build/test gate), so the pass must be wired before
+// run_tests — proving a generic program type-checks, STAMPS, and EXECUTES correctly.
+
+// A box struct so a generic body can exercise struct-init + field-access node rewrites.
+type GBox = struct { v: i64 }
+
+// (S4 type-generics) a GENERIC struct — instantiated via an annotation. The instantiation pass
+// stamps Gen__g__i64 / Gen__g__str into the table, mono emits the concrete decls into the program,
+// and codegen/VM build + construct + field-read them. Exercises the full type-generic pipeline.
+type Gen<T> = struct { val: T }
+
+// the identity generic — one opaque type-param in param + return position.
+fn idg<T>(x: T) -> T { return x }
+
+// a generic body with a TIfExpr / TBinary / TCompare (the value the param flows into is concrete
+// after stamping; the param itself is opaque, so we branch on a separate concrete operand).
+fn pickg<T>(x: T, y: T, useFirst: bool) -> T {
+    let r = if useFirst { x } else { y }
+    return r
+}
+
+// a generic that CALLS another generic (idg) — drives the Phase-2 fixpoint (transitive insts).
+fn wrapg<T>(x: T) -> T {
+    let inner = idg(x)
+    return inner
+}
+
+// a generic over a SLICE type-param shape: `firstg([]T) -> T` (exercises the Slice unify +
+// the slice_<elem> mangle branch). Indexing a slice is an honest stop in codegen but the VM
+// constructs/reads it; keep this VM-only by not building it into the binary example.
+fn firstg<T>(xs: []T) -> T { return xs[0] }
+
+#test fn generic_id_i64_runs() {
+    teko::assert::is_true(idg(7) == 7)
+}
+
+#test fn generic_id_str_runs() {
+    teko::assert::is_true(teko::runtime::str_eq(idg("hi"), "hi"))
+}
+
+#test fn generic_id_box_runs() {
+    let b = idg(GBox { v = 5 })
+    teko::assert::is_true(b.v == 5)
+}
+
+#test fn generic_pick_runs() {
+    teko::assert::is_true(pickg(3, 9, true) == 3)
+    teko::assert::is_true(pickg(3, 9, false) == 9)
+}
+
+#test fn generic_wrap_runs() {
+    teko::assert::is_true(wrapg(11) == 11)
+}
+
+#test fn generic_first_runs() {
+    let xs = teko::list::push(teko::list::push(teko::list::empty(), 4), 8)
+    teko::assert::is_true(firstg(xs) == 4)
+}
+
+#test fn generic_struct_i64_runs() {
+    let g: Gen<i64> = Gen { val = 42 }
+    teko::assert::is_true(g.val == 42)
+}
+
+#test fn generic_struct_str_runs() {
+    let s: Gen<str> = Gen { val = "ok" }
+    teko::assert::is_true(teko::runtime::str_eq(s.val, "ok"))
+}
+
+#test fn generic_nested_struct_runs() {
+    // nested `Gen<Gen<i64>>` — `>>` parser close-split + the expected type threaded into the inner
+    // constructor; stamps Gen__g__i64 + Gen__g__Gen__g__i64 (S4 crumb 1b).
+    let g: Gen<Gen<i64>> = Gen { val = Gen { val = 7 } }
+    teko::assert::is_true(g.val.val == 7)
+}
+
+// (W9.4) construct a generic struct via EXPLICIT type-args with NO annotation — the construction-site
+// `Gen<i64>{ … }` stamps + targets Gen__g__i64 by itself. Runs VM==native via the gate.
+#test fn generic_struct_explicit_type_args_runs() {
+    let g = Gen<i64>{ val = 42 }
+    teko::assert::is_true(g.val == 42)
+}
+
+#test fn generic_struct_explicit_type_args_str_runs() {
+    let s = Gen<str>{ val = "ok" }
+    teko::assert::is_true(teko::runtime::str_eq(s.val, "ok"))
+}
+
+// (W9.4) nested explicit type-args at BOTH levels with NO annotation — `Gen<Gen<i64>>{ … }` outer +
+// `Gen<i64>{ … }` inner; stamps Gen__g__i64 + Gen__g__Gen__g__i64 from the construction sites alone.
+#test fn generic_struct_explicit_nested_runs() {
+    let g = Gen<Gen<i64>>{ val = Gen<i64>{ val = 7 } }
+    teko::assert::is_true(g.val.val == 7)
+}
+
+// (W9.4) GENERIC INSTANCE AS A VARIANT MEMBER — end-to-end (construct → wrap → match → bind), run
+// VM==native by the gate. The normalization pass rewrites the syntactic `Gen<i64>` in the variant
+// decl body to the bare stamped `Gen__g__i64`, so the typedef member key, the wrap, the match tag
+// and the VM case-name all agree. A non-generic member (`GenOther`) is the reference path.
+type GenOther = struct { x: i64 }
+type GenWrap  = variant Gen<i64> | GenOther
+type GenMulti = variant Gen<i64> | Gen<str> | GenOther
+
+fn gw_mk_gen() -> GenWrap   { return Gen<i64>{ val = 7 } }       // W9.4 syntax — no annotation
+fn gw_mk_gen_ann() -> GenWrap { let g: Gen<i64> = Gen { val = 7 }; return g }   // bare annotated form
+fn gw_mk_other() -> GenWrap { return GenOther{ x = 42 } }
+fn gm_mk_i() -> GenMulti { return Gen<i64>{ val = 100 } }
+fn gm_mk_s() -> GenMulti { return Gen<str>{ val = "hi" } }
+fn gm_mk_o() -> GenMulti { return GenOther{ x = 9 } }
+
+// the reproducer (bare annotated form) → 7.
+#test fn generic_variant_member_annotated_runs() {
+    let r = match gw_mk_gen_ann() { Gen<i64> as gg => gg.val; GenOther as o => o.x }
+    teko::assert::is_true(r == 7)
+}
+
+// the W9.4-syntax form (construct `Gen<i64>{ … }` with no annotation, wrap, match) → 7.
+#test fn generic_variant_member_explicit_runs() {
+    let r = match gw_mk_gen() { Gen<i64> as gg => gg.val; GenOther as o => o.x }
+    teko::assert::is_true(r == 7)
+}
+
+// the OTHER (non-generic) arm → its value, the reference path that already worked.
+#test fn generic_variant_member_other_arm_runs() {
+    let r = match gw_mk_other() { Gen<i64> as gg => gg.val; GenOther as o => o.x }
+    teko::assert::is_true(r == 42)
+}
+
+// multi-instance: a variant with `Gen<i64>` AND `Gen<str>` (distinct stamped members) — match each.
+#test fn generic_variant_multi_instance_i_runs() {
+    let r = match gm_mk_i() { Gen<i64> as a => a.val; Gen<str> as b => 1; GenOther as c => c.x }
+    teko::assert::is_true(r == 100)
+}
+#test fn generic_variant_multi_instance_s_runs() {
+    let r = match gm_mk_s() { Gen<i64> as a => a.val; Gen<str> as b => 2; GenOther as c => c.x }
+    teko::assert::is_true(r == 2)
+}
+#test fn generic_variant_multi_instance_o_runs() {
+    let r = match gm_mk_o() { Gen<i64> as a => a.val; Gen<str> as b => 3; GenOther as c => c.x }
+    teko::assert::is_true(r == 9)
+}

--- a/samples/Teko/main.tks
+++ b/samples/Teko/main.tks
@@ -1,0 +1,53 @@
+// ROUND 1 `~` binary string-concat operator — reproducer.
+// Exercises chain flattening (a~b~c -> ONE concat call, not nested), adjacent-literal
+// compile-time folding (a run of literal pieces collapses to one literal; an all-literal
+// chain collapses to a bare literal with ZERO runtime concat calls), AND the FULL
+// string-literal-kind matrix (2026-07-01): plain / verbatim / multi-line all fold identically
+// (they decode to a plain literal by parse time, no flag leaks); an interpolated string with a
+// REAL hole cannot fold (genuinely runtime); an interpolated string with ZERO holes still folds
+// (a rare but real edge case — `$"…"`/`$@"…"` with nothing to interpolate).
+//
+// Sum (first 3, the original chain-flatten/fold cases):
+//   "lit" ~ "eral" ~ "-fold"                 all-literal -> folds to "literal-fold" (len 12) => +12
+//   x ~ " " ~ y  (x="hello", y="world")      no adjacent literals to fold  (len 11)          => +11
+//   "pre-" ~ "fix-" ~ x ~ "-suf" ~ "-fix"    literal runs fold at both ends (len 21)          => +21
+// Sum (string-kind matrix, verified against generated C to confirm which fold to bare literals):
+//   "foo" ~ "bar"                                    plain~plain, folds        (len 6)  => +6
+//   @"C:\raw" ~ "-tail"                              verbatim~plain, folds     (len 11) => +11
+//   """multi\nline""" ~ "-tail"                      multi-line~plain, folds   (len 15) => +15
+//   @"""verbatim\nmulti""" ~ "-tail"                 verbatim-multi~plain, folds (len 19) => +19
+//   $"hi {name}" ~ "!"  (name="world")               real hole, does NOT fold  (len 9)  => +9
+//   $"""hi\n{name}""" ~ "!"                          real hole multi-line, does NOT fold (len 9) => +9
+//   $@"raw {name}\n" ~ "!"                           verbatim-interp real hole (len 12) => +12
+//   $@"""raw\n{name}""" ~ "!"                        verbatim-interp multi real hole (len 10) => +10
+//   "pre-" ~ @"""mid\npart""" ~ name ~ "-post"       mixed chain, partial fold (len 22) => +22
+//   $"no holes here" ~ "-tail"                       zero-hole interp, folds   (len 18) => +18
+//   $@"""no holes\nmultiline""" ~ "-tail"            zero-hole verbatim-interp multi, folds (len 23) => +23
+//   total = 44 + 6+11+15+19+9+9+12+10+22+18+23 = 198
+
+let x = "hello"
+let y = "world"
+let a = "lit" ~ "eral" ~ "-fold"
+let b = x ~ " " ~ y
+let c = "pre-" ~ "fix-" ~ x ~ "-suf" ~ "-fix"
+
+let name = "world"
+let m1 = "foo" ~ "bar"
+let m2 = @"C:\raw" ~ "-tail"
+let m3 = """multi
+line""" ~ "-tail"
+let m4 = @"""verbatim
+multi""" ~ "-tail"
+let m5 = $"hi {name}" ~ "!"
+let m6 = $"""hi
+{name}""" ~ "!"
+let m7 = $@"raw {name}\n" ~ "!"
+let m8 = $@"""raw
+{name}""" ~ "!"
+let m9 = "pre-" ~ @"""mid
+part""" ~ name ~ "-post"
+let m10 = $"no holes here" ~ "-tail"
+let m11 = $@"""no holes
+multiline""" ~ "-tail"
+
+return a.len + b.len + c.len + m1.len + m2.len + m3.len + m4.len + m5.len + m6.len + m7.len + m8.len + m9.len + m10.len + m11.len

--- a/samples/Teko/optionals.tks
+++ b/samples/Teko/optionals.tks
@@ -1,0 +1,27 @@
+// Each pub fn returns a small i64; main sums a selection to a deterministic exit code.
+
+pub type Box = struct { v: i64 }
+
+// the dominant idiom: match over an error? — null arm vs present (error as e) arm.
+fn mk_err() -> error? { error { message = "x" } }
+fn mk_ok()  -> error? { null }
+pub fn idiom_present() -> i64 { match mk_err() { null => 0; error as e => 1 } }   // → 1
+pub fn idiom_null()    -> i64 { match mk_ok()  { null => 0; error as e => 1 } }   // → 0
+
+// a T? binding + present-match.
+pub fn bind_present() -> i64 {
+    let x: i64? = 5
+    match x { null => 0; i64 as v => v }                                          // → 5
+}
+
+// fn -> i64? returning null, matched.
+fn maybe() -> i64? { null }
+pub fn ret_null() -> i64 { match maybe() { null => 0; i64 as v => v } }           // → 0
+
+// ?. + ?? : present field, and NONE falling back.
+pub fn safe_present() -> i64 { let b: Box? = Box { v = 4 }; b?.v ?? 8 }           // → 4
+pub fn safe_none()    -> i64 { let b: Box? = null;        b?.v ?? 8 }             // → 8 (NONE → fallback)
+
+// ?? : present unwraps, NONE falls back.
+pub fn coalesce_present() -> i64 { let a: i64? = 7; a ?? 9 }                       // → 7
+pub fn coalesce_none()    -> i64 { let a: i64? = null; a ?? 9 }                   // → 9

--- a/samples/Teko/uniontest.tks
+++ b/samples/Teko/uniontest.tks
@@ -1,0 +1,27 @@
+// An inline `Box | error` producer + matchers that exercise BOTH arms of the union.
+// (Box is a named struct so BOTH the VM's name-tagged value model and the native tagged-union
+//  lowering can discriminate the member — the inline-union codegen is what is under test.)
+
+pub type Box = struct { v: i64 }
+
+// Returns the Box success member (wraps a bare Box into the `Box | error` slot).
+fn ok() -> Box | error { Box { v = 7 } }
+
+// Returns the error member (a bare `error { … }` wraps into the same `Box | error` slot).
+fn fail() -> Box | error { error { message = "boom" } }
+
+// match over the Box success arm → binds and returns its v (→ 7).
+pub fn classify_ok() -> i64 {
+    match ok() {
+        Box as b  => b.v
+        error     => 0
+    }
+}
+
+// match over the error arm → the success arm is skipped, the error arm returns 99 (→ 99).
+pub fn classify_err() -> i64 {
+    match fail() {
+        Box as b  => b.v
+        error     => 99
+    }
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -642,6 +642,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **TeX:** [textmate/latex.tmbundle](https://github.com/textmate/latex.tmbundle)
 - **Tea:** [pferruggiaro/sublime-tea](https://github.com/pferruggiaro/sublime-tea)
 - **Teal:** [teal-language/vscode-teal](https://github.com/teal-language/vscode-teal)
+- **Teko:** [schivei/teko-tmlanguage](https://github.com/schivei/teko-tmlanguage)
 - **Terra:** [pyk/sublime-terra](https://github.com/pyk/sublime-terra)
 - **Terraform Template:** [hashicorp/syntax](https://github.com/hashicorp/syntax)
 - **Texinfo:** [Alhadis/language-texinfo](https://github.com/Alhadis/language-texinfo)

--- a/vendor/licenses/git_submodule/teko-tmlanguage.dep.yml
+++ b/vendor/licenses/git_submodule/teko-tmlanguage.dep.yml
@@ -1,0 +1,48 @@
+---
+name: teko-tmlanguage
+version: 6b78c25b0f00e766ebdf26ab75dc00f16e1e37d4
+type: git_submodule
+homepage: https://github.com/schivei/teko-tmlanguage
+license: mit
+licenses:
+- sources: LICENSE
+  text: 'MIT License
+
+
+    Copyright (c) 2026 Elton Schivei Costa
+
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+
+    of this software and associated documentation files (the "Software"), to deal
+
+    in the Software without restriction, including without limitation the rights
+
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+
+    copies of the Software, and to permit persons to whom the Software is
+
+    furnished to do so, subject to the following conditions:
+
+
+    The above copyright notice and this permission notice shall be included in all
+
+    copies or substantial portions of the Software.
+
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+    SOFTWARE.
+
+    '
+notices: []

--- a/vendor/licenses/git_submodule/teko-tmlanguage.dep.yml
+++ b/vendor/licenses/git_submodule/teko-tmlanguage.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: teko-tmlanguage
-version: 6b78c25b0f00e766ebdf26ab75dc00f16e1e37d4
+version: 87146f5b75557ad0fc681693468ee1e50f836333
 type: git_submodule
 homepage: https://github.com/schivei/teko-tmlanguage
 license: mit


### PR DESCRIPTION
## Description

This PR adds support for **[Teko](https://github.com/schivei/teko-lang)**, a self-hosting, all-native (AOT) programming language. The compiler is written in Teko itself and rebuilds itself to a byte-identical fixpoint.

- **Extensions:** `.tks` (source), `.tkt` (test source — same language, run by `teko test`)
- **Manifest:** `.tkp` added to **TOML** (Teko project manifests are plain TOML)
- **Scope:** `source.teko` via the MIT-licensed grammar [schivei/teko-tmlanguage](https://github.com/schivei/teko-tmlanguage), vendored as a submodule with its license dep
- **Color:** `#E62E23` (the red of the guará / scarlet ibis, the language's mascot)
- **Samples:** real-world sources from the self-hosting compiler and its regression suite (classes, optionals, unions + match, string interpolation, generics + `#test`)

## Checklist

- [x] Added an entry to `lib/linguist/languages.yml` (unique `language_id`, alphabetical position)
- [x] Added a syntax-highlighting grammar (submodule + `grammars.yml` + license)
- [x] Added real-world code samples under `samples/Teko/`
- [ ] In-the-wild usage threshold — **not met yet, hence draft** (see note below)

## Note — draft on purpose

Teko is a young language (pre-release `0.0.1.0-bootstrap`); the `.tks` extension does not yet clear the in-the-wild usage bar ([code search for extension:tks](https://github.com/search?q=extension%3Atks+NOT+is%3Afork&type=code)). This PR is kept as a **draft staging ground** and will be marked ready for review once adoption reaches the required threshold. Feedback on the entry format in the meantime is very welcome.