### PR TITLE
Add Skript and Skip languages with .sk extension disambiguation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1163,6 +1163,9 @@
 [submodule "vendor/grammars/shaders-tmLanguage"]
 	path = vendor/grammars/shaders-tmLanguage
 	url = https://github.com/tgjones/shaders-tmLanguage
+[submodule "vendor/grammars/skript-grammar"]
+	path = vendor/grammars/skript-grammar
+	url = https://github.com/SkriptLang/skript-grammar.git
 [submodule "vendor/grammars/slang-vscode-extension"]
 	path = vendor/grammars/slang-vscode-extension
 	url = https://github.com/shader-slang/slang-vscode-extension.git
@@ -1614,3 +1617,4 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+

--- a/grammars.yml
+++ b/grammars.yml
@@ -1066,6 +1066,8 @@ vendor/grammars/selinux-policy-languages:
 vendor/grammars/shaders-tmLanguage:
 - source.hlsl
 - source.shaderlab
+vendor/grammars/skript-grammar:
+- source.skript
 vendor/grammars/slang-vscode-extension:
 - source.slang
 vendor/grammars/slint-tmLanguage:

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -804,6 +804,12 @@ disambiguations:
     pattern: '(?i:mov)\s+[^\s%]{2,},'
   - language: Motorola 68K Assembly
     named_pattern: m68k
+- extensions: ['.sk']
+  rules:
+  - language: Skript
+    pattern: '\{[_a-zA-Z]\w*(?:::[\w*]+)*\}'
+  - language: Skip
+    pattern: '^(?:module|fun|native|val|var|let)\s'
 - extensions: ['.sc']
   rules:
   - language: SuperCollider

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7442,6 +7442,22 @@ Singularity:
   - Singularity
   ace_mode: text
   language_id: 987024632
+Skip:
+  type: programming
+  color: "#9b278f"
+  extensions:
+  - ".sk"
+  tm_scope: none
+  ace_mode: text
+  language_id: 574768600
+Skript:
+  type: programming
+  color: "#FF9800"
+  extensions:
+  - ".sk"
+  tm_scope: source.skript
+  ace_mode: text
+  language_id: 754733364
 Slang:
   type: programming
   color: "#1fbec9"

--- a/samples/Skip/skipComment.sk
+++ b/samples/Skip/skipComment.sk
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module Token;
+
+class LineComment() extends CommentKind {
+  fun toString(): String {
+    "Line Comment"
+  }
+}
+
+class DelimitedComment() extends CommentKind {
+  fun toString(): String {
+    "Delimited Comment"
+  }
+}
+
+extension class Comment {
+  // The contents of the comment not including leading //, /* or trailing */
+  // Does include the trailing NewLine for // comments if present.
+  fun contents(): String {
+    v = this.value;
+    this.kind match {
+    | LineComment() -> v.getIter().forward(2).collectString()
+    | DelimitedComment() ->
+      v.getIter().forward(2).slice(v.getEndIter().rewind(2))
+    }
+  }
+}
+
+module end;

