### PR TITLE
Add Rux language support in languages.yml

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -796,6 +796,19 @@ disambiguations:
     pattern: '#include|#pragma\s+(rs|version)|__attribute__'
   - language: XML
     pattern: '^\s*<\?xml'
+- extensions: [".rux"]
+  rules:
+    - language: Rux
+      and:
+        - contains: '\bfunc\s+[A-Za-z_][A-Za-z0-9_]*(?:<[^>]+>)?\s*\('
+        - or:
+          - contains: '\bimport\s+[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)+'
+          - contains: '\b(let|var)\b'
+          - contains: '\b(pub|struct|enum|union|interface|type|extern)\b'
+          - contains: '@\[[A-Za-z_][A-Za-z0-9_]*(?:\([^]]*\))?\]'
+          - contains: '->\s*\*?(?:const\s+)?[A-Za-z_][A-Za-z0-9_<>]*'
+          - contains: '\b(as|is)\b'
+          - contains: '\.\.=?'
 - extensions: ['.s']
   rules:
   - language: Unix Assembly

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7006,6 +7006,14 @@ SAS:
   codemirror_mode: sas
   codemirror_mime_type: text/x-sas
   language_id: 328
+Rux:
+  type: programming
+  color: "#9262db"
+  extensions:
+    - ".rux"
+  tm_scope: source.rux
+  ace_mode: text
+  codemirror_mode: text
 SCSS:
   type: markup
   color: "#c6538c"


### PR DESCRIPTION
## Description

Adds support for [**Rux**](https://rux-lang.dev/), a statically typed systems programming language, to GitHub Linguist.

This PR adds:

* Language metadata (`languages.yml`)
* The `.rux` file extension
* A dedicated language color (`#9262db`)
* Sample source files for language detection
* A syntax highlighting grammar

## Checklist:

* [x] **I am adding a new language.**

  * [x] The extension of the new language is used in hundreds of repositories on GitHub.com.

    * Search results for each extension:

      * https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.rux+Rux
  * [x] I have included a real-world usage sample for all extensions added in this PR:

    * Sample source(s):

      * https://github.com/Natuworkguy/Pux-module
    * Sample license(s):

      * MIT
  * [x] I have included a syntax highlighting grammar:

    * https://github.com/rux-lang/VSCode/blob/main/syntaxes/rux.tmLanguage.json
  * [x] I have added a color

    * Hex value: `#9262db`
    * Rationale: This color was chosen by the Rux project and serves as its primary branding color.
  * [x] I have updated the heuristics to distinguish my language from others using the same extension.
