### PR TITLE
Rebuild the published Docker image on a supported Ruby, and pin the gem to the release

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -42,6 +42,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
+          build-args: |
+            LINGUIST_VERSION=${{ github.event.release.tag_name }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-FROM ruby:2-alpine3.13
+FROM ruby:3.4-alpine
+
+# The release tag (e.g. v9.6.0). Pinning the gem here is what makes the published image
+# match the release it is tagged with: with a bare `gem install github-linguist` the RUN
+# instruction text never changes, so the registry build cache replays the same layer on
+# every release. The `#v` strips the tag's leading "v" for RubyGems.
+ARG LINGUIST_VERSION=
 
 RUN apk --update add --virtual build_deps \
     build-base \
     libc-dev \
     cmake \
+    zlib-dev \
     && apk add icu-dev openssl-dev \
-    && gem install github-linguist \
+    && gem install github-linguist ${LINGUIST_VERSION:+-v ${LINGUIST_VERSION#v}} \
     && apk del build_deps \
 	&& rm /var/cache/apk/*
 


### PR DESCRIPTION
## Description

`ghcr.io/github-linguist/linguist:latest` is the image the README recommends (README.md:296). Pulling it today gives something older than I expected, in two separate ways, and I think both come from the same couple of lines.

### 1. The tag doesn't match the contents

I pulled three tags and looked inside:

| tag | github-linguist inside | image config created |
|---|---|---|
| `latest` | 9.3.0 | 2026-01-13 |
| `v9.6.0` | 9.3.0 | 2026-01-13 |
| `v9.5.0` | 9.3.0 | 2026-01-13 |

9.3.0 was released 2025-09-18, so the image tagged `v9.6.0` is three releases behind.

The cause looks like the build cache. The `Dockerfile` runs a bare `gem install github-linguist` with no version, so the cache key for that layer is the instruction text, which never changes. `publish_docker_image.yml` restores it with `cache-from: type=registry,…:buildcache` on every release, so the same January layer gets republished under each new tag. `docker history` on the published image shows the `gem install` layer months older than the push.

This also means the provenance attestation the workflow attaches ends up describing an artifact whose contents predate the source it was built from — which seems worth avoiding, given attestation is there precisely to raise trust in the image.

### 2. The base is past end of life

The published image is Alpine 3.13.7 with Ruby 2.7.5 and OpenSSL 1.1.1s. Alpine 3.13 went EOL 2022-11-01, Ruby 2.7 on 2023-03-31, OpenSSL 1.1.1 on 2023-09-11. Trivy reports 20 HIGH/CRITICAL against it.

One thing I'd flag because it's easy to miss: scanners under-report this one. Alpine 3.13's security database stopped being updated at EOL and its highest recorded `openssl` entry is `1.1.1q-r0`, while the image ships `1.1.1s-r0` — newer than anything that database knows about — so OpenSSL comes back clean even though 1.1.1s predates 1.1.1t–1.1.1w. And because 3.13 receives no updates, `apk upgrade` can't fix any of it.

## The change

Base moves to `ruby:3.4-alpine` (Alpine 3.24, Ruby 3.4.10 — 3.4 is already in your CI matrix), and the gem is pinned to the release tag via a build arg so each release produces a distinct cache key.

To be precise about why both halves are here: changing `FROM` invalidates the downstream layers, so the base bump on its own would force one honest rebuild and produce a correct image *for that release*. But the `gem install` line would then re-freeze at whatever gem was current during that rebuild, and the drift would start again from the next release. The version pin is what stops it recurring.

`zlib-dev` is added because it was arriving transitively on Alpine 3.13 but isn't on current Alpine — without it `charlock_holmes` fails to link with `cannot find -lz`. I hit that on my first attempt, so I'm flagging it rather than leaving it as a surprise.

## What I checked

- Builds clean, and `github-linguist` reports the language breakdown for this repo — the same smoke test `ci.yml` already runs (`docker run … | grep Ruby`).
- Trivy on the rebuilt image: **20 HIGH/CRITICAL → 0**.
- With `--build-arg LINGUIST_VERSION=v9.6.0` the image contains 9.6.0, so the tag and the contents agree.
- With no build arg — which is what `ci.yml:47` does — it still installs the latest gem, so the existing Dockerfile CI job is unaffected.
- Incidentally this also picks up `cgi` 0.4.2 instead of the 0.1.0.1 that ships with Ruby 2.7 (CVE-2021-33621, CVE-2025-27219, CVE-2025-27220). The gemspec's `cgi >= 0` places no floor, so it couldn't have pulled that forward on its own; happy to add a real floor in a separate PR if you'd like.

If you'd rather build the image from the checked-out source than install the published gem, that would make the provenance statement literally true rather than merely consistent — but that's a bigger change than this one and I didn't want to assume.

---

*Disclosure: I used an AI coding agent (Claude Opus 5) to help spot this and prepare the change. I pulled and inspected the published images, ran the builds and the scans, and verified the smoke test myself before opening this.*