--- a/samples/Skript/chest menus.sk
+++ b/samples/Skript/chest menus.sk
@@ -1,0 +1,62 @@
+
+#
+# An example of opening a chest inventory with an item.
+# Players will be able to take the item out.
+#
+
+command /simplechest:
+	permission: skript.example.chest
+	trigger:
+		set {_chest} to a new chest inventory named "Simple Chest"
+		set slot 0 of {_chest} to apple # Slots are numbered 0, 1, 2...
+		open {_chest} to player
+
+#
+# An example of listening for click events in a chest inventory.
+# This can be used to create fancy button-style interfaces for users.
+#
+
+command /chestmenu:
+	permission: skript.example.menu
+	trigger:
+		set {_menu} to a new chest inventory with 1 row named "Simple Menu"
+		set slot 4 of {_menu} to stone named "Button" # Slots are numbered 0, 1, 2...
+		open {_menu} to player
+
+on inventory click: # Listen for players clicking in an inventory.
+	name of event-inventory is "Simple Menu" # Make sure it's our menu.
+	cancel event
+	if index of event-slot is 4: # The button slot.
+		send "You clicked the button."
+	else:
+		send "You didn't click the button."
+
+#
+# An example of making and filling a fancy inventory with a function.
+# This demonstrates another way you can use chest inventories, and a safe way of listening to specific ones.
+#
+
+aliases:
+	menu items = TNT, lava bucket, string, coal, oak planks
+
+function make_menu(name: text, rows: number) :: inventory:
+	set {_gui} to a new chest inventory with {_rows} rows with name {_name}
+	loop {_rows} * 9 times: # Fill the inventory with random items.
+		set slot loop-number - 1 of {_gui} to random item out of menu items
+	return {_gui}
+
+command /fancymenu:
+	permission: skript.example.menu
+	trigger:
+		set {_menu} to make_menu("hello", 4)
+		add {_menu} to {my inventories::*} # Prepare to listen to this inventory.
+		open {_menu} to player
+
+on inventory click: # Listen for players clicking in any inventory.
+	if {my inventories::*} contains event-inventory: # Make sure it's our menu.
+		cancel event
+		send "You clicked slot %index of event-slot%!"
+
+on inventory close: # No longer need to listen to this inventory.
+	{my inventories::*} contains event-inventory
+	remove event-inventory from {my inventories::*}

--- a/samples/Skript/text formatting.sk
+++ b/samples/Skript/text formatting.sk
@@ -1,0 +1,39 @@
+
+#
+# This example is for colours and formatting in Skript.
+# Skript allows the old-style Minecraft codes using `&`, like &0 for black and &l for bold.
+# You can also use <> for colours and formats, like `<red>` for red and `<bold>` for bold
+#
+# In Minecraft 1.16, support was added for 6-digit hexadecimal colors to specify custom colors other than the 16 default color codes.
+# The tag for these colors looks like this: <#hex code> e.g. `<#123456>`
+#
+
+command /color:
+	permission: skript.example.color
+	trigger:
+		send "&6This message is golden."
+		send "<light red><bold>This message is light red and bold."
+		send "<#FF0000>This message is red."
+
+#
+# Other formatting options are also available.
+# You can create clickable text, which opens a website or execute a command, or even show a tool tip when hovering over the text.
+#
+
+command /forum:
+	permission: skript.example.link
+	trigger:
+		send "To visit the website, [<link:https://google.com><tooltip:click here>click here<reset>]"
+
+command /copy <text>:
+	permission: skript.example.copy
+	trigger:
+		# Insertion: when the player shift clicks on the message, it will add the text to their text box.
+		# To use variables and other expressions with these tags, you have to send the text as `formatted`.
+		send formatted "<insertion:%arg-1%>%arg-1%"
+
+command /suggest:
+	permission: skript.example.suggest
+	trigger:
+		send "<cmd:/say hi>Click here to run the command /say hi"
+		send "<sgt:/say hi>Click here to suggest the command /say hi"

