### PR TITLE
Add Double C* language supportCreate languages.yml

### DIFF
--- a/languages.yml
+++ b/languages.yml
@@ -1,0 +1,5 @@
+Double C*:
+  type: programming
+  extensions:
+    - ".dc*"
+  color: "#A67B5B"


### PR DESCRIPTION
# Add Double C* (Double Chocolate Cone) Language Support

This pull request adds support for the Double C* programming language to GitHub Linguist.

Double C* is a game‑focused scripting language designed for the ConeEngine ecosystem.  
It features a clean syntax, event‑driven structure, and a JavaScript‑based runtime.

This PR includes:
- `.dc*` file extension
- language name: Double C*
- type: programming
- official color: #A67B5B
- grammar and specification available at: https://github.com/CalcSolver/Double-C-Language

Double C* is actively developed and has:
- a formal language specification
- EBNF grammar
- example programs
- roadmap
- compiler development in progress
- VS Code extension planned

Adding Double C* to Linguist will allow GitHub to properly detect and classify `.dc*` files across repositories.

Thank you for reviewing this contribution.
