### PR TITLE
add Simula language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1187,6 +1187,9 @@
 [submodule "vendor/grammars/shaders-tmLanguage"]
 	path = vendor/grammars/shaders-tmLanguage
 	url = https://github.com/tgjones/shaders-tmLanguage
+[submodule "vendor/grammars/simula-tmlanguage"]
+	path = vendor/grammars/simula-tmlanguage
+	url = https://github.com/RobertFlexx/simula-tmlanguage.git
 [submodule "vendor/grammars/slang-vscode-extension"]
 	path = vendor/grammars/slang-vscode-extension
 	url = https://github.com/shader-slang/slang-vscode-extension.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1082,6 +1082,8 @@ vendor/grammars/selinux-policy-languages:
 vendor/grammars/shaders-tmLanguage:
 - source.hlsl
 - source.shaderlab
+vendor/grammars/simula-tmlanguage:
+- source.simula
 vendor/grammars/slang-vscode-extension:
 - source.slang
 vendor/grammars/slint-tmLanguage:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7533,6 +7533,17 @@ Simple File Verification:
   codemirror_mode: properties
   codemirror_mime_type: text/x-properties
   language_id: 735623761
+Simula:
+  type: programming
+  color: "#4F78A8"
+  aliases:
+  - simula67
+  - simula-67
+  extensions:
+  - ".sim"
+  tm_scope: source.simula
+  ace_mode: text
+  language_id: 582204041
 Singularity:
   type: programming
   color: "#64E6AD"

--- a/samples/Simula/arrays.sim
+++ b/samples/Simula/arrays.sim
@@ -1,0 +1,16 @@
+program Arrays;
+begin
+    array[1:5] integer values;
+    integer index;
+    integer total;
+    total := 0;
+    for index := 1 step 1 until 5 do
+    begin
+        values[index] := index * index;
+        total := total + values[index];
+    end;
+    assert(total = 55);
+    outint(total);
+    outimage;
+    exit(0)
+end;

--- a/samples/Simula/classes.sim
+++ b/samples/Simula/classes.sim
@@ -1,0 +1,29 @@
+Class Animal;
+Virtual: Procedure Speak Is Procedure Speak;;
+begin
+    Protected:
+    integer age;
+    Public:
+    Procedure Speak;
+    begin
+        outtext("animal")
+    end;
+end;
+
+Animal Class Dog;
+begin
+    Public:
+    Procedure Speak;
+    begin
+        outtext("dog")
+    end;
+end;
+
+program Classes;
+begin
+    Ref(Animal) subject;
+    subject :- new Dog();
+    subject.Speak();
+    outimage;
+    exit(0)
+end;

--- a/samples/Simula/inspect.sim
+++ b/samples/Simula/inspect.sim
@@ -1,0 +1,19 @@
+Class Animal;
+begin
+    integer age;
+end;
+
+Animal Class Dog;
+begin
+    integer barkCount;
+end;
+
+program ClassicInspect;
+begin
+    Ref(Animal) subject;
+    subject :- new Dog();
+    inspect subject
+        when Dog do begin outtext("dog") end
+        when Animal do begin outtext("animal") end
+        otherwise begin outtext("none") end
+end;

--- a/samples/Simula/labels.sim
+++ b/samples/Simula/labels.sim
@@ -1,0 +1,11 @@
+label Start, Finished;
+switch Dispatch := Start, Finished;
+
+program ClassicLabels;
+begin
+    integer value;
+    value := 0;
+    go to Start;
+    Finished: value := value + 1;
+    Start: if value = 0 then go to Finished
+end;

--- a/samples/Simula/modern.sim
+++ b/samples/Simula/modern.sim
@@ -1,0 +1,24 @@
+Task Class PipelineStage;
+Virtual: Procedure Run Is Procedure Run;;
+begin
+    Public:
+    channel(integer) input_values;
+    channel(integer) output_values;
+    Procedure Run;
+    begin
+        integer value;
+        value := receive(input_values);
+        send(output_values, value + 1)
+    end;
+end;
+
+program TaskPipeline;
+begin
+    Ref(PipelineStage) stage;
+    integer result;
+    stage :- new PipelineStage();
+    send(stage.input_values, 41);
+    join spawn stage.Run();
+    result := receive(stage.output_values);
+    assert(result = 42)
+end;

