### PR TITLE
Update Gno language color

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2738,7 +2738,7 @@ Glyph Bitmap Distribution Format:
   language_id: 997665271
 Gno:
   type: programming
-  color: "#530c04"
+  color: "#226c57"
   aliases:
   - gnolang
   extensions:


### PR DESCRIPTION
## Description

Updates the Gno language color from `#530c04` to the current official brand green, `#226c57`.

This is a small follow-up to #8077, requested by the Gno frontend/design team after the original PR was merged.

## Checklist

- [x] **I am changing the color associated with a language**
  - [x] I have obtained agreement from the wider language community on this color change.
    - Agreement: requested directly by the Gno frontend/design team in the project chat.
    - Official branding: https://github.com/gnolang/branding/blob/3de1fcff368df228d46b87ec476a3e1485e145c9/svg/Logo%20Full%20On%20White%20Background.svg

## Validation

- Confirmed `lib/linguist/languages.yml` parses successfully.
- Confirmed the Gno color resolves to `#226c57`.
- `git diff --check` passes.