### PR TITLE
Add Tape language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1572,6 +1572,9 @@
 [submodule "vendor/grammars/vscode-vento"]
 	path = vendor/grammars/vscode-vento
 	url = https://github.com/ventojs/vscode-vento.git
+[submodule "vendor/grammars/vscode-vhs"]
+	path = vendor/grammars/vscode-vhs
+	url = https://github.com/griimick/vscode-vhs.git
 [submodule "vendor/grammars/vscode-vlang"]
 	path = vendor/grammars/vscode-vlang
 	url = https://github.com/0x9ef/vscode-vlang
@@ -1620,6 +1623,3 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
-[submodule "vendor/grammars/vscode-vhs"]
-	path = vendor/grammars/vscode-vhs
-	url = https://github.com/griimick/vscode-vhs.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1620,3 +1620,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/vscode-vhs"]
+	path = vendor/grammars/vscode-vhs
+	url = https://github.com/griimick/vscode-vhs.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1418,6 +1418,8 @@ vendor/grammars/vscode-vcard:
 - source.vcard
 vendor/grammars/vscode-vento:
 - source.vento
+vendor/grammars/vscode-vhs:
+- source.vhs
 vendor/grammars/vscode-vlang:
 - source.v
 - v.mod

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7902,6 +7902,15 @@ Tact:
   ace_mode: text
   tm_scope: source.tact
   language_id: 606708469
+Tape:
+  type: programming
+  aliases:
+  - vhs
+  extensions:
+  - ".tape"
+  tm_scope: source.vhs
+  ace_mode: text
+  language_id: 516874200
 Talon:
   type: programming
   ace_mode: text

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7902,6 +7902,14 @@ Tact:
   ace_mode: text
   tm_scope: source.tact
   language_id: 606708469
+Talon:
+  type: programming
+  ace_mode: text
+  color: "#333333"
+  extensions:
+  - ".talon"
+  tm_scope: source.talon
+  language_id: 959889508
 Tape:
   type: programming
   aliases:
@@ -7911,14 +7919,6 @@ Tape:
   tm_scope: source.vhs
   ace_mode: text
   language_id: 516874200
-Talon:
-  type: programming
-  ace_mode: text
-  color: "#333333"
-  extensions:
-  - ".talon"
-  tm_scope: source.talon
-  language_id: 959889508
 Tcl:
   type: programming
   color: "#e4cc98"

--- a/samples/Tape/demo.tape
+++ b/samples/Tape/demo.tape
@@ -1,0 +1,51 @@
+# VHS documentation
+#
+# Output:
+#   Output <path>.gif               Create a GIF output at the given <path>
+#   Output <path>.mp4               Create an MP4 output at the given <path>
+#   Output <path>.webm              Create a WebM output at the given <path>
+#
+# Require:
+#   Require <string>                Ensure a program is on the $PATH to proceed
+#
+# Settings:
+#   Set FontSize <number>            Set the font size of the terminal
+#   Set FontFamily <string>          Set the font family of the terminal
+#   Set Height <number>              Set the height of the terminal
+#   Set Width <number>               Set the width of the terminal
+#   Set LetterSpacing <float>        Set the letter spacing of the terminal
+#   Set LineHeight <float>           Set the line height of the terminal
+#   Set LoopOffset <float>%          Set the starting frame offset of the GIF loop
+#   Set Theme <json|string>          Set the theme of the terminal
+#   Set Padding <number>             Set the padding of the terminal
+#   Set Framerate <number>           Set the framerate of the recording
+#   Set PlaybackSpeed <float>        Set the playback speed of the recording
+#   Set MarginFill <file|#000000>    Set the file or color the margin will be filled with
+#   Set Margin <number>              Set the size of the margin
+#   Set BorderRadius <number>        Set the border radius of the terminal
+#   Set WindowBar <string>           Set the window bar type
+#   Set WindowBarSize <number>       Set the window bar size
+#   Set TypingSpeed <time>           Set the typing speed of the terminal
+#
+# Sleep:
+#   Sleep <time>                     Sleep for <time> seconds
+#
+# Type:
+#   Type[@<time>] "<characters>"     Type characters with an optional delay
+#
+# Display:
+#   Hide                             Hide the subsequent commands from the output
+#   Show                             Show the subsequent commands from the output
+
+Output examples/demo.gif
+
+Require echo
+
+Set Shell "bash"
+Set FontSize 32
+Set Width 1200
+Set Height 600
+
+Type "echo 'Welcome to VHS!'" Sleep 500ms Enter
+
+Sleep 5s

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -638,6 +638,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **TXL:** [MikeHoffert/Sublime-Text-TXL-syntax](https://github.com/MikeHoffert/Sublime-Text-TXL-syntax)
 - **Tact:** [tact-lang/tact-sublime](https://github.com/tact-lang/tact-sublime)
 - **Talon:** [mrob95/vscode-TalonScript](https://github.com/mrob95/vscode-TalonScript)
+- **Tape:** [griimick/vscode-vhs](https://github.com/griimick/vscode-vhs)
 - **Tcl:** [textmate/tcl.tmbundle](https://github.com/textmate/tcl.tmbundle)
 - **Tcsh:** [atom/language-shellscript](https://github.com/atom/language-shellscript)
 - **TeX:** [textmate/latex.tmbundle](https://github.com/textmate/latex.tmbundle)

--- a/vendor/licenses/git_submodule/vscode-vhs.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-vhs.dep.yml
@@ -1,0 +1,30 @@
+---
+name: vscode-vhs
+version: 8e1da07699e0e9c716a0b608a1b62297b86f28a6
+type: git_submodule
+homepage: https://github.com/griimick/vscode-vhs.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2022 Soumik (griimick)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.


### PR DESCRIPTION
## Description

Adds GitHub Linguist support for Tape (`.tape`), the VHS terminal-recording language, including its TextMate grammar, language metadata, generated grammar/license metadata, and a real-world sample.

Fixes #6353

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for the `.tape` extension: https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.tape
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source: https://github.com/charmbracelet/vhs/blob/main/examples/demo.tape
    - Sample license: MIT (the sample is adapted from the linked VHS example).
  - [x] I have included a syntax highlighting grammar: https://github.com/griimick/vscode-vhs
  - [x] I have updated the language metadata for the `.tape` extension.

The grammar is vendored from `griimick/vscode-vhs` at commit `8e1da07699e0e9c716a0b608a1b62297b86f28a6`; its MIT license and copyright notice are included in the generated license metadata.

## Validation

- YAML and JSON parsing passed for the language metadata and vendored grammar.
- `git diff --check` passed.
- `bundle exec rake test` could not run because the local Ruby bundle is incomplete; the grammar helper could not run because Docker is unavailable. The generated submodule, grammar index, vendor index, and license metadata were reviewed against the repository's existing format.
