### PR TITLE
Add SRL language support to languages.yml

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -9461,3 +9461,14 @@ xBase:
   tm_scope: source.harbour
   ace_mode: text
   language_id: 421
+SRL:
+  type: programming
+  color: "#00BFFF"
+  extensions:
+  - ".srl"
+  tm_scope: source.srl
+  ace_mode: c_cpp
+  codemirror_mode: clike
+  codemirror_mime_type: text/x-c++src
+  language_id: 8901234
+


### PR DESCRIPTION
Add support for SRL (Serial Run Language), a high-performance C/Lua hybrid programming language with a self-hosted LLVM compiler and DSP engine.

## Description
This pull request adds language detection support for SRL (Serial Run Language) with the `.srl` file extension.

- Reference Implementation: https://github.com/srl-lang/srl-lang
- File Extension: `.srl`

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.srl+fn
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/srl-lang/srl-lang/blob/main/examples/package_demo.srl
    - Sample license(s): GPL-3.0
  - [x] I have included a syntax highlighting grammar: https://github.com/srl-lang/srl-lang
  - [x] I have added a color
    - Hex value: `#00BFFF`
   