--- a/samples/Skript/variables.sk
+++ b/samples/Skript/variables.sk
@@ -1,0 +1,53 @@
+
+#
+# This example stores a time-stamp in the global `{timer}` variable.
+# This variable is accessible everywhere, and will be saved when the server stops.
+#
+# The `{_difference}` variable is local and is different for each use of the command.
+#
+
+command /timer:
+	permission: skript.example.timer
+	trigger:
+		if {timer} is set:
+			send "This command was last run %time since {timer}% ago."
+		else:
+			send "This command has never been run."
+		set {timer} to now
+
+#
+# This example stores two items in a global list variable `{items::%uuid of player%::*}`.
+# These items can then be recalled with the example `/outfit` command, which then clears the list.
+#
+
+on join:
+	set {items::%uuid of player%::helmet} to player's helmet
+	set {items::%uuid of player%::boots} to player's boots
+	send "Stored your helmet and boots."
+
+command /outfit:
+	executable by: players
+	permission: skript.example.outfit
+	trigger:
+		give player {items::%uuid of player%::*} # gives the contents of the list
+		clear {items::%uuid of player%::*} # clears this list
+		send "Gave you the helmet and boots you joined with."
+
+#
+# An example of adding, looping and removing the contents of a list variable.
+# This list variable is local, and so will not be kept between uses of the command.
+#
+
+command /shoppinglist:
+	permission: skript.example.list
+	trigger:
+		add "bacon" to {_shopping list::*}
+		add "eggs" to {_shopping list::*}
+		add "oats" and "sugar" to {_shopping list::*}
+		send "You have %size of {_shopping list::*}% things in your shopping list:"
+		loop {_shopping list::*}:
+			send "%loop-index%. %loop-value%"
+		send "You bought some %{_shopping list::1}%!"
+		remove "bacon" from {_shopping list::*}
+		send "Removing bacon from your list."
+		send "You now have %size of {_shopping list::*}% things in your shopping list."

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -594,6 +594,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Sieve:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **Simple File Verification:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **Singularity:** [onnovalkering/vscode-singularity](https://github.com/onnovalkering/vscode-singularity)
+- **Skript:** [SkriptLang/skript-grammar](https://github.com/SkriptLang/skript-grammar)
 - **Slang:** [shader-slang/slang-vscode-extension](https://github.com/shader-slang/slang-vscode-extension)
 - **Slash:** [slash-lang/Slash.tmbundle](https://github.com/slash-lang/Slash.tmbundle)
 - **Slice:** [zeroc-ice/vscode-slice](https://github.com/zeroc-ice/vscode-slice)

--- a/vendor/licenses/git_submodule/skript-grammar.dep.yml
+++ b/vendor/licenses/git_submodule/skript-grammar.dep.yml
@@ -1,0 +1,31 @@
+---
+name: skript-grammar
+version: 2cef6b9a4f8200e34134aed0da0ab56854b4582c
+type: git_submodule
+homepage: https://github.com/SkriptLang/skript-grammar.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2022 SkriptLang
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
## Description

Adds support for the Skript language (Minecraft server scripting) and Skip language (general-purpose reactive programming) to Linguist, with a heuristic to disambiguate `.sk` files.

This PR supersedes #7659 (Camden-png's draft PR) and closes #6857.

### Skript
- **Type**: Programming
- **Extension**: `.sk`
- **Grammar**: [SkriptLang/skript-grammar](https://github.com/SkriptLang/skript-grammar) (MIT)
- **Samples**: chest menus, text formatting, variables (from [SkriptLang/Skript](https://github.com/SkriptLang/Skript) examples)
- **Color**: `#FF9800` (matches Skript logo)

### Skip
- **Type**: Programming
- **Extension**: `.sk`
- **Grammar**: none (`tm_scope: none`)
- **Samples**: skipComment.sk (from [skiplang/skip](https://github.com/skiplang/skip) compiler source)
- **Color**: `#9b278f` (Skip brand purple)

### Heuristic
- **Skript**: Matches curly-brace variable syntax unique to Skript (`{var}`, `{list::key}`)
- **Skip**: Matches module/fun/val declarations at line start

### Checklist
- [x] Extension used in 2000+ repos on GitHub.com ([search for `.sk`](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.sk) shows ~46.8k files)
- [x] Included real-world samples with license info
- [x] Included syntax highlighting grammar (Skript)
- [x] Added color for both languages
- [x] Added heuristic to disambiguate from other `.sk` languages (Skip)

### License
- Skript samples: GPL (from SkriptLang/Skript)
- Skript grammar: MIT (SkriptLang/skript-grammar)
- Skip sample: MIT (from skiplang/skip)
