### PR TITLE
Add SIP (PyQt bindings specification) language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7139,6 +7139,16 @@ SELinux Policy:
   - security_classes
   ace_mode: text
   language_id: 880010326
+SIP:
+  type: programming
+  color: "#A45069"
+  extensions:
+  - ".sip"
+  tm_scope: source.c++
+  ace_mode: c_cpp
+  codemirror_mode: clike
+  codemirror_mime_type: text/x-c++src
+  language_id: 796891177
 SMT:
   type: programming
   extensions:

--- a/samples/SIP/_ApplicationEx.sip
+++ b/samples/SIP/_ApplicationEx.sip
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2020 Weitian Leung
+ *
+ * This file is part of pywpsrpc.
+ *
+ * This file is distributed under the MIT License.
+ * See the LICENSE file for details.
+ *
+*/
+
+namespace wpsapiex
+{
+    struct _ApplicationEx : public IDispatch /Abstract/
+    {
+    public:
+        virtual HRESULT get_WpsCloudService(
+            WpsCloudService **prop /Out/) = 0;
+
+        virtual HRESULT get_SaveRememberStatus(
+            VARIANT_BOOL *prop /Out/) = 0;
+
+        virtual HRESULT put_SaveRememberStatus(
+            VARIANT_BOOL prop) = 0;
+
+        virtual HRESULT CreateCustomTaskPane(
+            long wid,
+            BSTR title,
+            IDispatch **prop /Out/) = 0;
+        virtual HRESULT put_ForceBackupEnable(
+            VARIANT_BOOL prop) = 0;
+
+        virtual HRESULT get_ForceBackupEnable(
+            VARIANT_BOOL *prop /Out/) = 0;
+
+        virtual HRESULT get_EmbedWid(
+            unsigned long *wid /Out/) = 0;
+
+        WpsCloudService* getWpsCloudService();
+        %MethodCode
+            wpsapiex::WpsCloudService *prop = nullptr;
+            HRESULT hr = sipCpp->get_WpsCloudService(&prop);
+            if (hr != S_OK)
+            {
+                PyErr_Format(PyExc_AttributeError,
+                    "Call 'get_WpsCloudService()' failed with 0x%x", hr);
+                return nullptr;
+            }
+            else
+            {
+                sipRes = prop;
+            }
+        %End
+
+        %Property(name=WpsCloudService, get=getWpsCloudService)
+
+        VARIANT_BOOL getSaveRememberStatus();
+        %MethodCode
+            VARIANT_BOOL *prop = new VARIANT_BOOL;
+            HRESULT hr = sipCpp->get_SaveRememberStatus(prop);
+            if (hr != S_OK)
+            {
+                delete prop;
+                PyErr_Format(PyExc_AttributeError,
+                    "Call 'get_SaveRememberStatus()' failed with 0x%x", hr);
+                return nullptr;
+            }
+            else
+            {
+                sipRes = prop;
+            }
+        %End
+
+        PyObject* setSaveRememberStatus(VARIANT_BOOL prop);
+        %MethodCode
+            HRESULT hr = sipCpp->put_SaveRememberStatus(*a0);
+            if (hr != S_OK)
+            {
+                PyErr_Format(PyExc_AttributeError,
+                    "Call 'put_SaveRememberStatus()' failed with 0x%x", hr);
+                sipRes = nullptr;
+            }
+            else
+            {
+                Py_INCREF(Py_None);
+                sipRes = Py_None;
+            }
+        %End
+
+        %Property(name=SaveRememberStatus, get=getSaveRememberStatus, set=setSaveRememberStatus)
+
+        VARIANT_BOOL getForceBackupEnable();
+        %MethodCode
+            VARIANT_BOOL *prop = new VARIANT_BOOL;
+            HRESULT hr = sipCpp->get_ForceBackupEnable(prop);
+            if (hr != S_OK)
+            {
+                delete prop;
+                PyErr_Format(PyExc_AttributeError,
+                    "Call 'get_ForceBackupEnable()' failed with 0x%x", hr);
+                return nullptr;
+            }
+            else
+            {
+                sipRes = prop;
+            }
+        %End
+
+        PyObject* setForceBackupEnable(VARIANT_BOOL prop);
+        %MethodCode
+            HRESULT hr = sipCpp->put_ForceBackupEnable(*a0);
+            if (hr != S_OK)
+            {
+                PyErr_Format(PyExc_AttributeError,
+                    "Call 'put_ForceBackupEnable()' failed with 0x%x", hr);
+                sipRes = nullptr;
+            }
+            else
+            {
+                Py_INCREF(Py_None);
+                sipRes = Py_None;
+            }
+        %End
+
+        %Property(name=ForceBackupEnable, get=getForceBackupEnable, set=setForceBackupEnable)
+
+        unsigned long getEmbedWid();
+        %MethodCode
+            unsigned long prop = 0;
+            HRESULT hr = sipCpp->get_EmbedWid(&prop);
+            if (hr != S_OK)
+            {
+                PyErr_Format(PyExc_AttributeError,
+                    "Call 'get_EmbedWid()' failed with 0x%x", hr);
+                return nullptr;
+            }
+            else
+            {
+                sipRes = prop;
+            }
+        %End
+
+        %Property(name=EmbedWid, get=getEmbedWid)
+    };
+};

