### PR TITLE
Add Rhai language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1575,6 +1575,9 @@
 [submodule "vendor/grammars/vscode-rbs-syntax"]
 	path = vendor/grammars/vscode-rbs-syntax
 	url = https://github.com/soutaro/vscode-rbs-syntax.git
+[submodule "vendor/grammars/vscode-rhai"]
+	path = vendor/grammars/vscode-rhai
+	url = https://github.com/rhaiscript/vscode-rhai.git
 [submodule "vendor/grammars/vscode-ron"]
 	path = vendor/grammars/vscode-ron
 	url = https://github.com/a5huynh/vscode-ron.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1420,6 +1420,8 @@ vendor/grammars/vscode-python:
 - source.pip-requirements
 vendor/grammars/vscode-rbs-syntax:
 - source.rbs
+vendor/grammars/vscode-rhai:
+- source.rhai
 vendor/grammars/vscode-ron:
 - source.ron
 vendor/grammars/vscode-ruby-slim:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6864,6 +6864,14 @@ Rez:
   ace_mode: text
   color: "#FFDAB3"
   language_id: 498022874
+Rhai:
+  type: programming
+  color: "#FBA63B"
+  extensions:
+  - ".rhai"
+  tm_scope: source.rhai
+  ace_mode: text
+  language_id: 713228814
 Rich Text Format:
   type: markup
   extensions:

--- a/samples/Rhai/cabin.rhai
+++ b/samples/Rhai/cabin.rhai
@@ -1,0 +1,39 @@
+// Isometric render:   --scale 0.05 --pitch 80 --roll 130 --center=0,0,-14 --isometric
+// Perspective render: --scale 0.05 --pitch 80 --roll 130 --center=0,0,-14 --perspective=0.2 --zflatten 2
+let logs = x.abs() - 10 -  max(0.05, 1.0 - (y % 2 - 1).square()).sqrt();
+let cabin = max(
+    logs.remap(x, z, y),
+    logs.remap(y, z, x)
+);
+
+let roof = z/2 + y.abs()/2 - 15;
+
+// extrude the roof
+let lower_roof = -roof;
+let upper_roof = roof - 1 + (((-y.abs()/2 + z/2) % 1) - 0.5).abs() / 4;
+let cabin = max(cabin, upper_roof);
+let roof = max(lower_roof,  upper_roof);
+let x_clamp = x.abs() - 13;
+let roof = max(max(x_clamp, roof), 18 - z);
+
+// Build a door frame
+let door_frame = max(y.abs() - 5, z - 14);
+let door_frame_inner = -(door_frame + 1.5);
+let door_width = max(10 - x, x - 11);
+let door_frame = max(max(door_frame, door_frame_inner),
+    door_width);
+let doorknob = (x.square() + y.square() + z.square()).sqrt() - 0.6;
+let door = min(door_frame, doorknob.remap(x - 10.5, y - 2, z - 6));
+let cabin = max(cabin, -max(-door_frame_inner, door_width));
+let cabin = min(cabin, door);
+
+// Build a window
+let window_root = max(x.abs(), (z - 9).abs());
+let cabin = max(cabin, -max(window_root - 4, 10 - y.abs())); // cut out window
+let window_cross = max(window_root - 4, min(x.abs() - 0.2, (z - 9).abs() - 0.2));
+let window_frame = max(window_root - 4, 3 - window_root);
+let cabin = min(cabin, max(min(window_frame, window_cross), y.abs() - 11));
+let cabin = min(cabin, max(window_root - 3, y.abs() - 10.6));
+
+let cabin = min(max(-z, cabin), roof);
+draw(cabin)

