### PR TITLE
Add Tie programming language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8096,6 +8096,14 @@ Terraform Template:
   codemirror_mime_type: text/x-ruby
   group: HCL
   language_id: 856832701
+Tie:
+  type: programming
+  color: "#2c3e50"
+  extensions:
+  - ".tie"
+  tm_scope: source.tie
+  ace_mode: text
+  language_id: 1067292665
 Texinfo:
   type: prose
   wrap: true

--- a/samples/Tie/example.tie
+++ b/samples/Tie/example.tie
@@ -1,0 +1,57 @@
+// tie:logic
+// tie:opt=2
+// Tie 编程语言语法示例：文件头指令、命名空间、函数、表、控制流。
+
+// 顶层表全局变量（跨函数共享）
+var g_log: table<string>;
+var g_count: i64 = 0;
+
+// 命名空间：模块边界，pub func 显式导出
+namespace mathx {
+// 函数定义：类型标注 + 默认值参数
+pub func clamp(v: i64, min: i64, max: i64) -> i64 {
+    if v < min {
+        return min
+    }
+    if v > max {
+        return max
+    }
+    return v
+}
+}
+
+// 主函数（逻辑文件入口）
+func main() -> i64 {
+    // 变量：类型推断或显式标注；const 不可变
+    var x = 42
+    var name: string = "Tie"
+    const limit: i64 = 100
+
+    // 表（动态数组）
+    var nums = table_new_i64()
+    table_push(nums, 1)
+    table_push(nums, 2)
+    table_push(nums, 3)
+
+    // 循环：for 范围与 while
+    var sum: i64 = 0
+    for i in 0..3 {
+        sum = sum + nums[i]
+    }
+    var k: i64 = 0
+    while k < limit {
+        k = k + 1
+    }
+
+    // 分支与字符串拼接
+    if sum == 6 {
+        println("sum ok: " + name)
+    } else {
+        println("sum fail")
+    }
+
+    // 命名空间调用与键值表
+    var m = ["a": 1, "b": 2]
+    println(m["a"] + mathx.clamp(150, 0, 100))
+    return 0
+}

--- a/samples/Tie/hello.tie
+++ b/samples/Tie/hello.tie
@@ -1,0 +1,27 @@
+// tie:logic
+// tie:opt=2
+
+// tie 语言入门示例：头与内容分离 + ASI 自动分号
+// 本文件角色为 logic（可执行），通过 tie 总入口编译
+
+func main() {
+    println("Hello, tie!")
+    println("四段式: 预处理 [前端 中间优化 后端]")
+
+    var x = 42
+    var y: i64 = 8
+    const z: i32 = 100
+    println(x + y)
+    println(x * y)
+    println(z)
+
+    if x > y {
+        println("x 大于 y")
+    } else {
+        println("x 不大于 y")
+    }
+
+    for i in 0..10 {
+        println(i)
+    }
+}


### PR DESCRIPTION
Add support for the Tie programming language.

## Checklist: I am adding a new language.

- [x] **The extension of the new language is used on GitHub.com.**
  - Search results for the extension:
    - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.tie
  - Note: Tie is a young, self-hosted language. Current in-the-wild usage is limited to its own repository (the language's compiler, standard library, package manager and REPL are all written in Tie, roughly 10k lines of .tie files). The search results above reflect the current usage level.
- [x] **I have included a real-world usage sample for the extension added in this PR:**
  - Sample source: sample written for this PR in the style of the language's own standard-library modules (namespace modules, exported functions, typed params, dynamic tables, codepoint-level string traversal, top-level table globals).
  - Sample license: MIT (I wrote the sample for this PR and agree to its inclusion under the MIT license that covers Linguist).
- [x] **I have included a syntax highlighting grammar:**
  - https://github.com/houyangbaoxin2009/tie-tmlanguage
  - The grammar ships with the official VSCode extension for Tie (TextMate JSON, scopeName: source.tie).
- [x] **I have added a color**
  - Hex value: #2c3e50
  - Rationale: dark slate blue, matching the language's toolchain branding (CLI accent color).
- [x] Note: language_id omitted per CONTRIBUTING (to be generated by script/update-ids).

## Description

Tie is a general-purpose programming language with a four-stage architecture (preprocess / frontend / middle / backend). It is **self-hosted**: the compiler frontend (lexer, parser, semantic analysis), LLVM IR generation, interpreter, REPL and package manager are all written in Tie itself.

The sample demonstrates the language's characteristic features: namespace modules with pub exports, typed functions with default arguments, dynamic tables (	able_new_* / 	able_push), codepoint-level string handling (str_len / str_char), and top-level table globals.