--- a/samples/SIP/common.sip
+++ b/samples/SIP/common.sip
@@ -1,0 +1,380 @@
+/**
+ * Copyright (c) 2020-2023 Weitian Leung
+ *
+ * This file is part of pywpsrpc.
+ *
+ * This file is distributed under the MIT License.
+ * See the LICENSE file for details.
+ *
+*/
+
+%Module(name=pywpsrpc.common, keyword_arguments="Optional")
+
+%ModuleHeaderCode
+    #include "stdafx.h"
+    #include <QCoreApplication>
+    #include <atomic>
+
+BSTR _SysAllocString(const OLECHAR* psz);
+UINT _SysStringLen(BSTR bstr);
+void _SysFreeString(BSTR bstr);
+
+UINT32 _SafeArrayGetElemsize(SAFEARRAY *psa);
+HRESULT _SafeArrayGetElement(SAFEARRAY *psa, INT32 *rgIndices, void *pv);
+_SAFEARRAY_PTR _SafeArrayCreate(VARTYPE vt, UINT32 cDims, SAFEARRAYBOUND* rgsabound);
+HRESULT _SafeArrayPutElement(SAFEARRAY *psa, INT32 *rgIndices, void *pv);
+UINT32 _SafeArrayGetDim(SAFEARRAY *psa);
+HRESULT _SafeArrayGetUBound(SAFEARRAY *psa, UINT32 nDim, INT32 *plUbound);
+HRESULT _SafeArrayGetLBound(SAFEARRAY *psa, UINT32 nDim, INT32 *plLbound);
+
+bool _getVarDate(double date,
+                 int &year, int &month, int &day,
+                 int &hour, int &minute, int &second,
+                 int &us);
+
+double _toVarDate(int year, int month, int day,
+                  int hour, int minute, int second,
+                  int us);
+
+class QtApp
+{
+public:
+    QtApp(PyObject *args);
+    ~QtApp();
+
+private:
+    static int argc;
+    static char **argv;
+    static QCoreApplication *qtApp;
+    static std::atomic<int> ref;
+};
+%End
+
+%Include typedef.sip
+%Include objbase.sip
+%Include objidl.sip
+%Include oaidl.sip
+%Include guid.sip
+%Include ksoapi.sip
+%Include wpsapiex.sip
+
+HRESULT S_OK;
+HRESULT S_FALSE;
+
+HRESULT E_INVALIDARG;
+HRESULT E_NOINTERFACE;
+HRESULT E_ABORT;
+HRESULT E_FAIL;
+HRESULT E_ACCESSDENIED;
+HRESULT E_NOTIMPL;
+
+bool SUCCEEDED(HRESULT hr);
+bool FAILED(HRESULT hr);
+
+class QtApp /NoDefaultCtors/
+{
+public:
+    QtApp(PyObject *args /TypeHint="List[str]"/);
+    ~QtApp();
+};
+
+%ModuleCode
+
+BSTR _SysAllocString(const OLECHAR* psz)
+{
+    typedef BSTR (*pfnSysAllocString)(const OLECHAR*);
+    static pfnSysAllocString fnAllocStr = (pfnSysAllocString)sipImportSymbol("SysAllocString");
+
+    return fnAllocStr(psz);
+}
+
+UINT _SysStringLen(BSTR bstr)
+{
+    typedef UINT (*pfnSysStringLen)(BSTR);
+    static pfnSysStringLen fnStrLen = (pfnSysStringLen)sipImportSymbol("SysStringLen");
+
+    return fnStrLen(bstr);
+}
+
+void _SysFreeString(BSTR bstr)
+{
+    typedef void (*pfnSysFreeString)(BSTR);
+    static pfnSysFreeString fnFreeStr = (pfnSysFreeString)sipImportSymbol("SysFreeString");
+
+    fnFreeStr(bstr);
+}
+
+UINT32 _SafeArrayGetElemsize(SAFEARRAY *psa)
+{
+    typedef UINT32 (*pfnSafeArrayGetElemsize)(SAFEARRAY*);
+    static pfnSafeArrayGetElemsize fnGetSize = (pfnSafeArrayGetElemsize)sipImportSymbol("SafeArrayGetElemsize");
+
+    return fnGetSize(psa);
+}
+
+HRESULT _SafeArrayGetElement(SAFEARRAY *psa, INT32 *rgIndices, void *pv)
+{
+    typedef HRESULT (*pfnSafeArrayGetElement)(SAFEARRAY *, INT32 *, void *);
+    static pfnSafeArrayGetElement fnGetEle = (pfnSafeArrayGetElement)sipImportSymbol("SafeArrayGetElement");
+
+    return fnGetEle(psa, rgIndices, pv);
+}
+
+_SAFEARRAY_PTR _SafeArrayCreate(VARTYPE vt, UINT32 cDims, SAFEARRAYBOUND* rgsabound)
+{
+    typedef _SAFEARRAY_PTR (*pfnSafeArrayCreate)(VARTYPE vt, UINT32 cDims, SAFEARRAYBOUND* rgsabound);
+    static pfnSafeArrayCreate fnCreate = (pfnSafeArrayCreate)sipImportSymbol("SafeArrayCreate");
+
+    return fnCreate(vt, cDims, rgsabound);
+}
+
+HRESULT _SafeArrayPutElement(SAFEARRAY *psa, INT32 *rgIndices, void *pv)
+{
+    typedef HRESULT (*pfnSafeArrayPutElement)(SAFEARRAY *, INT32 *, void *);
+    static pfnSafeArrayPutElement fnPutEle = (pfnSafeArrayPutElement)sipImportSymbol("SafeArrayPutElement");
+
+    return fnPutEle(psa, rgIndices, pv);
+}
+
+UINT32 _SafeArrayGetDim(SAFEARRAY *psa)
+{
+    typedef UINT32 (*pfnSafeArrayGetDim)(SAFEARRAY *);
+    static pfnSafeArrayGetDim fnGetDim = (pfnSafeArrayGetDim)sipImportSymbol("SafeArrayGetDim");
+
+    return fnGetDim(psa);
+}
+
+HRESULT _SafeArrayGetUBound(SAFEARRAY *psa, UINT32 nDim, INT32 *plUbound)
+{
+    typedef UINT32 (*pfnSafeArrayGetUBound)(SAFEARRAY *, UINT32, INT32*);
+    static pfnSafeArrayGetUBound fnGetUBound = (pfnSafeArrayGetUBound)sipImportSymbol("SafeArrayGetUBound");
+
+    return fnGetUBound(psa, nDim, plUbound);
+}
+
+HRESULT _SafeArrayGetLBound(SAFEARRAY *psa, UINT32 nDim, INT32 *plLbound)
+{
+    typedef UINT32 (*pfnSafeArrayGetLBound)(SAFEARRAY *, UINT32, INT32*);
+    static pfnSafeArrayGetLBound fnGetLBound = (pfnSafeArrayGetLBound)sipImportSymbol("SafeArrayGetLBound");
+
+    return fnGetLBound(psa, nDim, plLbound);
+}
+
+bool _getVarDate(double date,
+                 int &year, int &month, int &day,
+                 int &hour, int &minute, int &second,
+                 int &us)
+{
+    const int DATE_MIN = -657434;
+    const int DATE_MAX = 2958465;
+
+    if (date <= (DATE_MIN - 1.0) || date >= (DATE_MAX + 1.0))
+        return false;
+
+    double datePart = date < 0.0 ? ceil(date) : floor(date);
+    double timePart = fabs(date - datePart) + 0.00000000001;
+    if (timePart >= 1.0)
+        timePart -= 0.00000000001;
+
+    auto julianDays = [](int date) -> int
+    {
+        date -= DATE_MIN;
+        date += 1757585;
+        return date;
+    };
+
+    auto parseJulian = [](int jd, int &year, int &month, int &day)
+    {
+        int l = jd + 68569;
+        int n = l * 4 / 146097;
+        l -= (n * 146097 + 3) / 4;
+        int i = (4000 * (l + 1)) / 1461001;
+        l += 31 - (i * 1461) / 4;
+        int j = (l * 80) / 2447;
+        day = l - (j * 2447) / 80;
+        l = j / 11;
+        month = (j + 2) - (12 * l);
+        year = 100 * (n - 49) + i + l;
+    };
+
+    parseJulian(julianDays(date), year, month, day);
+
+    timePart *= 24.0;
+    hour = timePart;
+    timePart -= hour;
+    timePart *= 60.0;
+    minute = timePart;
+    timePart -= minute;
+    timePart *= 60.0;
+    second = timePart;
+    timePart -= second;
+    us = timePart * 1000 * 1000;
+
+    return true;
+}
+
+double _toVarDate(int year, int month, int day,
+                  int hour, int minute, int second,
+                  int us)
+{
+    auto toJulian = [](int year, int month, int day) -> double
+    {
+        int m12 = (month - 14) / 12;
+
+        return ((1461 * (year + 4800 + m12)) / 4 +
+                (367 * (month - 2 - 12 * m12)) / 12 -
+                (3 * ((year + 4900 + m12) / 100)) / 4 + day - 32075);
+    };
+
+    auto dateFromJulian = [](int date) -> int
+    {
+        date -= 1757585;
+        date += -657434;
+        return date;
+    };
+
+    double date = dateFromJulian(toJulian(year, month, day));
+    double sign = (date < 0.0) ? -1.0 : 1.0;
+
+    date += hour / 24.0 * sign;
+    date += minute / 1440.0 * sign;
+    date += second / 86400.0 * sign;
+    date += us / 1000000 * sign;
+
+    return date;
+}
+
+#define _HRESULT_CONST(name, value) \
+    static const HRESULT name = value;
+
+#undef S_OK
+#undef S_FALSE
+#undef E_INVALIDARG
+#undef E_NOINTERFACE
+#undef E_ABORT
+#undef E_FAIL
+#undef E_ACCESSDENIED
+#undef E_NOTIMPL
+
+_HRESULT_CONST(S_OK, 0x00000000)
+_HRESULT_CONST(S_FALSE, 0x00000001)
+_HRESULT_CONST(E_INVALIDARG, 0x80070057)
+_HRESULT_CONST(E_NOINTERFACE, 0x80004002)
+_HRESULT_CONST(E_ABORT, 0x80004004)
+_HRESULT_CONST(E_FAIL, 0x80004005)
+_HRESULT_CONST(E_ACCESSDENIED, 0x80070005)
+_HRESULT_CONST(E_NOTIMPL, 0x80004001)
+
+#undef SUCCEEDED
+static bool SUCCEEDED(HRESULT hr)
+{
+    return hr >= 0;
+}
+
+#undef FAILED
+static bool FAILED(HRESULT hr)
+{
+    return hr < 0;
+}
+
+// to avoid depends on python's Qt (PySide2, PyQt5 etc.)
+#include <QString>
+
+int QtApp::argc = 0;
+char **QtApp::argv = nullptr;
+QCoreApplication *QtApp::qtApp = nullptr;
+std::atomic<int> QtApp::ref;
+
+
+QtApp::QtApp(PyObject *args)
+{
+    ++ref;
+    if (qtApp)
+        return;
+
+    argc = PyList_Size(args);
+    argv = new char *[argc + 1];
+
+    for (int i = 0; i < argc; ++i)
+    {
+        PyObject *item = PyList_GetItem(args, i);
+        char *arg = nullptr;
+
+        if (PyUnicode_Check(item))
+        {
+            int char_size = 0;
+            Py_ssize_t len = 0;
+            void *data = sipUnicodeData(item, &char_size, &len);
+
+            switch (char_size)
+            {
+            case 1:
+                arg = strdup(reinterpret_cast<char*>(data));
+                break;
+
+            case 2:
+                {
+                    QString qStr(reinterpret_cast<QChar*>(data), len);
+                    const QByteArray ba = qStr.toLocal8Bit();
+                    arg = strdup(ba.constData());
+                }
+                break;
+
+            case 4:
+                {
+                    QString qStr = QString::fromUcs4(reinterpret_cast<uint*>(data), len);
+                    const QByteArray ba = qStr.toLocal8Bit();
+                    arg = strdup(ba.constData());
+                }
+                break;
+            }
+        }
+        else if (PyBytes_Check(item))
+        {
+            arg = strdup(PyBytes_AsString(item));
+        }
+
+        argv[i] = arg;
+    }
+
+    argv[argc] = nullptr;
+
+    qtApp = new QCoreApplication(argc, argv);
+}
+
+QtApp::~QtApp()
+{
+    --ref;
+    if (ref == 0 && qtApp)
+    {
+        delete qtApp;
+
+        for (int i = 0; i < argc; ++i)
+        {
+            if (argv[i])
+                free(argv[i]);
+        }
+
+        delete [] argv;
+
+        qtApp = nullptr;
+        argc = 0;
+        argv = nullptr;
+    }
+}
+
+static void IUnknown_CollectingWrapperEventHandler(sipSimpleWrapper *sipSelf)
+{
+    if (!sipIsOwnedByPython(sipSelf))
+    {
+        if (IUnknown *cppPtr = reinterpret_cast<IUnknown*>(sipGetAddress(sipSelf)))
+            cppPtr->Release();
+    }
+}
+%End
+
+%PostInitialisationCode
+sipRegisterEventHandler(sipEventCollectingWrapper,
+    sipType_IUnknown,
+    (void *)IUnknown_CollectingWrapperEventHandler);
+%End