--- a/samples/Simula/prefixing.sim
+++ b/samples/Simula/prefixing.sim
@@ -1,0 +1,19 @@
+Class PrefixPart;
+begin
+    outtext("A");
+    inner;
+    outtext("C")
+end;
+
+PrefixPart Class CompletePart;
+begin
+    outtext("B")
+end;
+
+program PrefixInner;
+begin
+    Ref(CompletePart) item;
+    item :- new CompletePart();
+    outimage;
+    exit(0)
+end;

--- a/samples/Simula/procedures.sim
+++ b/samples/Simula/procedures.sim
@@ -1,0 +1,14 @@
+integer procedure Accumulate(seed, amount);
+value amount;
+integer seed, amount;
+begin
+    seed := seed + amount;
+    Accumulate := seed
+end;
+
+program ProcedureParameterModes;
+begin
+    integer total;
+    total := 40;
+    total := Accumulate(total, 2)
+end;

--- a/samples/Simula/simulation.sim
+++ b/samples/Simula/simulation.sim
@@ -1,0 +1,21 @@
+Process Class Customer;
+begin
+    Ref(Customer) nextCustomer;
+    Procedure Life;
+    begin
+        detach;
+        hold 1.0;
+        passivate
+    end;
+end;
+
+program ClassicSimulation;
+begin
+    Ref(Customer) first;
+    Ref(Customer) second;
+    first :- new Customer();
+    second :- new Customer();
+    activate first at 1.0 prior;
+    activate second after first;
+    reactivate first delay 2.0
+end;

--- a/samples/Simula/text.sim
+++ b/samples/Simula/text.sim
@@ -1,0 +1,8 @@
+program TextFrames;
+begin
+    text message;
+    integer frameLength;
+    message := "SIMULA";
+    frameLength := message.length;
+    outtext(message.main)
+end;

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -602,6 +602,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Shen:** [rkoeninger/sublime-shen](https://github.com/rkoeninger/sublime-shen)
 - **Sieve:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **Simple File Verification:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
+- **Simula:** [RobertFlexx/simula-tmlanguage](https://github.com/RobertFlexx/simula-tmlanguage)
 - **Singularity:** [onnovalkering/vscode-singularity](https://github.com/onnovalkering/vscode-singularity)
 - **Slang:** [shader-slang/slang-vscode-extension](https://github.com/shader-slang/slang-vscode-extension)
 - **Slash:** [slash-lang/Slash.tmbundle](https://github.com/slash-lang/Slash.tmbundle)

--- a/vendor/licenses/git_submodule/simula-tmlanguage.dep.yml
+++ b/vendor/licenses/git_submodule/simula-tmlanguage.dep.yml
@@ -1,0 +1,33 @@
+---
+name: simula-tmlanguage
+version: 662c574f5d0cfba6a3d2e11924833819d1eca8de
+type: git_submodule
+homepage: https://github.com/RobertFlexx/simula-tmlanguage.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2026 Robert Flexx
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+- sources: README.md
+  text: MIT — see [LICENSE](LICENSE).
+notices: []


### PR DESCRIPTION
adds simula support to linguist, including `.sim` detection, syntax highlighting, samples, and a language color.

the grammar covers classic simula / simula 67 as well as newer simula-style syntax.

## description

this adds simula as a programming language in linguist.

it includes a textmate grammar using `source.simula`, `.sim` file recognition, several real simula samples, and the color `#4f78a8`.

the grammar handles classes, prefixing, `ref`, `new`, `inner`, procedures, `inspect`, `when`, `text`, labels, comments, and the `:=` / `:-` assignment distinction.

it also handles newer simula-style syntax while keeping everything under the simula language.

the full linguist test suite passes with these changes.

## checklist

* [x] **i am adding a new language.**

  * [ ] the extension of the new language is used in hundreds of repositories on github.com.

    * search results for each extension:

      * no usage search is included here yet
  * [x] i have included real-world usage samples for the extension added in this pr:

    * sample source(s):

      * https://github.com/RobertFlexx/Free-Simula
    * sample license(s):

      * mit
  * [x] i have included a syntax highlighting grammar:

    * https://github.com/RobertFlexx/simula-tmlanguage
  * [x] i have added a color

    * hex value: `#4f78a8`
    * rationale: i chose a muted blue that felt fitting for simula and was distinct from nearby language colors.
  * [ ] i have updated the heuristics to distinguish my language from others using the same extension.

    * not needed because `.sim` is not currently shared with another linguist language.

* [x] **i am adding new or changing current functionality**

  * [x] i have added or updated the tests for the new or changed functionality.
