### PR TITLE
Add Pop-11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1653,3 +1653,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/tree-sitter-pop11"]
+	path = vendor/grammars/tree-sitter-pop11
+	url = https://github.com/IoTone/tree-sitter-pop11.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1238,6 +1238,8 @@ vendor/grammars/ton-language-server:
 - source.tasm
 - source.tlb
 - source.tolk
+vendor/grammars/tree-sitter-pop11:
+- source.pop11
 vendor/grammars/turtle.tmbundle:
 - source.sparql
 - source.turtle

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -679,6 +679,11 @@ disambiguations:
     pattern:
     - '(?i)\bDEFINE\s+(?:VARIABLE|TEMP-TABLE|BUFFER|QUERY|INPUT\s+PARAMETER|OUTPUT\s+PARAMETER)\b'
     - '(?i)\bEND(?:\s+(?:PROCEDURE|FUNCTION|DO|FOR\s+EACH))?\.'
+  - language: Pop-11
+    pattern:
+    - '\benddefine\b'
+    - '^\s*;;;'
+    - '^\s*(?:section|uses|compile_mode)\b[^\n]*;'
 - extensions: ['.pc']
   rules:
   - language: Pro*C

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6073,6 +6073,17 @@ Pony:
   tm_scope: source.pony
   ace_mode: text
   language_id: 290
+Pop-11:
+  type: programming
+  color: "#8145a5"
+  aliases:
+  - pop11
+  - poplog
+  extensions:
+  - ".p"
+  tm_scope: source.pop11
+  ace_mode: text
+  language_id: 331890104
 Portugol:
   type: programming
   color: "#f8bd00"

--- a/samples/Pop-11/csv.p
+++ b/samples/Pop-11/csv.p
@@ -1,0 +1,128 @@
+/* --- CSV / TSV reading and writing --------------------------------------
+ > File:            pop/lib/lib/csv.p
+ > Purpose:         RFC 4180 CSV parse/generate (any single-char separator)
+ > Author:          D.Kordsmeier (@truedat101) and Claude (@claude), Aug 2026
+ > Documentation:   HELP * CSV
+ > Related Files:   tools/tests/test_csv.p, LIB * FILEUTILS
+ >
+ > Rows are vectors of field strings.  Quoting follows RFC 4180: fields
+ > containing the separator, quotes or newlines are double-quoted, with
+ > embedded quotes doubled; quoted fields may span lines.
+ */
+compile_mode :pop11 +strict;
+
+uses fileutils;
+
+section $-csv => csv_parse csv_generate csv_read csv_write;
+
+;;; parse CSV text into a list of row vectors; sep is a character
+;;; (e.g. `,` or `\t`)
+define csv_parse(s, sep) -> rows;
+    lvars i = 1, len = length(s), c, nf, nr = 0, nchars, inq;
+    unless isstring(s) and isinteger(sep) then
+        mishap(s, sep, 2, 'csv_parse: string and separator character needed')
+    endunless;
+    [% while i <= len do
+        ;;; one row
+        0 -> nf;
+        repeat
+            ;;; one field
+            0 -> nchars;
+            if i <= len and subscrs(i, s) == `"` then
+                ;;; quoted field
+                i + 1 -> i;
+                true -> inq;
+                while inq do
+                    if i > len then
+                        mishap(nchars, 1, 'csv_parse: unterminated quoted field')
+                    endif;
+                    subscrs(i, s) -> c;
+                    i + 1 -> i;
+                    if c == `"` then
+                        if i <= len and subscrs(i, s) == `"` then
+                            `"`; nchars + 1 -> nchars;
+                            i + 1 -> i;
+                        else
+                            false -> inq;
+                        endif;
+                    else
+                        c; nchars + 1 -> nchars;
+                    endif;
+                endwhile;
+            else
+                ;;; bare field: up to sep or line end
+                while i <= len do
+                    subscrs(i, s) -> c;
+                    quitif(c == sep or c == `\n` or c == `\r`);
+                    c; nchars + 1 -> nchars;
+                    i + 1 -> i;
+                endwhile;
+            endif;
+            consstring(nchars);
+            nf + 1 -> nf;
+            ;;; after a field: separator continues the row, EOL/EOF ends it
+            if i <= len and subscrs(i, s) == sep then
+                i + 1 -> i;
+            else
+                quitloop;
+            endif;
+        endrepeat;
+        consvector(nf);
+        nr + 1 -> nr;
+        ;;; consume one line ending (\r\n, \n or \r)
+        if i <= len and subscrs(i, s) == `\r` then i + 1 -> i endif;
+        if i <= len and subscrs(i, s) == `\n` then i + 1 -> i endif;
+    endwhile %] -> rows;
+enddefine;
+
+define lconstant needs_quote(f, sep);
+    lvars i, c;
+    for i from 1 to length(f) do
+        subscrs(i, f) -> c;
+        if c == sep or c == `"` or c == `\n` or c == `\r` then
+            return(true)
+        endif;
+    endfor;
+    false
+enddefine;
+
+;;; generate CSV text (rows end with \n) from a list of vectors or lists
+define csv_generate(rows, sep) -> s;
+    lvars row, f, i, c, first, n = 0;
+    unless isinteger(sep) then
+        mishap(sep, 1, 'csv_generate: separator character needed')
+    endunless;
+    for row in rows do
+        true -> first;
+        if isvector(row) then datalist(row) -> row endif;
+        for f in row do
+            unless first then sep; n + 1 -> n endunless;
+            false -> first;
+            unless isstring(f) then f sys_>< nullstring -> f endunless;
+            if needs_quote(f, sep) then
+                `"`; n + 1 -> n;
+                for i from 1 to length(f) do
+                    subscrs(i, f) -> c;
+                    if c == `"` then `"`; n + 1 -> n endif;
+                    c; n + 1 -> n;
+                endfor;
+                `"`; n + 1 -> n;
+            else
+                appdata(f, identfn);
+                n + length(f) -> n;
+            endif;
+        endfor;
+        `\n`; n + 1 -> n;
+    endfor;
+    consstring(n) -> s;
+enddefine;
+
+define csv_read(file, sep) -> rows;
+    csv_parse(file_to_string(file), sep) -> rows;
+enddefine;
+
+define csv_write(rows, file, sep);
+    string_to_file(csv_generate(rows, sep), file);
+enddefine;
+
+endsection;

