### PR TITLE
Draft: Add L++ language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1614,3 +1614,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/lpp-vscode-grammar"]
+	path = vendor/grammars/lpp-vscode-grammar
+	url = https://github.com/samarnever-droid/lpp-vscode-grammar.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1473,3 +1473,6 @@ vendor/grammars/zenstack:
 - source.zmodel
 vendor/grammars/zephir-sublime:
 - source.php.zephir
+
+vendor/grammars/lpp-vscode-grammar:
+- source.lpp

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4096,6 +4096,14 @@ Kusto:
   tm_scope: source.kusto
   ace_mode: text
   language_id: 225697190
+L++:
+  type: programming
+  color: "#6B8E23"
+  extensions:
+  - ".lpp"
+  tm_scope: source.lpp
+  ace_mode: text
+
 LFE:
   type: programming
   color: "#4C3023"

--- a/samples/L++/LICENSE.md
+++ b/samples/L++/LICENSE.md
@@ -1,0 +1,3 @@
+The L++ samples in this directory were copied from
+https://github.com/samarnever-droid/lplusplus and are contributed under the
+MIT license of that repository.

--- a/samples/L++/control_flow_demo.lpp
+++ b/samples/L++/control_flow_demo.lpp
@@ -1,0 +1,8 @@
+def main() -> Void:
+    mut i := 0
+    while i < 5:
+        if i == 2:
+            print(100)
+        else:
+            print(i)
+        i = i + 1


### PR DESCRIPTION
## Summary

Adds a draft L++ language definition for the `.lpp` extension, its MIT-licensed TextMate grammar, and representative real-world samples.

## Language details

- Name: L++
- Extension: `.lpp`
- TextMate scope: `source.lpp`
- Grammar source: https://github.com/samarnever-droid/lpp-vscode-grammar
- Language repository: https://github.com/samarnever-droid/lplusplus

## Samples and license

The samples are copied from the MIT-licensed L++ repository and the sample directory states that provenance explicitly.

## Draft status

This is intentionally a draft until upstream maintainers can review the grammar vendoring, language ID generation, and GitHub usage requirements. The repository currently has generated benchmark reports excluded from Linguist statistics via `.gitattributes`.