--- a/samples/Rhai/calyx.rhai
+++ b/samples/Rhai/calyx.rhai
@@ -1,0 +1,45 @@
+export const verilog_state = state("verilog", ["sv", "v"]);
+export const verilog_noverify = state("verilog-noverify", ["sv"]);
+export const calyx_state = state("calyx", ["futil"]);
+
+export let calyx_setup = calyx_setup;
+fn calyx_setup(e) {
+   e.config_var("calyx-base", "calyx.base");
+   e.config_var_or("calyx-exe", "calyx.exe", "$calyx-base/target/debug/calyx");
+   e.config_var_or("calyx-lib-path", "calyx.lib_path", "$calyx-base");
+   e.config_var_or("args", "calyx.args", "");
+
+   e.rule("calyx", "$calyx-exe -l $calyx-lib-path -b $backend $args $in > $out");
+   e.rule("calyx-pass", "$calyx-exe -l $calyx-lib-path -p $pass $args $in > $out");
+
+   e.config_var_or("cider-calyx-passes", "cider.calyx-passes", "-p none");
+   e.rule(
+       "calyx-cider",
+       "$calyx-exe -l $calyx-lib-path $cider-calyx-passes $args $in > $out",
+   );
+}
+
+op(
+  "calyx-to-verilog",
+  [calyx_setup],
+  calyx_state,
+  verilog_state,
+  |e, input, output| {
+    e.build_cmd([output], "calyx", [input], []) ;
+    e.arg("backend", "verilog");
+  }
+);
+
+
+op(
+    "calyx-noverify",
+    [calyx_setup],
+    calyx_state,
+    verilog_noverify,
+    |e, input, output| {
+        // Icarus requires a special --disable-verify version of Calyx code.
+        e.build_cmd([output], "calyx", [input], []);
+        e.arg("backend", "verilog");
+        e.arg("args", "--disable-verify $args");
+    },
+);