--- a/samples/Pop-11/gensym.p
+++ b/samples/Pop-11/gensym.p
@@ -1,0 +1,36 @@
+/*  --- Copyright University of Sussex 1993.  All rights reserved. ---------
+ >  File:           C.all/lib/auto/gensym.p
+ >  Purpose:        Generate integer-suffixed words on basis of
+ >                  a given root word.
+ >  Author:         John Gibson, Nov 25 1992 (see revisions)
+ >  Documentation:  REF *gensym
+ >  Related Files:  LIB *GENSYM_PROPERTY
+ */
+compile_mode:pop11 +strict;
+
+section;
+
+define gensym(root);
+    lvars root, n;
+    check_word(root);
+    gensym_property(root) -> n;
+    n + 1 -> gensym_property(root);
+    consword(root sys_>< n);
+enddefine;
+;;;
+define updaterof gensym(n, root);
+    lvars n, root;
+    check_word(root);
+    unless isinteger(n) then
+        mishap(n, root, 2, 'gensym: INTEGER SUFFIX NEEDED')
+    endunless;
+    n -> gensym_property(root)
+enddefine;
+
+endsection;
+
+
+/* --- Revision History ---------------------------------------------------
+--- John Gibson, Sep 22 1993
+        Made new version using gensym_property
+ */

