### PR TITLE
updated to latest Q# grammar

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -1016,8 +1016,10 @@ vendor/grammars/python-django.tmbundle:
 - source.python.django
 - text.html.django
 vendor/grammars/qsharp:
+- source.deq
 - source.openqasm
 - source.qsharp
+- source.stim
 vendor/grammars/quake:
 - source.quake
 vendor/grammars/quakec-syntax:


### PR DESCRIPTION
Pulls in the latest Q# grammar from QDK repo. 
I think this might happen automatically too, but I wanted to proactively get it in. Hope this is fine.

This includes 
a) the latest, much improved TM grammar for Q# 
b) fixes the OpenQASM grammar issues.

That would tick the open boxes here https://github.com/github-linguist/linguist/issues/3924

> repository vendor/grammars/qsharp (from https://github.com/microsoft/qsharp.git) (2 errors)
> [ ] Invalid regex in grammar: source.openqasm (in source/vscode/syntaxes/openqasm.tmLanguage.json) contains a malformed regex (regex "(?<!\s*\.\s*)\b(in|for|return|if...": lookbehind assertion is not fixed length (at offset 12))
> [ ] Invalid regex in grammar: source.openqasm (in source/vscode/syntaxes/openqasm.tmLanguage.json) contains a malformed regex (regex "(?<!\s*\.\s*)\b(OPENQASM|include...": lookbehind assertion is not fixed length (at offset 12)) 