--- a/samples/Rhai/esp_idf_pre_script.rhai
+++ b/samples/Rhai/esp_idf_pre_script.rhai
@@ -1,0 +1,76 @@
+let targets = #{
+    esp32: #{
+        arch: "xtensa",
+        rust_target: "xtensa-esp32-espidf",
+        gcc_target: "xtensa-esp32-elf",
+        wokwi_board: "board-esp32-devkit-c-v4",
+    },
+    esp32c2: #{
+        arch: "riscv",
+        rust_target: "riscv32imc-esp-espidf",
+        gcc_target: "riscv32-esp-elf",
+        wokwi_board: "",
+    },
+    esp32c3: #{
+        arch: "riscv",
+        rust_target: "riscv32imc-esp-espidf",
+        gcc_target: "riscv32-esp-elf",
+        wokwi_board: "board-esp32-c3-devkitm-1",
+    },
+    esp32c5: #{
+        arch: "riscv",
+        rust_target: "riscv32imac-esp-espidf",
+        gcc_target: "riscv32-esp-elf",
+        wokwi_board: "board-esp32-c5-devkitc-1",
+    },
+    esp32c6: #{
+        arch: "riscv",
+        rust_target: "riscv32imac-esp-espidf",
+        gcc_target: "riscv32-esp-elf",
+        wokwi_board: "board-esp32-c6-devkitc-1",
+    },
+    esp32c61: #{
+        arch: "riscv",
+        rust_target: "riscv32imac-esp-espidf",
+        gcc_target: "riscv32-esp-elf",
+    },
+    esp32h2: #{
+        arch: "riscv",
+        rust_target: "riscv32imac-esp-espidf",
+        gcc_target: "riscv32-esp-elf",
+        wokwi_board: "board-esp32-h2-devkitm-1",
+    },
+    esp32p4: #{
+        arch: "riscv",
+        rust_target: "riscv32imafc-esp-espidf",
+        gcc_target: "riscv32-esp-elf",
+        wokwi_board: "board-esp32-p4-preview",
+    },
+    esp32s2: #{
+        arch: "xtensa",
+        rust_target: "xtensa-esp32s2-espidf",
+        gcc_target: "xtensa-esp32s2-elf",
+        wokwi_board: "board-esp32-s2-devkitm-1",
+    },
+    esp32s3: #{
+        arch: "xtensa",
+        rust_target: "xtensa-esp32s3-espidf",
+        gcc_target: "xtensa-esp32s3-elf",
+        wokwi_board: "board-esp32-s3-devkitc-1",
+    },
+};
+
+let target = variable::get("mcu");
+let target_properties = targets.get(target);
+for key in target_properties.keys() {
+    variable::set(key, target_properties.get(key));
+}
+
+let advanced = variable::get("advanced");
+if !advanced {
+    variable::set("espidfver", "v5.5.3");
+    variable::set("git", "false");
+    variable::set("installdir", "workspace");
+    variable::set("devcontainer", false);
+    variable::set("wokwi", false);
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -561,6 +561,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Regular Expression:** [tree-sitter/tree-sitter-regex](https://github.com/tree-sitter/tree-sitter-regex) 🐌
 - **Ren'Py:** [williamd1k0/language-renpy](https://github.com/williamd1k0/language-renpy)
 - **Rez:** [textmate/rez.tmbundle](https://github.com/textmate/rez.tmbundle)
+- **Rhai:** [rhaiscript/vscode-rhai](https://github.com/rhaiscript/vscode-rhai)
 - **Rich Text Format:** [nwhetsell/language-rtf](https://github.com/nwhetsell/language-rtf)
 - **Ring:** [MahmoudFayed/atom-language-ring](https://github.com/MahmoudFayed/atom-language-ring)
 - **Riot:** [riot/syntax-highlight](https://github.com/riot/syntax-highlight)

--- a/vendor/licenses/git_submodule/vscode-rhai.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-rhai.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: vscode-rhai
-version: a9d3cc8932b370ae0834954974a69218c3db0908
+version: b7f91ddd8074e6b566a9e5b1abe9fae8ddad7adc
 type: git_submodule
 homepage: https://github.com/rhaiscript/vscode-rhai.git
 license: mpl-2.0

--- a/vendor/licenses/git_submodule/vscode-rhai.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-rhai.dep.yml
@@ -1,0 +1,367 @@
+---
+name: vscode-rhai
+version: a9d3cc8932b370ae0834954974a69218c3db0908
+type: git_submodule
+homepage: https://github.com/rhaiscript/vscode-rhai.git
+license: mpl-2.0
+licenses:
+- sources: LICENSE
+  text: |+
+    Mozilla Public License Version 2.0
+    ==================================
+
+    ### 1. Definitions
+
+    **1.1. “Contributor”**
+        means each individual or legal entity that creates, contributes to
+        the creation of, or owns Covered Software.
+
+    **1.2. “Contributor Version”**
+        means the combination of the Contributions of others (if any) used
+        by a Contributor and that particular Contributor's Contribution.
+
+    **1.3. “Contribution”**
+        means Covered Software of a particular Contributor.
+
+    **1.4. “Covered Software”**
+        means Source Code Form to which the initial Contributor has attached
+        the notice in Exhibit A, the Executable Form of such Source Code
+        Form, and Modifications of such Source Code Form, in each case
+        including portions thereof.
+
+    **1.5. “Incompatible With Secondary Licenses”**
+        means
+
+    * **(a)** that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+    * **(b)** that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+    **1.6. “Executable Form”**
+        means any form of the work other than Source Code Form.
+
+    **1.7. “Larger Work”**
+        means a work that combines Covered Software with other material, in
+        a separate file or files, that is not Covered Software.
+
+    **1.8. “License”**
+        means this document.
+
+    **1.9. “Licensable”**
+        means having the right to grant, to the maximum extent possible,
+        whether at the time of the initial grant or subsequently, any and
+        all of the rights conveyed by this License.
+
+    **1.10. “Modifications”**
+        means any of the following:
+
+    * **(a)** any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+    * **(b)** any new file in Source Code Form that contains any Covered
+        Software.
+
+    **1.11. “Patent Claims” of a Contributor**
+        means any patent claim(s), including without limitation, method,
+        process, and apparatus claims, in any patent Licensable by such
+        Contributor that would be infringed, but for the grant of the
+        License, by the making, using, selling, offering for sale, having
+        made, import, or transfer of either its Contributions or its
+        Contributor Version.
+
+    **1.12. “Secondary License”**
+        means either the GNU General Public License, Version 2.0, the GNU
+        Lesser General Public License, Version 2.1, the GNU Affero General
+        Public License, Version 3.0, or any later versions of those
+        licenses.
+
+    **1.13. “Source Code Form”**
+        means the form of the work preferred for making modifications.
+
+    **1.14. “You” (or “Your”)**
+        means an individual or a legal entity exercising rights under this
+        License. For legal entities, “You” includes any entity that
+        controls, is controlled by, or is under common control with You. For
+        purposes of this definition, “control” means **(a)** the power, direct
+        or indirect, to cause the direction or management of such entity,
+        whether by contract or otherwise, or **(b)** ownership of more than
+        fifty percent (50%) of the outstanding shares or beneficial
+        ownership of such entity.
+
+
+    ### 2. License Grants and Conditions
+
+    #### 2.1. Grants
+
+    Each Contributor hereby grants You a world-wide, royalty-free,
+    non-exclusive license:
+
+    * **(a)** under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+    * **(b)** under Patent Claims of such Contributor to make, use, sell, offer
+        for sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+    #### 2.2. Effective Date
+
+    The licenses granted in Section 2.1 with respect to any Contribution
+    become effective for each Contribution on the date the Contributor first
+    distributes such Contribution.
+
+    #### 2.3. Limitations on Grant Scope
+
+    The licenses granted in this Section 2 are the only rights granted under
+    this License. No additional rights or licenses will be implied from the
+    distribution or licensing of Covered Software under this License.
+    Notwithstanding Section 2.1(b) above, no patent license is granted by a
+    Contributor:
+
+    * **(a)** for any code that a Contributor has removed from Covered Software;
+        or
+    * **(b)** for infringements caused by: **(i)** Your and any other third party's
+        modifications of Covered Software, or **(ii)** the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+    * **(c)** under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+    This License does not grant any rights in the trademarks, service marks,
+    or logos of any Contributor (except as may be necessary to comply with
+    the notice requirements in Section 3.4).
+
+    #### 2.4. Subsequent Licenses
+
+    No Contributor makes additional grants as a result of Your choice to
+    distribute the Covered Software under a subsequent version of this
+    License (see Section 10.2) or under the terms of a Secondary License (if
+    permitted under the terms of Section 3.3).
+
+    #### 2.5. Representation
+
+    Each Contributor represents that the Contributor believes its
+    Contributions are its original creation(s) or it has sufficient rights
+    to grant the rights to its Contributions conveyed by this License.
+
+    #### 2.6. Fair Use
+
+    This License is not intended to limit any rights You have under
+    applicable copyright doctrines of fair use, fair dealing, or other
+    equivalents.
+
+    #### 2.7. Conditions
+
+    Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+    in Section 2.1.
+
+
+    ### 3. Responsibilities
+
+    #### 3.1. Distribution of Source Form
+
+    All distribution of Covered Software in Source Code Form, including any
+    Modifications that You create or to which You contribute, must be under
+    the terms of this License. You must inform recipients that the Source
+    Code Form of the Covered Software is governed by the terms of this
+    License, and how they can obtain a copy of this License. You may not
+    attempt to alter or restrict the recipients' rights in the Source Code
+    Form.
+
+    #### 3.2. Distribution of Executable Form
+
+    If You distribute Covered Software in Executable Form then:
+
+    * **(a)** such Covered Software must also be made available in Source Code
+        Form, as described in Section 3.1, and You must inform recipients of
+        the Executable Form how they can obtain a copy of such Source Code
+        Form by reasonable means in a timely manner, at a charge no more
+        than the cost of distribution to the recipient; and
+
+    * **(b)** You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter
+        the recipients' rights in the Source Code Form under this License.
+
+    #### 3.3. Distribution of a Larger Work
+
+    You may create and distribute a Larger Work under terms of Your choice,
+    provided that You also comply with the requirements of this License for
+    the Covered Software. If the Larger Work is a combination of Covered
+    Software with a work governed by one or more Secondary Licenses, and the
+    Covered Software is not Incompatible With Secondary Licenses, this
+    License permits You to additionally distribute such Covered Software
+    under the terms of such Secondary License(s), so that the recipient of
+    the Larger Work may, at their option, further distribute the Covered
+    Software under the terms of either this License or such Secondary
+    License(s).
+
+    #### 3.4. Notices
+
+    You may not remove or alter the substance of any license notices
+    (including copyright notices, patent notices, disclaimers of warranty,
+    or limitations of liability) contained within the Source Code Form of
+    the Covered Software, except that You may alter any license notices to
+    the extent required to remedy known factual inaccuracies.
+
+    #### 3.5. Application of Additional Terms
+
+    You may choose to offer, and to charge a fee for, warranty, support,
+    indemnity or liability obligations to one or more recipients of Covered
+    Software. However, You may do so only on Your own behalf, and not on
+    behalf of any Contributor. You must make it absolutely clear that any
+    such warranty, support, indemnity, or liability obligation is offered by
+    You alone, and You hereby agree to indemnify every Contributor for any
+    liability incurred by such Contributor as a result of warranty, support,
+    indemnity or liability terms You offer. You may include additional
+    disclaimers of warranty and limitations of liability specific to any
+    jurisdiction.
+
+
+    ### 4. Inability to Comply Due to Statute or Regulation
+
+    If it is impossible for You to comply with any of the terms of this
+    License with respect to some or all of the Covered Software due to
+    statute, judicial order, or regulation then You must: **(a)** comply with
+    the terms of this License to the maximum extent possible; and **(b)**
+    describe the limitations and the code they affect. Such description must
+    be placed in a text file included with all distributions of the Covered
+    Software under this License. Except to the extent prohibited by statute
+    or regulation, such description must be sufficiently detailed for a
+    recipient of ordinary skill to be able to understand it.
+
+
+    ### 5. Termination
+
+    **5.1.** The rights granted under this License will terminate automatically
+    if You fail to comply with any of its terms. However, if You become
+    compliant, then the rights granted under this License from a particular
+    Contributor are reinstated **(a)** provisionally, unless and until such
+    Contributor explicitly and finally terminates Your grants, and **(b)** on an
+    ongoing basis, if such Contributor fails to notify You of the
+    non-compliance by some reasonable means prior to 60 days after You have
+    come back into compliance. Moreover, Your grants from a particular
+    Contributor are reinstated on an ongoing basis if such Contributor
+    notifies You of the non-compliance by some reasonable means, this is the
+    first time You have received notice of non-compliance with this License
+    from such Contributor, and You become compliant prior to 30 days after
+    Your receipt of the notice.
+
+    **5.2.** If You initiate litigation against any entity by asserting a patent
+    infringement claim (excluding declaratory judgment actions,
+    counter-claims, and cross-claims) alleging that a Contributor Version
+    directly or indirectly infringes any patent, then the rights granted to
+    You by any and all Contributors for the Covered Software under Section
+    2.1 of this License shall terminate.
+
+    **5.3.** In the event of termination under Sections 5.1 or 5.2 above, all
+    end user license agreements (excluding distributors and resellers) which
+    have been validly granted by You or Your distributors under this License
+    prior to termination shall survive termination.
+
+
+    ### 6. Disclaimer of Warranty
+
+    > Covered Software is provided under this License on an “as is”
+    > basis, without warranty of any kind, either expressed, implied, or
+    > statutory, including, without limitation, warranties that the
+    > Covered Software is free of defects, merchantable, fit for a
+    > particular purpose or non-infringing. The entire risk as to the
+    > quality and performance of the Covered Software is with You.
+    > Should any Covered Software prove defective in any respect, You
+    > (not any Contributor) assume the cost of any necessary servicing,
+    > repair, or correction. This disclaimer of warranty constitutes an
+    > essential part of this License. No use of any Covered Software is
+    > authorized under this License except under this disclaimer.
+
+    ### 7. Limitation of Liability
+
+    > Under no circumstances and under no legal theory, whether tort
+    > (including negligence), contract, or otherwise, shall any
+    > Contributor, or anyone who distributes Covered Software as
+    > permitted above, be liable to You for any direct, indirect,
+    > special, incidental, or consequential damages of any character
+    > including, without limitation, damages for lost profits, loss of
+    > goodwill, work stoppage, computer failure or malfunction, or any
+    > and all other commercial damages or losses, even if such party
+    > shall have been informed of the possibility of such damages. This
+    > limitation of liability shall not apply to liability for death or
+    > personal injury resulting from such party's negligence to the
+    > extent applicable law prohibits such limitation. Some
+    > jurisdictions do not allow the exclusion or limitation of
+    > incidental or consequential damages, so this exclusion and
+    > limitation may not apply to You.
+
+
+    ### 8. Litigation
+
+    Any litigation relating to this License may be brought only in the
+    courts of a jurisdiction where the defendant maintains its principal
+    place of business and such litigation shall be governed by laws of that
+    jurisdiction, without reference to its conflict-of-law provisions.
+    Nothing in this Section shall prevent a party's ability to bring
+    cross-claims or counter-claims.
+
+
+    ### 9. Miscellaneous
+
+    This License represents the complete agreement concerning the subject
+    matter hereof. If any provision of this License is held to be
+    unenforceable, such provision shall be reformed only to the extent
+    necessary to make it enforceable. Any law or regulation which provides
+    that the language of a contract shall be construed against the drafter
+    shall not be used to construe this License against a Contributor.
+
+
+    ### 10. Versions of the License
+
+    #### 10.1. New Versions
+
+    Mozilla Foundation is the license steward. Except as provided in Section
+    10.3, no one other than the license steward has the right to modify or
+    publish new versions of this License. Each version will be given a
+    distinguishing version number.
+
+    #### 10.2. Effect of New Versions
+
+    You may distribute the Covered Software under the terms of the version
+    of the License under which You originally received the Covered Software,
+    or under the terms of any subsequent version published by the license
+    steward.
+
+    #### 10.3. Modified Versions
+
+    If you create software not governed by this License, and you want to
+    create a new license for such software, you may create and use a
+    modified version of this License if you rename the license and remove
+    any references to the name of the license steward (except to note that
+    such modified license differs from this License).
+
+    #### 10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+
+    If You choose to distribute Source Code Form that is Incompatible With
+    Secondary Licenses under the terms of this version of the License, the
+    notice described in Exhibit B of this License must be attached.
+
+    ## Exhibit A - Source Code Form License Notice
+
+        This Source Code Form is subject to the terms of the Mozilla Public
+        License, v. 2.0. If a copy of the MPL was not distributed with this
+        file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular
+    file, then You may include the notice in a location (such as a LICENSE
+    file in a relevant directory) where a recipient would be likely to look
+    for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    ## Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+        This Source Code Form is "Incompatible With Secondary Licenses", as
+        defined by the Mozilla Public License, v. 2.0.
+
+notices: []
+...


### PR DESCRIPTION
## Description

Adds GitHub Linguist support for [Rhai](https://rhai.rs), an embedded scripting language for Rust. This includes `.rhai` metadata, the official TextMate grammar, generated grammar/license/vendor metadata, and three real-world samples from independent projects.

The grammar submodule points at the upstream merge commit from [rhaiscript/vscode-rhai#9](https://github.com/rhaiscript/vscode-rhai/pull/9).

Fixes #6269.

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for `.rhai`: https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.rhai
    - GitHub code search returned 8,832 files on 2026-08-26 (8,576 after excluding the primary Rhai and VS Code grammar repositories).
  - [x] I have included real-world usage samples for the `.rhai` extension:
    - [Calyx `fud2/scripts/calyx.rhai`](https://github.com/calyxir/calyx/blob/d6bcdc8707fe2f024a7b18a86523bda6f770186a/fud2/scripts/calyx.rhai) — MIT
    - [ESP-IDF template `cargo/pre-script.rhai`](https://github.com/esp-rs/esp-idf-template/blob/08115a069d167a5ee37363e84f168a565f17bbca/cargo/pre-script.rhai) — Apache-2.0
    - [Fidget `models/cabin.rhai`](https://github.com/mkeeter/fidget/blob/19a904926a72a4e8509d02060bfef109fe37e488/models/cabin.rhai) — MPL-2.0
  - [x] I have included the official syntax highlighting grammar: https://github.com/rhaiscript/vscode-rhai
  - [x] I have added a color.
    - Hex value: `#FBA63B`
    - Rationale: this is the midpoint of the official Rhai icon's `#FFD776` to `#F67500` gradient: https://github.com/rhaiscript/vscode-rhai/blob/master/assets/icon.svg
  - [x] I have added the language metadata for the unique `.rhai` extension; no disambiguation heuristic is required.

## Validation

- `bundle exec rake`: 2,034 runs, 40,580 assertions, 0 failures, 0 errors
- `bundle exec script/cross-validation --test`: passed at the repository's existing 14-error threshold
- `bundle exec licensed status -c vendor/licenses/config.yml`: 554 dependencies, 0 errors
- Linguist grammar compiler: accepted and generated `source.rhai` after the prerequisite grammar fix
- `bin/github-linguist`: all three samples detected as Rhai when tested outside the uncommitted worktree
- samples compared byte-for-byte with their pinned sources; repository licenses verified through GitHub
- post-merge refresh: the Rhai grammar files at merge commit `b7f91ddd` are byte-identical to the fully tested prerequisite commit
- `git diff --check`
