### PR TITLE
add-seven-language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7309,6 +7309,37 @@ ShaderLab:
   ace_mode: text
   tm_scope: source.shaderlab
   language_id: 664257356
+  Self:
+  type: programming
+  color: "#0579aa"
+  extensions:
+  - ".self"
+  tm_scope: none
+  ace_mode: text
+  language_id: 345
+
+Seven:
+  type: programming
+  color: "#6B4EFF"
+  aliases:
+  - seven
+  - sev
+  extensions:
+  - ".sev"
+  tm_scope: source.seven
+  ace_mode: text
+
+ShaderLab:
+  type: programming
+  color: "#222c37"
+  extensions:
+  - ".shader"
+  ace_mode: text
+  tm_scope: source.shaderlab
+  language_id: 664257356
+
+Shell:
+  type: programming
 Shell:
   type: programming
   color: "#89e051"


### PR DESCRIPTION
## Description

This pull request adds preliminary support for the **Seven** programming language to GitHub Linguist.

### Changes
- Added the `Seven` language definition to `languages.yml`.
- Registered the `.sev` file extension.
- Added language aliases: `seven` and `sev`.
- Assigned a language color (`#6B4EFF`).
- Configured the TextMate scope as `source.seven`.
- Configured the Ace mode as `text`.

### Motivation

Seven is a new programming language currently under development. This change is the first step toward allowing GitHub to recognize `.sev` source files and correctly classify repositories containing Seven code instead of treating them as plain text or another language.

Future pull requests will include syntax highlighting, additional heuristics, and more usage samples as the language ecosystem grows.

## Checklist

- [ ] **I am adding a new extension to a language.**

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
  - [ ] I have included a real-world usage sample for all extensions added in this PR.
  - [ ] I have included a syntax highlighting grammar.
  - [x] I have added a color.
    - Hex value: `#6B4EFF`
    - Rationale: Chosen as the official color for the Seven programming language.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**

- [ ] **I am changing the source of a syntax highlighting grammar**

- [ ] **I am updating a grammar submodule**

- [ ] **I am adding new or changing current functionality**

- [ ] **I am changing the color associated with a language**