### PR TITLE
add claire support

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -187,6 +187,8 @@ disambiguations:
   rules:
   - language: Common Lisp
     pattern: '^\s*\((?i:defun|in-package|defpackage) '
+  - language: Claire
+    pattern: '\b(?:Defclass|Defmethod|Defobj)\b|\s+<:\s+|\?>'
   - language: Cool
     pattern: '^class'
   - language: OpenCL

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1225,6 +1225,16 @@ Cirru:
   extensions:
   - ".cirru"
   language_id: 58
+Claire:
+  type: programming
+  color: "#009688"
+  extensions:
+  - ".cl"
+  tm_scope: none
+  ace_mode: text
+  codemirror_mode: text
+  codemirror_mime_type: text/plain
+  language_id: 734793890
 Clarion:
   type: programming
   color: "#db901e"

--- a/samples/Claire/airline-old.cl
+++ b/samples/Claire/airline-old.cl
@@ -1,0 +1,46 @@
+;; This programs compute the cities that one can visit from another city
+;;
+FLIGHT <: object
+CITY <: thing
+
+CITY <: thing(flight:set[CITY],
+               directflight:set[CITY],
+               flight_of:set[CITY],
+               directflight_of:set[CITY],
+               departs:set[FLIGHT],
+               arrives:set[FLIGHT],
+			   query:boolean = false)
+			   
+FLIGHT <: object(leaves:CITY,
+                  go-to:CITY,
+                  departure:integer,
+                  arrival:integer,
+                  id:symbol)
+
+
+// set inverses
+(inverse(flight) := flight_of,
+ inverse(directflight) := directflight_of,
+ inverse(leaves) := departs,
+ inverse(go-to) := arrives)
+ 
+event(query,flight,directflight)
+
+// rules
+Rr1(x:CITY, y:CITY) :: rule(
+  query(x) = true & exists(z:FLIGHT, leaves(z) = x & go-to(z) = y) 
+  =>  (directflight(x) :add y, query(y) := true))
+
+Rr2(x:CITY, y:CITY) :: rule(
+  y % directflight(x) | exists(z:CITY, z % flight(x) & y % directflight(z))
+  => flight(x) :add y )
+
+[do_test()
+  -> let m := value("muenchen") in
+       (time_set(),
+        query(m) := true,
+        time_show(),
+        printf("there are ~A cities where you can go from Muenchen.~%",
+                size(flight(m)))) ]
+		
+[do_load() -> load(home() / "lib\\other\\rule\\airdata") ]

--- a/samples/Claire/queens.cl
+++ b/samples/Claire/queens.cl
@@ -1,0 +1,61 @@
+// a naive N-queen problem
+
+N:integer := 64
+
+column[n:(1 .. N)] : (0 .. N) := 0     // 0 for no values yet
+possible[x:(1 .. N), y:(1 .. N)] : boolean := true
+countPos[n:(1 .. N)] : (0 .. N) := N 
+ 	
+// two defeasible attributes    
+store(column, possible, countPos)
+
+// remove a possible value
+forbid(x:(1 .. N),y:(1 .. N)) : void 
+  -> (if (column[x] = 0 & possible[x,y])
+        (possible[x,y] := false, 
+         countPos[x] :- 1,
+         if (countPos[x] = 0) contradiction!()))
+
+// three rules that implement the allDifferent constraints
+r1() :: rule( 
+ 		column[x] := z => for y in ((1 .. N) but x) forbid(y,z))
+
+r2() :: rule( 	
+        column[x] := z => let d := x + z in
+                            for y in (max(1,d - N) .. min(d - 1, N))
+                                forbid(y,d - y))
+r3() :: rule( 	
+        column[x] := z => let d := (z - x) in 
+                            for y in (max(1,1 - d) .. min(N,N - d))
+                                forbid(y,y + d))
+	
+// finds the position with the fewest choice, 0 if none
+tightest()
+  -> let m := N + 1, best := 0 in
+       (for j in (1 .. N)
+          (if (column[j] = 0 & countPos[j] < m) 
+              (best := j, m := countPos[j])),
+        best)
+            
+
+queens(n:integer) : boolean
+		-> (if (n = 0) true
+            else let q := tightest() in
+			    exists(p in (1 .. N) |
+					(possible[q,p]	&
+                      branch( (column[q] := p, queens(n - 1)) ))))
+	
+// print the solution
+  solution() -> list{column[i] | i in (1 .. N)}
+
+
+// check the solution before blogging :)
+[checkSol()
+ -> for i in (1 .. N)
+      for j in ((1 .. N) but i)
+        (if (column[i] = column[j] |
+            column[i] + i = column[j] + j |
+            column[i] - i = column[j] - j)
+            printf("Error at ~S:~S and ~S:~S\n", i,column[i], j,column[j]))]    
+
+  