--- a/samples/SIP/core.sip
+++ b/samples/SIP/core.sip
@@ -1,0 +1,33 @@
+// Define the SIP wrapper to the core library.
+
+%Module(name=examples.core, use_limited_api=True, gil_use="NotUsed",
+        multi_interpreter_support="Supported")
+
+%MinimumABIVersion "12.0"
+%MinimumABIVersion "13.0"
+%MinimumABIVersion "14.0"
+
+%DefaultEncoding "ASCII"
+
+%Platforms {Linux macOS Windows}
+
+%If (Linux)
+const char *what_am_i();
+%MethodCode
+    sipRes = "Linux";
+%End
+%End
+
+%If (macOS)
+const char *what_am_i();
+%MethodCode
+    sipRes = "macOS";
+%End
+%End
+
+%If (Windows)
+const char *what_am_i();
+%MethodCode
+    sipRes = "Windows";
+%End
+%End

--- a/samples/SIP/docstrings_module.sip
+++ b/samples/SIP/docstrings_module.sip
@@ -1,0 +1,93 @@
+// The SIP implementation of the docstrings_module test module.
+
+
+%DefaultDocstringFormat "deindented"
+
+%Module(name=docstrings_module, gil_use="NotUsed",
+        multi_interpreter_support="PerInterpreterGILSupported")
+{
+%Docstring
+Module
+%End
+};
+
+%MinimumABIVersion "12.0"
+%MinimumABIVersion "13.0"
+%MinimumABIVersion "14.0"
+
+
+%ModuleCode
+void overloaded() {}
+void overloaded(const char *arg) {}
+void overloaded(int arg) {}
+void overloaded(double arg) {}
+
+void pod_ptr_arg(const char *arg) {}
+void pod_ptr_opt_arg(const char *arg) {}
+void bool_opt_arg(bool arg) {}
+%End
+
+%ModuleHeaderCode
+void overloaded();
+void overloaded(const char *arg);
+void overloaded(int arg);
+void overloaded(double arg);
+
+void pod_ptr_arg(const char *arg);
+void pod_ptr_opt_arg(const char *arg = NULL);
+void bool_opt_arg(bool arg = true);
+
+class Klass
+{
+public:
+    Klass() {}
+    Klass(const Klass &other) {}
+
+    void callable() {}
+};
+%End
+
+
+void overloaded();
+
+void overloaded(const char *arg);
+%Docstring(signature="prepended")
+    prepended
+%End
+
+void overloaded(int arg /Constrained/);
+%Docstring(signature="appended")
+    appended
+%End
+
+void overloaded(double arg);
+%Docstring(signature="discarded")
+    discarded
+%End
+
+void pod_ptr_arg(const char *arg);
+void pod_ptr_opt_arg(const char *arg = NULL);
+void bool_opt_arg(bool arg = true);
+
+class Klass
+{
+%Docstring(signature="appended")
+    Klass overview
+%End
+
+public:
+    Klass();
+    %Docstring(signature="prepended")
+        Default constructor
+    %End
+
+    Klass(const Klass &other);
+    %Docstring(signature="prepended")
+        Copy constructor
+    %End
+
+    void callable();
+    %Docstring
+        callable
+    %End
+};