--- a/samples/Pop-11/sys_file_match.p
+++ b/samples/Pop-11/sys_file_match.p
@@ -1,0 +1,347 @@
+/* --- Copyright University of Sussex 1995. All rights reserved. ----------
+ > File:            C.unix/lib/auto/sys_file_match.p
+ > Purpose:         Produce a file-name repeater from given file spec
+ > Author:          John Gibson, Aug 16 1983 (see revisions)
+ > Documentation:   REF *SYSUTIL
+ > Related Files:
+ */
+
+compile_mode :pop11 +strict;
+
+;;; load match codes for "sys_match_filename"
+#_INCLUDE '$usepop/pop/lib/include/sys_match_filename.ph'
+
+section;
+
+lconstant
+    SFM_STRIP_DIR           =   2:1e0,
+    SFM_FOLLOW_SYMLINKS     =   2:1e1,
+    ;
+
+lvars
+    filename_patt,
+    stat_buf,
+    strip_dir,
+    follow_symlinks,
+    ;
+
+
+    ;;; don't make syssort copy the list
+lconstant procedure sort = syssort(%false, alphabefore%);
+
+define lconstant returnfiles(filelist, dir);
+    lvars f, n, filelist, dir;
+    returnunless(filelist and filelist /== []);
+    if strip_dir then suspend(dir dir_>< nullstring, false, 2) endif;
+    fast_for f in sort(filelist) do
+        if stat_buf then
+            dir dir_>< f -> n;
+            suspend(sys_file_stat(n, stat_buf, follow_symlinks),
+                    if strip_dir then f else n endif, 2)
+        else
+            unless strip_dir then dir dir_>< f -> f endunless;
+            suspend(f, 1)
+        endif
+    endfor
+enddefine;
+
+define lconstant 4 dir dir_<> name;
+    lvars s, slash = false, dir, name;
+    returnif(name == []) (dir);
+    consstring(#|
+        explode(dir),
+        unless dir = nullstring then dup() /== `/` -> slash endunless,
+        if islist(name) then
+            fast_for s in name do
+                if slash then `/` endif;
+                explode(s);
+                true -> slash
+            endfor
+        else
+            if slash then `/` endif;
+            if isstring(name) then explode(name) else name endif
+        endif
+    |#)
+enddefine;
+
+define lconstant matchanypath(startdir, dir, path_patt);
+    lvars fulldir, dirlist, d, startdir, dir, path_patt;
+
+    define lconstant matchdirpath(path, dir_patt);
+        lvars patt, path, dir_patt;
+        until dir_patt == [] do
+            destpair(dir_patt) -> dir_patt -> patt;
+            unless patt then
+                ;;; ...
+                until path == [] do
+                    returnif(matchdirpath(path, dir_patt)) (true);
+                    back(path) -> path
+                enduntil
+            elseunless path /== [] and sys_match_filename(front(path), patt)
+            then
+                return(false)
+            else
+                back(path) -> path;
+            endunless
+        enduntil;
+        path == []
+    enddefine;
+
+    startdir dir_<> dir -> fulldir;
+    if matchdirpath(dir, path_patt) then
+        if sys_matchin_dir(fulldir, filename_patt, 2:111) ->> dirlist then
+            returnfiles((), fulldir)
+        else
+            return
+        endif
+    else
+        unless sys_matchin_dir(fulldir, false, 2:001) ->> dirlist then
+            return
+        endunless
+    endif;
+    ;;; get sorted list of all directories
+    fast_for d in sort(dirlist) do
+        matchanypath(startdir, dir <> [^d], path_patt)
+    endfor
+enddefine;
+
+define lconstant do_sfm(path_patt, filename_patt, rootdir, stat_buf,
+                                                                strip_dir);
+    lvars path_patt, rootdir;
+    dlocal filename_patt, stat_buf, strip_dir, follow_symlinks;
+
+    if isinteger(strip_dir) then
+        strip_dir &&/=_0 SFM_FOLLOW_SYMLINKS -> follow_symlinks;
+        strip_dir &&/=_0 SFM_STRIP_DIR -> strip_dir;
+    else
+        true -> follow_symlinks;
+    endif;
+
+    define lconstant matchindir(dir, path_patt);
+        lvars d, patt, path, dirlist, dir, path_patt, code;
+        if path_patt == [] then
+            ;;; extract the files that match the filename part
+            returnfiles(sys_matchin_dir(dir, filename_patt, 2:011), dir);
+            return
+        endif;
+        front(path_patt) -> patt;
+        unless patt then
+            ;;; ...
+            matchanypath(dir, [], path_patt);
+        elseif listlength(patt) == 2
+        and ((front(patt) ->> code) == M_STRING or code == M_CHAR) then
+            ;;; fixed directory name
+            dir dir_<> front(back(patt)) -> dir;
+            ;;; check it exists
+            if sysisdirectory(dir) then matchindir(dir, back(path_patt)) endif
+        else
+            ;;; pattern directory name
+            ;;; get sorted list of matching directories
+            back(path_patt) -> path_patt;
+            returnunless(sys_matchin_dir(dir, patt, 2:001) ->> dirlist);
+            fast_for d in sort(dirlist) do
+                matchindir(dir dir_<> d, path_patt)
+            endfor
+        endunless
+    enddefine;
+
+    matchindir(rootdir, path_patt);
+    termin
+enddefine;
+
+
+define lconstant transpatt(string);
+    lvars char, m, n = 1, slen, string, list, range, isnot;
+    dlvars count = 0;
+
+    lconstant macro NEXTCHAR = [fast_subscrs(n,string) -> char, n+1 -> n ];
+
+    define lconstant grabc();
+        lvars char;
+        if count == 1 then
+            -> char;
+            M_CHAR, char
+        elseif count /== 0 then
+            consstring(count) -> char;
+            M_STRING, char
+        endif;
+        0 -> count
+    enddefine;
+
+    datalength(string) -> slen;
+    [%  while n <= slen do
+            NEXTCHAR;
+            if char == `*` then
+                ;;; match any number of chars
+                grabc(), M_STAR
+            elseif char == `?` then
+                ;;; match any character
+                grabc();
+                n -> m;
+                while n <= slen and fast_subscrs(n, string) == `?` do
+                    n+1 -> n
+                endwhile;
+                M_NCHARS, n-m+1
+            elseif char == `#` then
+                ;;; match start of version
+                grabc(), M_VERS
+            elseif char == `[` then
+                ;;; set of alternative characters
+                grabc();
+                false ->> isnot -> range;
+                [%  repeat
+                        if n > slen then
+                            mishap(0, 'sys_file_match: MISSING "]" IN PATTERN')
+                        endif;
+                        NEXTCHAR;
+                        quitif(char == `]`);
+                        if char == `^` then
+                            true -> isnot; nextloop
+                        elseif char == `\` and n <= slen then
+                            NEXTCHAR
+                        endif;
+                        if n <= slen and fast_subscrs(n,string) == `-` then
+                            n+1 -> n;
+                            char -> range
+                        elseif range then
+                            [^M_CHAR_RANGE ^range ^char];
+                            false -> range
+                        else
+                            [^M_CHAR ^char]
+                        endif
+                    endrepeat
+                %] -> list;
+                if isnot then
+                    M_NOT, [^M_XOR ^list], 1
+                else
+                    M_XOR, list
+                endif
+            elseif char == `{` then
+                ;;; set of alternative (comma-separated) patterns
+                lvars depth = 0;
+                grabc();
+                [%  repeat
+                        if n > slen then
+                            mishap(0, 'sys_file_match: MISSING "}" IN PATTERN')
+                        endif;
+                        NEXTCHAR;
+                        if (char == `,` or char == `}`) and depth == 0 then
+                            transpatt(consstring(count));
+                            0 -> count;
+                            quitif(char == `}`)
+                        else
+                            if char == `}` then
+                                depth-1 -> depth
+                            elseif char == `{` then
+                                depth+1 -> depth
+                            elseif char == `\` and n <= slen then
+                                char, count+1 -> count;
+                                NEXTCHAR
+                            endif;
+                            char, count+1 -> count
+                        endif
+                    endrepeat
+                %] -> list;
+                M_OR, list
+            else
+                ;;; match normal char
+                if char == `\` and n <= slen then NEXTCHAR endif;
+                char;
+                count fi_+ 1 -> count;
+            endif
+        endwhile,
+        grabc()
+    %]
+enddefine;
+
+define sys_file_match(fspec, dspec, statbuf, stripdir);
+    lvars fspec, dspec, statbuf, stripdir;
+
+    define lconstant parsefilespec(string) -> (rootdir, path, filename, vers);
+        lvars n, m, s, rootdir, slen, string, path, filename, vers;
+        sysfileok(string) -> string;
+        datalength(string) -> slen;
+        1 -> n;
+        ;;; root directory
+        if slen /== 0 and fast_subscrs(1, string) == `/` then
+            2 -> n;
+            '/'
+        else
+            nullstring
+        endif -> rootdir;
+        ;;; rest of pathname
+        [%  while n <= slen and (locchar(`/`, n, string) ->> m) do
+                substring(n, m-n, string) -> s;
+                if s = '...' then
+                    false
+                elseif s /= nullstring then
+                    transpatt(s)
+                endif;
+                m+1 -> n
+            endwhile
+        %] -> path;
+        ;;; filename
+        transpatt(substring(n, slen-n+1, string)) ->> filename -> s;
+        [] -> vers;
+        lvars last = false;
+        until s == [] do
+            if front(s) == M_VERS then
+                s -> vers;
+                [] -> if last then back(last) else filename endif;
+                quitloop
+            else
+                s -> last;
+                back(s) -> s
+            endif
+        enduntil
+    enddefine;
+
+    lvars
+        (froot, fpath, ffile, fvers) = parsefilespec(fspec),
+        (droot, dpath, dfile, dvers) =  if dspec then
+                                            parsefilespec(dspec)
+                                        else
+                                            nullstring, [], [], []
+                                        endif;
+
+    if froot = nullstring and fpath == [] then
+        droot -> froot, dpath -> fpath
+    endif;
+    if ffile == [] then dfile -> ffile endif;
+    if fvers == [] then dvers -> fvers endif;
+    if ffile == [] then [^M_STAR] -> ffile endif;
+
+    runproc(%0, consproc(fpath, ffile nc_<> fvers, froot, statbuf, stripdir,
+                                                5, do_sfm)%)
+enddefine;
+
+endsection;
+
+
+
+/* --- Revision History ---------------------------------------------------
+--- John Gibson, Sep  5 1995
+        Fixed stupid bug in sys_file_match introduced by last change
+--- John Gibson, Aug 29 1995
+        Added {...} pattern matching (i.e. alternative patterns)
+--- John Williams, Jul  5 1993
+        Can now pass "follow symlinks" flag through to call of sys_file_stat
+--- John Gibson, Nov 13 1992
+        Made matchindir uses sysisdirectory instead of sys_file_stat
+        (which was using a non-writeable vector)
+--- Robert John Duncan, Aug 29 1990
+        Changed -n*ote- to -weak-.
+--- John Gibson, May 29 1990
+        Corrected bugs with matching [a-z] etc, including change to operation
+        of M_NOT in patterns.
+--- John Gibson, Jul  1 1989
+        Added +strict etc
+--- John Gibson, Jun  5 1989
+        #_INCLUDEd sys_match_filename.ph instead of compiling
+--- John Gibson, Jul 16 1987
+        Made default filespec to sys_file_match do something, also generally
+        cleaned up.
+--- John Williams, Feb  5 1986
+        transferred match codes to
+            $usepop/pop/lib/include/sys_match_filename.ph
+ */

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -499,6 +499,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **PogoScript:** [featurist/PogoScript.tmbundle](https://github.com/featurist/PogoScript.tmbundle)
 - **Polar:** [osohq/polar-grammar](https://github.com/osohq/polar-grammar)
 - **Pony:** [CausalityLtd/sublime-pony](https://github.com/CausalityLtd/sublime-pony)
+- **Pop-11:** [IoTone/tree-sitter-pop11](https://github.com/IoTone/tree-sitter-pop11)
 - **Portugol:** [luisgbr1el/portugol-grammar](https://github.com/luisgbr1el/portugol-grammar)
 - **PostCSS:** [hudochenkov/Syntax-highlighting-for-PostCSS](https://github.com/hudochenkov/Syntax-highlighting-for-PostCSS)
 - **PostScript:** [Alhadis/Atom-PostScript](https://github.com/Alhadis/Atom-PostScript)


### PR DESCRIPTION
Adds **Pop-11**, the core language of the [Poplog](https://en.wikipedia.org/wiki/Poplog) environment (University of Sussex, 1970s–present; freely distributable since 1999). Pop-11 is an incrementally natively-compiling AI language with open-stack semantics — the implementation language of classic AI teaching material and of the SimAgent toolkit, and actively maintained today by several forks.

## Description

- `languages.yml`: `Pop-11`, extension `.p` (contested with Gnuplot and OpenEdge ABL), `tm_scope: source.pop11`, `language_id` from `script/update-ids`' formula.
- `heuristics.yml`: Pop-11 rule added to the existing `.p` group. The markers (`enddefine`, `;;;` line comments, `section`/`uses`/`compile_mode` statements) are near-unambiguous; I verified none of the existing Gnuplot / OpenEdge ABL `.p` samples match them, and none of the Pop-11 samples match the existing rules.
- `samples/Pop-11/`: three real library files from the actively maintained Poplog distribution (one small classic, one large classic, one modern library).
- Grammar: [IoTone/tree-sitter-pop11](https://github.com/IoTone/tree-sitter-pop11) (MIT) — carries the TextMate grammar `pop11.tmLanguage.json` (`source.pop11`) alongside the tree-sitter grammar.

`.ph` (Pop-11 headers) and `.pop11` also exist in the wild but are below the usage thresholds, so this PR claims only `.p`.

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.p+enddefine — ~7,300 files. Being transparent: a substantial share are Poplog distribution forks/mirrors (`poplog/poplog`, `hebisch/poplog`, `GetPoplog/Seed`, `IanRogers/Poplog` are independent maintained lines of the system, each carrying the ~1,800-file corpus), with independent user code alongside (e.g. `hakank/hakank`, `sfkleach/GOSPL`, course material).
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/IoTone/poplog/blob/master/pop/lib/auto/gensym.p
      - https://github.com/IoTone/poplog/blob/master/pop/lib/auto/sys_file_match.p
      - https://github.com/IoTone/poplog/blob/master/pop/lib/lib/csv.p
    - Sample license(s): Poplog free licence (MIT/XFree86-style; Poplog has been freely distributable since 1999)
  - [x] I have included a syntax highlighting grammar: https://github.com/IoTone/tree-sitter-pop11
  - [x] I have added a color
    - Hex value: `#8145a5`
    - Rationale: violet, unused by any existing language entry; no official Poplog brand colour exists.
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.