### PR TITLE
Add LSS (Light Style Sheets) language support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4466,6 +4466,11 @@ Luau:
   interpreters:
   - luau
   language_id: 365050359
+LSS:
+  type: markup
+  color: "#C8A2FF"
+  extensions:
+  - ".lss"
 M:
   type: programming
   aliases:


### PR DESCRIPTION
## Description

Adds support for LSS (Light Style Sheets), a lightweight stylesheet language designed to work with HTML and JavaScript.

## Checklist:

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [https://github.com/liamprosser77/lss-programming-language]
    - Sample license(s):
      - [MIT Licence]
  - [ ] I have included a syntax highlighting grammar: [Add grammar URL if available]
  - [x] I have added a color
    - Hex value: `#C8A2FF`
    - Rationale: Light purple was chosen to represent the "Light" in Light Style Sheets and to give LSS a unique identity.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.