--- a/samples/SIP/typedef.sip
+++ b/samples/SIP/typedef.sip
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2020 Weitian Leung
+ *
+ * This file is part of pywpsrpc.
+ *
+ * This file is distributed under the MIT License.
+ * See the LICENSE file for details.
+ *
+*/
+
+typedef unsigned long ULONG;
+typedef ULONG *PULONG;
+typedef unsigned short USHORT;
+typedef USHORT *PUSHORT;
+typedef unsigned char UCHAR;
+typedef UCHAR *PUCHAR;
+typedef char *PSZ;
+
+typedef void VOID;
+typedef char CHAR;
+typedef short SHORT;
+typedef long LONG;
+typedef LONG *PLONG;
+
+typedef char int8_t;
+typedef short int16_t;
+typedef int int32_t;
+typedef long long int64_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+
+%MappedType intptr_t /TypeHint="sip.voidptr"/
+{
+%ConvertToTypeCode
+    intptr_t ptr = (intptr_t)sipConvertToVoidPtr(sipPy);
+    if (!sipIsErr)
+        return !PyErr_Occurred();
+    
+    intptr_t *heap = new intptr_t;
+    *heap = ptr;
+
+    *sipCppPtr = heap;
+
+    return SIP_TEMPORARY;
+%End
+
+%ConvertFromTypeCode
+    return sipConvertFromVoidPtr((void *)*sipCpp);
+%End
+};
+
+%MappedType uintptr_t /TypeHint="sip.voidptr"/
+{
+%ConvertToTypeCode
+    uintptr_t ptr = (uintptr_t)sipConvertToVoidPtr(sipPy);
+    if (!sipIsErr)
+        return !PyErr_Occurred();
+    
+    uintptr_t *heap = new uintptr_t;
+    *heap = ptr;
+
+    *sipCppPtr = heap;
+
+    return SIP_TEMPORARY;
+%End
+
+%ConvertFromTypeCode
+    return sipConvertFromVoidPtr((void *)*sipCpp);
+%End
+};
+
+
+typedef int8_t				int8;
+typedef int16_t				int16;
+typedef int32_t				int32;
+typedef int64_t				int64;
+typedef uint8_t				uint8;
+typedef uint16_t			uint16;
+typedef uint32_t			uint32;
+typedef uint64_t			uint64;
+typedef intptr_t			intp;
+typedef uintptr_t			uintp;
+
+typedef int8				INT8;
+typedef uint8				UINT8;
+typedef int16				INT16;
+typedef uint16				UINT16;
+typedef int32				INT32;
+typedef uint32				UINT32;
+typedef int64				INT64;
+typedef uint64				UINT64;
+typedef UINT32				DWORD;
+typedef int32				BOOL;
+typedef unsigned char		BYTE;
+typedef uint16				WORD;
+typedef float				FLOAT;
+typedef double				DOUBLE;
+typedef FLOAT				*PFLOAT;
+typedef BOOL    			*PBOOL;
+typedef BOOL    			*LPBOOL;
+typedef BYTE    			*PBYTE;
+typedef BYTE    			*LPBYTE;
+typedef int     			*PINT;
+typedef int 				*LPINT;
+typedef WORD    			*PWORD;
+typedef WORD    			*LPWORD;
+typedef long    			*LPLONG;
+typedef DWORD   			*PDWORD;
+typedef DWORD   			*LPDWORD;
+typedef void    			*LPVOID;
+typedef const void  		*LPCVOID;
+
+typedef int					INT;
+typedef unsigned int		UINT;
+typedef unsigned int		*PUINT;
+typedef long long			LONGLONG;
+typedef unsigned long long	ULONGLONG;
+typedef DWORD				LCID;
+typedef DWORD				LCTYPE;
+
+typedef uintp				UINTP;
+typedef intp				INTP;
+typedef uintp				KSO_WParam;
+typedef intp				KSO_LParam;
+
+typedef int32				size32;
+typedef uint32				usize32;
+typedef size32				SIZE32;
+typedef usize32				USIZE32;
+
+typedef DWORD   COLORREF;
+typedef DWORD*	LPCOLORREF;
+
+typedef INT32 HRESULT;
+
+typedef unsigned short WCHAR;
+
+typedef WCHAR* PWCHAR;
+typedef WCHAR* LPWCH;
+typedef WCHAR* PWCH;
+typedef WCHAR* LPWSTR;
+typedef WCHAR* PWSTR;
+typedef const WCHAR* PCWCHAR;
+typedef const WCHAR* LPCWCH;
+typedef const WCHAR* PCWCH;
+typedef const WCHAR* LPCWSTR;
+typedef const WCHAR* PCWSTR;
+
+//typedef LPCWSTR LPCOLESTR;
+//typedef LPWSTR LPOLESTR;
+
+typedef CHAR *PCHAR;
+typedef CHAR *LPCH;
+typedef CHAR *PCH;
+
+typedef const CHAR *LPCCH;
+typedef const CHAR *PCCH;
+typedef CHAR *NPSTR;
+typedef CHAR *LPSTR;
+typedef CHAR *PSTR;
+typedef const CHAR *LPCSTR;
+typedef const CHAR *PCSTR;
+
+typedef void* PVOID;
+typedef unsigned short VARTYPE;
+typedef long SCODE;
+
+// typedef short VARIANT_BOOL;
+%MappedType VARIANT_BOOL /TypeHint="bool"/
+{
+%ConvertToTypeCode
+    if (!sipIsErr)
+        return PyBool_Check(sipPy) || PyLong_Check(sipPy);
+
+    VARIANT_BOOL *boolPtr = new VARIANT_BOOL;
+    if (PyBool_Check(sipPy))
+        *boolPtr = sipPy == Py_True ? VARIANT_TRUE : VARIANT_FALSE;
+    else // PyLong_Check
+        *boolPtr = PyLong_AsLong(sipPy) == 0 ? VARIANT_FALSE : VARIANT_TRUE;
+
+    *sipCppPtr = boolPtr;
+
+    return SIP_TEMPORARY;
+%End
+
+%ConvertFromTypeCode
+    return PyBool_FromLong(*sipCpp == VARIANT_FALSE ? 0 : 1);
+%End
+};

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -575,6 +575,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **SAS:** [rpardee/sas.tmbundle](https://github.com/rpardee/sas.tmbundle)
 - **SCSS:** [atom/language-sass](https://github.com/atom/language-sass)
 - **SELinux Policy:** [google/selinux-policy-languages](https://github.com/google/selinux-policy-languages)
+- **SIP:** [mikomikotaishi/c.tmbundle](https://github.com/mikomikotaishi/c.tmbundle)
 - **SMT:** [SRI-CSL/SMT.tmbundle](https://github.com/SRI-CSL/SMT.tmbundle)
 - **SPARQL:** [peta/turtle.tmbundle](https://github.com/peta/turtle.tmbundle)
 - **SQF:** [JonBons/Sublime-SQF-Language](https://github.com/JonBons/Sublime-SQF-Language)


### PR DESCRIPTION
Adds the `SIP` language for `.sip` specification files — the bindings-definition format read by [SIP](https://github.com/Python-SIP/sip), Riverbank Computing's C/C++ bindings generator and the tool behind PyQt, QGIS' Python API, PyKDE, python-poppler-qt5 and others.

## Description

A `.sip` file describes the Python API of a C/C++ library: C/C++ declarations annotated with SIP directives (`%Module`, `%Import`, `%Include`, `%MappedType`, `%MethodCode` … `%End`) and `/Annotation/` blocks.

`.sip` was previously unclaimed in [`languages.yml`](/lib/linguist/languages.yml), so these files were left unclassified: no language, no syntax highlighting and no contribution to the repository language bar.

Changes:

- Add the `SIP` entry to `languages.yml`, between `SELinux Policy` and `SMT`.
- `tm_scope: source.c++`, `ace_mode: c_cpp`, `codemirror_mode: clike`, `codemirror_mime_type: text/x-c++src`, following the existing `SWIG` entry (`lib/linguist/languages.yml` L7284-L7294). SWIG interface files are the same category of artifact — C/C++ declarations plus tool-specific `%` directives — and there is no SIP-specific TextMate grammar to vendor.
- `language_id` generated with `script/update-ids`.
- Regenerate the `vendor/README.md` grammar index row.
- Add five real-world samples under `samples/SIP/`.

No heuristic is added: `.sip` is claimed by no other language in `languages.yml`, so `Strategy::Extension` short-circuits the chain (`lib/linguist.rb` L35-L37) and a heuristic entry would be unreachable. See the note at the bottom.

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.sip+%22%25Module%22 — **47.5k files** (`%Module`, the module-declaration directive carried by every SIP specification's top-level file)
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.sip+%22%25MethodCode%22 — **106k files** (`%MethodCode`, the handwritten-C/C++-body directive)
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.sip — 577k files for the bare extension, no keyword
    - Distribution across unique `:user/:repo`: a 905-result sample of the search API returned 406 distinct owner/repo combinations. The unfiltered first pages span `veusz/veusz`, `KDE/pykde4`, `GauiStori/PyQt-Qwt`, `frescobaldi/python-poppler-qt5`, `dimv36/QCustomPlot-PyQt5`, `Ultimaker/pyArcus`, `esrf-bliss/Lima-camera-ximea`, `CefView/PyQCefView`, `massivethreads/dagviz`, `sourcepole/qgis`, `plasmodic/hippodraw`, `qingfengxia/qhexedit` and `timxx/pywpsrpc` — no single owner dominates, so no `-user:` filtering is needed.
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - `samples/SIP/common.sip` — https://github.com/timxx/pywpsrpc/blob/master/sip/common/common.sip
      - `samples/SIP/typedef.sip` — https://github.com/timxx/pywpsrpc/blob/master/sip/common/typedef.sip
      - `samples/SIP/_ApplicationEx.sip` — https://github.com/timxx/pywpsrpc/blob/master/sip/common/wpsapiex/_ApplicationEx.sip
      - `samples/SIP/core.sip` — https://github.com/Python-SIP/sip/blob/main/examples/package/core/core.sip
      - `samples/SIP/docstrings_module.sip` — https://github.com/Python-SIP/sip/blob/main/test/docstrings/docstrings_module.sip
    - Sample license(s): MIT for the three `timxx/pywpsrpc` files, BSD-2-Clause for the two `Python-SIP/sip` files. PyQt's own `.sip` files are GPL-3.0-only and are deliberately not used.
  - [x] I have included a syntax highlighting grammar: https://github.com/mikomikotaishi/c.tmbundle — already vendored. `SIP` reuses the `source.c++` scope exactly as `SWIG` does; there is no SIP-specific TextMate grammar in existence to add.
  - [x] I have added a color
    - Hex value: `#A45069`
    - Rationale: not randomly selected. SIP has no brand palette of its own, so the value is derived reproducibly from what a `.sip` file contains — C/C++ declarations — as the per-channel sRGB midpoint of Linguist's own C `#555555` and C++ `#f34b7d`:

      | | C | C++ | midpoint | |
      |---|---|---|---|---|
      | R | `0x55` | `0xF3` | 164 | `0xA4` |
      | G | `0x55` | `0x4B` | 80 | `0x50` |
      | B | `0x55` | `0x7D` | 105 | `0x69` |

      Every channel sum is even, so no rounding is involved and the derivation is exact. The nearest colours already in `languages.yml` are QuakeC `#975777` and Sass `#a53b70`, at Euclidean RGB distances of 20 and 22. Happy to change it if you would prefer something else.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension. — not applicable, see below.

---

One thing worth flagging honestly: a minority of `.sip` files on GitHub are not SIP specifications but Intel Quartus IP settings files (Tcl-style `set_global_assignment` lines, typically `sys/pll_cfg.sip` in FPGA projects) — [2.1k files](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.sip+set_global_assignment) against 47.5k for `%Module`. Linguist has no language entry for Quartus settings files, so there is nothing to disambiguate against and a `heuristics.yml` rule for `.sip` could never fire. If such a language is ever added, `.sip` would need a heuristic at that point, and `%Module`/`%End` versus `set_global_assignment` separates the two cleanly. I'm happy to add one pre-emptively if you'd rather have it in place now.
