### PR TITLE
Add support for Cj

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1587,6 +1587,15 @@ Cython:
   codemirror_mode: python
   codemirror_mime_type: text/x-cython
   language_id: 79
+  
+CJ:
+  type: programming
+  color: "#E34C26"
+  extensions:
+    - .cj
+  tm_scope: source.cj
+  ace_mode: cj
+
 D:
   type: programming
   color: "#ba595e"

--- a/samples/CJ/main.cj
+++ b/samples/CJ/main.cj
@@ -1,0 +1,6 @@
+Library.-(Text.rar)./yex
+text.txt/(Hello World)
+indexes[
+  virtual_archive_memory_start: 0x00F1,
+  file_end_declaration: true
+]


### PR DESCRIPTION
### Description
Please add support for CJ (official extension `.cj`). 

CjProjectLang is a lightweight compiled/interpreted programming language designed for extreme modularity, automation, and 2.5D/3D multimedia components. It utilizes structured footer Finalization declarations (`indexes`) and a unique stream-oriented output approach.

- **Language Name:** CJ
- **Extension:** `.cj`
- **Grammar URL/Scope:** source.cj
- **Sample included:** Yes, added under `samples/CjProjectLang/main.cj`

Thank you for reviewing and merging this addition to the GitHub ecosystem!
