### PR TITLE
Add AGSL language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -644,6 +644,9 @@
 [submodule "vendor/grammars/language-agc"]
 	path = vendor/grammars/language-agc
 	url = https://github.com/Alhadis/language-agc
+[submodule "vendor/grammars/language-agsl"]
+	path = vendor/grammars/language-agsl
+	url = https://github.com/styropyr0/language-agsl
 [submodule "vendor/grammars/language-algol60"]
 	path = vendor/grammars/language-algol60
 	url = https://github.com/PolariTOON/language-algol60.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -532,6 +532,8 @@ vendor/grammars/language-4d:
 - source.4dm
 vendor/grammars/language-agc:
 - source.agc
+vendor/grammars/language-agsl:
+- source.agsl
 vendor/grammars/language-algol60:
 - source.algol60
 vendor/grammars/language-apl:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -96,6 +96,14 @@ AGS Script:
   codemirror_mode: clike
   codemirror_mime_type: text/x-c++src
   language_id: 2
+AGSL:
+  type: programming
+  color: "#c5fb64"
+  extensions:
+  - ".agsl"
+  tm_scope: source.agsl
+  ace_mode: text
+  language_id: 800925429
 AIDL:
   type: programming
   color: "#34EB6B"

--- a/samples/AGSL/animated_noise.agsl
+++ b/samples/AGSL/animated_noise.agsl
@@ -1,0 +1,8 @@
+uniform float2 iResolution;
+uniform float iTime;
+
+vec4 main(float2 fragCoord) {
+    vec2 uv = fragCoord / iResolution.xy;
+    vec3 col = 0.8 + 0.2 * cos(iTime * 2.0 + uv.xxx * 2.0 + vec3(1, 2, 4));
+    return vec4(col, 1.0);
+}

--- a/samples/AGSL/shader_eval.agsl
+++ b/samples/AGSL/shader_eval.agsl
@@ -1,0 +1,6 @@
+uniform float2 resolution;
+uniform shader image;
+
+half4 main(float2 fragCoord) {
+    return image.eval(fragCoord);
+}

--- a/samples/AGSL/solar_flare.agsl
+++ b/samples/AGSL/solar_flare.agsl
@@ -1,0 +1,43 @@
+uniform float2 resolution;
+uniform float time;
+layout(color) uniform half4 baseColor;
+layout(color) uniform half4 backgroundColor;
+
+const int ITERATIONS = 1;
+const float INTENSITY = 100.0;
+const float TIME_MULTIPLIER = 0.25;
+
+float4 main(in float2 fragCoord) {
+    float calculatedTime = time * TIME_MULTIPLIER;
+
+    float2 uv = fragCoord / resolution.xy;
+    float2 uvCalc = (uv * 6.0) - (INTENSITY * 1.0);
+
+    float2 iterationChange = float2(uvCalc);
+    float colorPart = 1.0;
+
+    for (int i = 0; i < ITERATIONS; i++) {
+        iterationChange = uvCalc + float2(
+            cos(calculatedTime + iterationChange.x) +
+            sin(calculatedTime - iterationChange.y),
+            cos(calculatedTime - iterationChange.x) +
+            sin(calculatedTime + iterationChange.y)
+        );
+        colorPart += 0.8 / length(
+            float2(uvCalc.x / (cos(iterationChange.x + calculatedTime) * INTENSITY),
+                uvCalc.y / (sin(iterationChange.y + calculatedTime) * INTENSITY)
+            )
+        );
+    }
+    colorPart = 2.0 - (colorPart / float(ITERATIONS));
+
+    float mixRatio = 1.0 - (uv.y * uv.y);
+    float4 color = float4(colorPart * baseColor.r, colorPart * baseColor.g, colorPart * baseColor.b, 1.0);
+    color = float4(
+        mix(backgroundColor.r, color.r, mixRatio),
+        mix(backgroundColor.g, color.g, mixRatio),
+        mix(backgroundColor.b, color.b, mixRatio),
+        1.0
+    );
+    return clamp(color, 0.0, 1.0);
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -13,6 +13,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **ABAP CDS:** [FreHu/abap-cds-grammar](https://github.com/FreHu/abap-cds-grammar)
 - **ABNF:** [Alhadis/language-grammars](https://github.com/Alhadis/language-grammars)
 - **AGS Script:** [mikomikotaishi/c.tmbundle](https://github.com/mikomikotaishi/c.tmbundle)
+- **AGSL:** [styropyr0/language-agsl](https://github.com/styropyr0/language-agsl)
 - **AIDL:** [google/aidl-language](https://github.com/google/aidl-language)
 - **AL:** [microsoft/AL](https://github.com/microsoft/AL)
 - **ALGOL:** [PolariTOON/language-algol60](https://github.com/PolariTOON/language-algol60)

--- a/vendor/licenses/git_submodule/language-agsl.dep.yml
+++ b/vendor/licenses/git_submodule/language-agsl.dep.yml
@@ -1,0 +1,30 @@
+---
+type: git_submodule
+name: language-agsl
+version: HEAD
+license: mit
+licenses:
+- sources: LICENSE
+  text: |-
+    MIT License
+
+    Copyright (c) 2026 styropyr0
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
Add support for **Android Graphics Shading Language (AGSL)** to GitHub Linguist.

This adds:

* `.agsl` file extension support
* AGSL syntax highlighting through the `language-agsl` grammar
* AGSL language metadata and language color
* Real-world AGSL samples
* Grammar submodule and associated license metadata

AGSL is Android's shading language used with Android's graphics and rendering APIs, including `RuntimeShader` and `RenderEffect`.

## Checklist:

* [ ] **I am adding a new extension to a language.**

* [x] **I am adding a new language.**

  * [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.

    * Search results for the extension:

      * https://github.com/search?type=code&q=NOT+is%3Afork+path%3A%2A.agsl

  * [x] I have included a real-world usage sample for all extensions added in this PR:

    * Sample source(s):

      * `samples/AGSL/solar_flare.agsl`
      * `samples/AGSL/animated_noise.agsl`
      * `samples/AGSL/shader_eval.agsl`
    * Sample license(s):

      * See the corresponding sample/license metadata included in this PR.

  * [x] I have included a syntax highlighting grammar:

    * https://github.com/styropyr0/language-agsl

  * [x] I have added a color

    * Hex value: `#c5fb64`
    * Rationale: A bright green color was chosen to visually distinguish AGSL while reflecting its association with GPU/shader programming and Android graphics.

  * [ ] I have updated the heuristics to distinguish my language from others using the same extension.

* [ ] **I am fixing a misclassified language**

* [ ] **I am changing the source of a syntax highlighting grammar**

* [x] **I am updating/adding a grammar submodule**

  * Grammar:

    * https://github.com/styropyr0/language-agsl

* [ ] **I am adding new or changing current functionality**

* [ ] **I am changing the color associated with a language**

## Additional information

AGSL is syntactically related to GLSL, but is specifically used by Android's graphics APIs and has Android-specific built-in types, functions, and semantics.

The included grammar is maintained separately in:

https://github.com/styropyr0/language-agsl
