### PR TITLE
Add the Corros programming language (.cor)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1489,6 +1489,14 @@ Cool:
   tm_scope: source.cool
   ace_mode: text
   language_id: 68
+Corros:
+  type: programming
+  color: "#b7410e"
+  extensions:
+  - ".cor"
+  tm_scope: source.corros
+  ace_mode: text
+  language_id: 1067292665
 Cpp-ObjDump:
   type: data
   extensions:


### PR DESCRIPTION
Adds **Corros** — a from-scratch, bytecode-compiled scripting language with its own lexer, compiler, and virtual machine, and a syntax that belongs to no other language (`forge`, `craft`, `when`, `whilst`, `each`, `speak`). Corros is self-hosting: the compiler, VM, and standard library are written in Corros and proven by a byte-identical bootstrap chain.

- Extension: `.cor`
- Type: programming
- Repository: https://github.com/CocoCopi/corros
- Example:
  ```corros
  forge greet = craft(name) {
    return "hello, " + name
  }
  speak(greet("corros"))
  ```