### PR TITLE
Add Jau programming language support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -9581,3 +9581,15 @@ xBase:
   tm_scope: source.harbour
   ace_mode: text
   language_id: 421
+Jau:
+  type: programming
+  color: "#f1c40f"
+  aliases:
+  - jau-lang
+  - jau
+  extensions:
+  - ".jau"
+  tm_scope: source.jau
+  ace_mode: text
+  codemirror_mode: null
+  language_id: 422

--- a/samples/Jau/hello.jau
+++ b/samples/Jau/hello.jau
@@ -1,0 +1,7 @@
+func main()
+{
+    let value = 42;
+    print(value);
+}
+
+main();

--- a/vendor/grammars/Jau.tmLanguage.json
+++ b/vendor/grammars/Jau.tmLanguage.json
@@ -1,0 +1,22 @@
+{
+  "name": "Jau",
+  "scopeName": "source.jau",
+  "patterns": [
+    {
+      "name": "keyword.control.jau",
+      "match": "\\b(func|let|return|if|else|while|import|struct|namespace)\\b"
+    },
+    {
+      "name": "string.quoted.double.jau",
+      "match": "\".*?\""
+    },
+    {
+      "name": "constant.numeric.jau",
+      "match": "\\b[0-9]+\\b"
+    },
+    {
+      "name": "comment.line.jau",
+      "match": "//.*$"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for the Jau programming language.

Jau is a native compiled language with:
- AOT compiler
- custom linker
- package manager
- native PE backend

File extension:
.jau