### PR TITLE
Added CeruleanFlux programming language and syntax grammar

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -15,6 +15,9 @@ vendor/grammars/AutoHotkey:
 - source.ahk
 vendor/grammars/CUE-Sheet_sublime:
 - source.cuesheet
+CeruleanFlux:
+  source: https://github.com
+  commit: c3f4ab1
 vendor/grammars/Clue-for-VSCode:
 - source.clue
 vendor/grammars/CoDT7-Sublime:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1139,6 +1139,13 @@ CartoCSS:
   ace_mode: text
   tm_scope: source.css.mss
   language_id: 53
+CeruleanFlux:
+  type: programming
+  type: "#007BA7"
+  extensions:
+  - ".cflx"
+  tm_scope: source.ceruleanflux
+  ace_mode: text
 Ceylon:
   type: programming
   color: "#dfa535"

--- a/samples/CeruleanFlux/concurrency.cflx
+++ b/samples/CeruleanFlux/concurrency.cflx
@@ -1,0 +1,28 @@
+use system
+
+frozen MAX_LIMIT: int32 = 4
+ptm square(fixed n: int32): int32 {
+  return n * n
+}
+
+ptm main() {
+  // Tunnel
+  fixed tun = tunnel string: MAX_LIMIT // The tunnel only accepts strings, but only 4 maximum
+  "Data #1" -> tun
+  "Data #2" -> tun
+  "Data #3" -> tun
+  "Data #4" -> tun
+  // "This causes a compile error" -> tun
+  fixed data = <-tun
+  system#stdout#writewn("Data received: ${i?tun}")
+  close(tun)
+  // Pool
+  pool 4 as workerPool { // Worker limit is 4
+    fixed task1 = spawn square(8)
+    fixed task2 = spawn square(16)
+    fixed result1 = join task1
+    fixed result2 = join task2
+    system#stdout#writewn("Result 1: ${i?result1}")
+    system#stdout#writewn("Result 2: ${i?result2}")
+  }
+}

--- a/samples/CeruleanFlux/sample.cflx
+++ b/samples/CeruleanFlux/sample.cflx
@@ -1,0 +1,19 @@
+use system
+
+enum MathError {
+  DivBy0
+}
+
+ptm div(fixed a: float64, fixed b: float64): (float64, error?) {
+  verify b != 0.0 else return error{ message: "divide by 0", code: MathError#DivBy0 }
+  return a / b, nothing
+}
+
+ptm main() {
+  fixed result, err = div(8, 0)
+  if err != nothing {
+    system#stdout#writewn("Error occurred: ${i?err#message}")
+  } else {
+    system#stdout#writewn("Result: ${i?result}")
+  }
+}


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am adding a new extension to a language.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.FOOBAR+KEYWORDS
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.cflx+CeruleanFlux
      **Note:** The link may yield no results if the unknown extension isn’t supported by Github Linguist yet. Sorry for the inconvenience!
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/just-for-smths/linguist/blob/main/samples/CeruleanFlux/sample.cflx
      - https://github.com/just-for-smths/linguist/blob/main/samples/CeruleanFlux/concurrency.cflx
    - Sample license(s): MIT
    **Note:** Multiple sample sources were added for distinct, independent training.
  - [x] I have included a syntax highlighting grammar: https://github.com/just-for-smths/ceruleanflux-language-grammar
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#007BA7`
    - Rationale: Official hex color code for CeruleanFlux
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  - Old: [URL to grammar repo]
  - New: [URL to grammar repo]

- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

- [ ] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [URL to public discussion]
    - [Optional: URL to official branding guidelines for the language]