--- a/samples/Claire/testFib.cl
+++ b/samples/Claire/testFib.cl
@@ -1,0 +1,78 @@
+// fib test - the oldest claire file :)
+fib(n:integer) : integer -> (if (n < 2) n else (fib(n - 1) + fib(n - 2)))
+
+g(n:integer) : void
+  -> (time_set(), fib(n), time_show())
+
+// version with floats
+[fab(n:float) : float -> if (n < 2.0) 1.0001 else fab(n - 1.0) + fab(n - 2.0)]
+
+[tfab(n:float) 
+  -> time_set(), fab(n), time_show()]
+
+// bug for debugging
+foo(n:integer) : integer
+  -> (if (n < 1) (1 / n) else 1 + foo(n - 1)) 
+
+// quicksort was added from Julia benchmark ----------
+
+// float random generator
+[random(f:float) : float
+  -> let m := 10000000, n := random(m) in
+       (f * float!(n) / float!(m))]
+
+
+// call quicksort on a random array of 5000 
+// too fast when compiled => added a x10
+testSort(N:integer) 
+ -> let lst := make_array(N,float,0.0) in 
+   	(time_set(),
+   	 for k in (1 .. 100)
+        (for i in (1 .. N) lst[i] := random(1.0),
+         qsort(lst,1,N)),
+     time_show())
+
+// test and see :)
+tests(N:integer)
+  -> let lst := make_array(N, float, 0.0) in 
+   	  (for i in (1 .. N) lst[i] := random(1.0),
+       qsort(lst,1,N),
+       printf("sorted = ~S\n",list{lst[i] | i in (1 .. N)})) 
+
+// quick sort from the Julia benchmark
+qsort(a:float[], lo:integer, hi:integer) : float[]
+-> let i := lo, j := hi in 
+ (while (i < hi)
+   let pivot := a[(lo + hi) / 2] in
+       (while (i <= j)
+           (while (a[i] < pivot) i :+ 1,
+            while (a[j] > pivot) j :- 1, 
+            if (i <= j)
+              let z := a[i] in 
+                 (a[i] := a[j], 
+                  a[j] := z,
+                  i :+ 1,
+                  j :- 1)),
+      if (lo < j) qsort(a, lo, j),
+      lo := i,
+      j := hi),
+ a)
+
+
+// execute all tests
+
+all() ->
+  (princ("fib(30)"),
+   g(30),
+   princ("fib(35)"),
+   g(35),
+   princ("fib(35.0)"),
+   tfab(35.0),
+   princ("100 x quicksort(10000)"),
+   testSort(10000))
+
+[main() -> 
+  //[0] test fib ----- //,
+  all(),
+  exit(0) ]
+


### PR DESCRIPTION
## Description

Add support for the **Claire** language; Claire 3.x, its fork as XL Claire, and Claire 4.

Common Lisp and Cool use the same .cl file extension.

Linguist registers 3.4% Cool in  [ycaseau/CLAIRE3.5](https://github.com/ycaseau/CLAIRE3.5).
Linguist registers 1.4% Cool in [expert-solutions-clariprint/Claire](https://github.com/expert-solutions-clariprint/Claire); the fork as XL Claire.
Linguist registers 23.5% C In [ycaseau/CLAIRE4](https://github.com/ycaseau/CLAIRE4); not a single C language file in the repository.

## Checklist:

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.FOOBAR+KEYWORDS
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s): airline-old.cl, queens.cl, testFib.cl
      - https://github.com/ycaseau/CLAIRE4/blob/main/test/rules/airline-old.cl
      - https://github.com/ycaseau/CLAIRE4/blob/main/test/toys/queens.cl
      - https://github.com/ycaseau/CLAIRE4/blob/main/test/perf/testFib.cl
    - Sample license(s): https://github.com/ycaseau/CLAIRE4/blob/main/LICENSE
  - [ ] I have included a syntax highlighting grammar: [URL to grammar repo]
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#009688`
    - Rationale: An æsthetic evocative of former hard cover bindings for scientific textbooks.
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.