### PR TITLE
Add Nebulara language support (.nbs / .neb)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5354,6 +5354,15 @@ Nushell:
   codemirror_mode: shell
   codemirror_mime_type: text/x-sh
   language_id: 446573572
+Nebulara:
+  type: programming
+  color: "#8b00ff"
+  extensions:
+  - ".nbs"
+  - ".neb"
+  tm_scope: none
+  ace_mode: text
+  language_id: 310168885
 OASv2-json:
   type: data
   color: "#85ea2d"

--- a/samples/Nebulara/json.nbs
+++ b/samples/Nebulara/json.nbs
@@ -1,0 +1,71 @@
+# JSON parser and stringifier
+# Pure Nebulara implementation
+# Each parse function returns [value, new_position]
+
+FUNC! json_parse(xstr):
+    IF? LEN(xstr) == 0: RETURN NULL
+    END!
+    LET xr = parse_val(xstr, 0)
+    LET xinner = xr[0]
+    LET xpos = xr[1]
+    RETURN xinner
+END!
+
+FUNC! parse_val(ps, pp):
+    LET pnp = skip_ws(ps, pp)
+    LET pc = CHAR_AT(ps, pnp)
+    IF? pc == "\"":
+        RETURN parse_str(ps, pnp + 1)
+    ELSEIF? pc == "t" OR pc == "T":
+        RETURN [TRUE, pnp + 4]
+    ELSEIF? pc == "f" OR pc == "F":
+        RETURN [FALSE, pnp + 5]
+    ELSEIF? pc == "n" OR pc == "N":
+        RETURN [NULL, pnp + 4]
+    ELSEIF? pc == "{":
+        RETURN parse_obj(ps, pnp + 1)
+    ELSEIF? pc == "[":
+        RETURN parse_arr(ps, pnp + 1)
+    ELSEIF? (ORD(pc) >= 48 AND ORD(pc) <= 57) OR pc == "-":
+        RETURN parse_num(ps, pnp)
+    END!
+    RETURN [NULL, pnp]
+END!
+
+FUNC! skip_ws(ss, sp):
+    LET sn = LEN(ss)
+    WHILE? sp < sn:
+        LET sc = CHAR_AT(ss, sp)
+        IF? sc == " " OR sc == "\n" OR sc == "\r" OR sc == "\t":
+            sp = sp + 1
+        ELSE:
+            BREAK
+        END!
+    END!
+    RETURN sp
+END!
+
+FUNC! parse_str(ps2, pp2):
+    LET pn = LEN(ps2)
+    LET presult = ""
+    WHILE? pp2 < pn:
+        LET c2 = CHAR_AT(ps2, pp2)
+        IF? c2 == "\"":
+            RETURN [presult, pp2 + 1]
+        END!
+        IF? c2 == "\\":
+            LET nxt = CHAR_AT(ps2, pp2 + 1)
+            IF? nxt == "n": presult = presult + "\n"
+            ELSEIF? nxt == "t": presult = presult + "\t"
+            ELSEIF? nxt == "\\": presult = presult + "\\"
+            ELSEIF? nxt == "\"": presult = presult + "\""
+            ELSE: presult = presult + nxt
+            END!
+            pp2 = pp2 + 2
+        ELSE:
+            presult = presult + c2
+            pp2 = pp2 + 1
+        END!
+    END!
+    RETURN [presult, pp2]
+END!


### PR DESCRIPTION
Add Nebulara language support (.nbs / .neb extensions)

## Description
Adds Nebulara, an AI-native universal programming language developed by CODURRALABS, to the Linguist language database. Nebulara is a single-binary interpreter/compiler written in C with a fully-featured standard library including JSON parsing, string manipulation, collections, and networking. The language uses no required punctuation (commas, semicolons, colons are optional).

## Checklist:

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.nbs
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.neb
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/CODURRALABS/NEBULARA/blob/main/std/json.nbs (JSON parser library shipped with the language, written entirely in Nebulara)
    - Sample license(s):
      - MIT
  - [ ] I have included a syntax highlighting grammar: https://github.com/CODURRALABS/NEBULARA/tree/main/vscode-nebulara/syntaxes (TextMate-compatible grammar shipped in the VS Code extension)
  - [x] I have added a color
    - Hex value: `#8b00ff`
    - Rationale: Nebulara is described as "AI-native"; the vivid purple (electric violet) reflects the deep space / nebula naming and the AI/modern tooling association.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

> Note: The `.nbs` and `.neb` extensions are not currently claimed by any other language in languages.yml, so no heuristics are required. Nebulara is a new project; usage will grow as the ecosystem expands.
