### PR TITLE
Fix Git LFS pointer detection and exclusion

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -119,6 +119,24 @@ module Linguist
       @detect_encoding ||= CharlockHolmes::EncodingDetector.new.detect(data) if data
     end
 
+    # Public: Is the blob content a Git LFS pointer file?
+    #
+    # Return true or false
+    def lfs_pointer?
+      return false unless data
+
+      data.start_with?("version https://git-lfs.github.com/spec/v1\n") &&
+        data.include?("\noid sha256:") &&
+        data.match?(/\nsize \d+\n?\z/)
+    end
+
+    # Public: Is the blob path tracked by Git LFS?
+    #
+    # Return true or false
+    def lfs_tracked?
+      false
+    end
+
     # Public: Is the blob binary?
     #
     # Return true or false
@@ -380,6 +398,7 @@ module Linguist
       !vendored? &&
       !documentation? &&
       !generated? &&
+      !(lfs_tracked? && lfs_pointer?) &&
       language && ( defined?(detectable?) && !detectable?.nil? ?
         detectable? :
         DETECTABLE_TYPES.include?(language.type)

--- a/lib/linguist/lazy_blob.rb
+++ b/lib/linguist/lazy_blob.rb
@@ -9,7 +9,8 @@ module Linguist
                 'linguist-language',
                 'linguist-vendored',
                 'linguist-generated',
-                'linguist-detectable']
+                'linguist-detectable',
+                'filter']
 
     # DEPRECATED: use Linguist::Source::RuggedRepository::GIT_ATTR_OPTS instead
     GIT_ATTR_OPTS = Linguist::Source::RuggedRepository::GIT_ATTR_OPTS
@@ -103,6 +104,10 @@ module Linguist
       else
         nil
       end
+    end
+
+    def lfs_tracked?
+      git_attributes['filter'] == 'lfs'
     end
 
     def data

--- a/test/test_cli_integration.rb
+++ b/test/test_cli_integration.rb
@@ -136,4 +136,27 @@ class TestCLIIntegration < Minitest::Test
     assert_match(/src\/app\.rb \[Extension\]/, stdout, "Should show Extension strategy for Ruby file")
     assert_match(/config\.config \[.* \(overridden by \.gitattributes\)\]/, stdout, "Should show override for overridden file")
   end
+
+  def test_breakdown_excludes_git_lfs_pointer_blobs
+    File.write('.gitattributes', "*.nc filter=lfs diff=lfs merge=lfs -text\n")
+    File.write('test.rb', "puts 'Hello, World!'\n")
+    File.write('data.nc', <<~LFS)
+      version https://git-lfs.github.com/spec/v1
+      oid sha256:a9d8db4a33528bbd0ff5f88fcbd0ddf74ee5dc150b4e02e77e0ee4f4002a1eb9
+      size 14131452
+    LFS
+
+    system("git add .")
+    system("git commit -m 'Add lfs pointer blob' --quiet")
+
+    stdout, stderr, status = Open3.capture3(
+      "bundle", "exec", "github-linguist", @temp_dir, "--breakdown", "--strategies",
+      chdir: @original_dir
+    )
+
+    assert status.success?, "CLI command failed: #{stderr}"
+    assert_match(/test\.rb \[Extension\]/, stdout, "Should still report normal source files")
+    refute_match(/data\.nc/, stdout, "Should exclude Git LFS pointer blobs from breakdown output")
+    refute_match(/nesC:/, stdout, "Should not report a language section created only by an LFS pointer blob")
+  end
 end


### PR DESCRIPTION
In repository scan mode, Linguist analyzes Git blobs directly instead of files on disk. For LFS-tracked paths, that blob can be a text pointer file, which may be misclassified as source code via its extension.

Those text pointers only contain text which means binary data can appear as code if the extension supported by Linguist as a programming language extension. Example of a Git LFS pointer file:

```
version https://git-lfs.github.com/spec/v1
oid sha256:a9d8db4a33528bbd0ff5f88fcbd0ddf74ee5dc150b4e02e77e0ee4f4002a1eb9
size 14131452
```

This problem was discovered in https://github.com/github-linguist/linguist/discussions/8072#discussioncomment-17630723

## The Fix Proposed in this PR

The fix proposed here is to exclude files from stats only when both conditions are true:

1. The file path is LFS-tracked via Git attributes (`filter=lfs`).
2. The analyzed blob content matches Git LFS pointer format.

That avoids over-filtering while preventing pointer blobs from inflating language totals.

## Reproduce The Bug From The Linguist Repo

### 1) Clone a repository that contains large binary data tracked with Git LFS

Use a known repro repository and commit:

```bash
git clone https://github.com/MO-Helena-Reid/isca-analysis /tmp/isca-analysis
cd /tmp/isca-analysis
git checkout b92be0273597077a2fd6d7e409195a790155b8a6
```

### 2) Run Linguist from this repository against that target repo

From a local checkout of Linguist:

```bash
cd /path/to/linguist
bundle exec bin/github-linguist /tmp/isca-analysis --breakdown --strategies
```

### 3) Show that repository mode is reading LFS pointer blob content

To illustrate what Linguist sees during repository stats, add this temporary debug snippet in `update_file_map` in [`lib/linguist/repository.rb`](https://github.com/github-linguist/linguist/compare/lib/linguist/repository.rb):

```ruby
if ENV['LINGUIST_DEBUG_BLOB_PATH'] == key
  warn "--- LINGUIST DEBUG BLOB: #{key} ---"
  warn blob.data.to_s
  warn "--- END LINGUIST DEBUG BLOB: #{key} ---"
end
```

Then run:

```bash
LINGUIST_DEBUG_BLOB_PATH='data/linear_no_sc_p4k_164.nc' \
  bundle exec bin/github-linguist /tmp/isca-analysis --breakdown --strategies
```

You can observe pointer text such as:

```
version https://git-lfs.github.com/spec/v1
oid sha256:...
size ...
```

## Why Not Exclude All filter=lfs Files

We cannot safely exclude every path with `filter=lfs`.

Some repositories adopt LFS after initial history was created. In those cases, paths that are currently LFS-tracked may still have older revisions where content is not stored as an LFS pointer blob.

Excluding by attribute alone can over-filter and hide valid source content in such mixed-history cases.

That is why this PR uses both checks:

1. LFS-tracked path check (`filter=lfs`).
2. Pointer-content check (Git LFS pointer shape in blob data).

Only files satisfying both are excluded from language stats.

## Test Coverage

A CLI integration test was added/updated in [`test/test_cli_integration.rb`](https://github.com/github-linguist/linguist/compare/test/test_cli_integration.rb) to verify behavior:

1. A test repo includes `.gitattributes` with `*.nc filter=lfs ...`.
2. A `.nc` file is committed as an LFS pointer-shaped blob.
3. A normal source file is also committed.
4. Running `github-linguist --breakdown --strategies` confirms:
   - normal source files still appear in output;
   - the LFS pointer blob does not contribute to language stats.

This ensures the fix is narrow and prevents regressions.