### PR TITLE
Add 010 Editor Binary Template language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -35,6 +35,16 @@
 #
 # Please keep this list alphabetized. Capitalization comes before lowercase.
 ---
+010 Editor Binary Template:
+  type: programming
+  color: "#ffbe0c"
+  extensions:
+  - ".bt"
+  tm_scope: source.c
+  ace_mode: c_cpp
+  codemirror_mode: clike
+  codemirror_mime_type: text/x-csrc
+  language_id: 981978635
 1C Enterprise:
   type: programming
   color: "#814CCC"

--- a/samples/010 Editor Binary Template/G1M.bt
+++ b/samples/010 Editor Binary Template/G1M.bt
@@ -1,0 +1,113 @@
+//------------------------------------------------
+//--- 010 Editor v9.0.2 Binary Template
+//
+//      File: G1M.bt
+//   Authors: Raytwo, HealingBrew, Joschka
+//   Version: 1.2
+//   Purpose: Parsing G1M models
+//  Category: Game File
+// File Mask: *.g1m
+//  ID Bytes: 5F 4D 31 47
+//   History:
+//   1.2      2020-01-01  Joschka : Updated with NUNO and NUNV parsing
+//   1.1      2019-11-01  HealingBrew: Updated with section parsing
+//   1.0      2019-08-26  Raytwo: Made the original file
+//------------------------------------------------
+
+
+#ifndef G1M
+#define G1M
+
+
+#ifndef G1M_FILELESS
+#define G1M_FILELESS
+#define G1M_FILELESS_MASTER
+LittleEndian();
+#endif // G1M_FILELESS
+
+#include "G1SharedStructures.bt"
+#include "G1M/G1MF.bt"
+#include "G1M/G1MS.bt"
+#include "G1M/G1MM.bt"
+#include "G1M/G1MG/G1MG_Socket.bt"
+#include "G1M/G1MG/G1MG_Material.bt"
+#include "G1M/G1MG/G1MG_ShaderParam.bt"
+#include "G1M/G1MG/G1MG_VertexBuffer.bt"
+#include "G1M/G1MG/G1MG_VertexAttribute.bt"
+#include "G1M/G1MG/G1MG_BoneBind.bt"
+#include "G1M/G1MG/G1MG_IndexBuffer.bt"
+#include "G1M/G1MG/G1MG_SubMesh.bt"
+#include "G1M/G1MG/G1MG_Mesh.bt"
+#include "G1M/G1MG.bt"
+#include "G1M/NUNO.bt"
+#include "G1M/NUNV.bt"
+#include "G1M/NUNS.bt"
+#include "G1M/EXTR.bt"
+#include "G1M/SOFT.bt"
+
+typedef struct G1MSUBSECTION {
+    local int32 pos = FTell();
+    GResourceSectionHeader header<name="Section Header", read=GetSectionName>;
+    switch(header.magic)
+    {
+        case "FM1G":
+            FSeek(pos);
+            G1MFormat data<name="Format">;
+            break;
+        case "SM1G":
+            G1MSkeleton data<name="Skeleton">;
+            break;
+        case "MM1G":
+            G1MMatrixSet data<name="Matrix">;
+            break;
+        case "GM1G":
+            G1MGeometry data<name="Geometry">;
+            break;
+        case "ONUN":
+            G1MNunoSection date<name="Nuno data">;
+            break;
+        case "VNUN":
+            G1MNunvSection date<name="Nunv data">;
+            break;
+        case "SNUN":
+            G1MNunsSection date<name="Nuns data">;
+            break;
+        case "RTXE":
+            G1MExtraSet data<name="Extra">;
+            break;
+        case "TFOS":
+            G1MSoftSection data<name="Soft">;
+            break;
+        default:
+            Printf("*NOTE (%s) Offset 0x%X: Unhandled G1 Resource Section %s\n", GetFileName(), pos, header.magic);
+            byte data[header.size - 0xC]<name="Blob">;
+            break;
+    }
+    FSeek(pos + header.size);
+} G1MSubSection;
+
+string GetSubSectionName(G1MSUBSECTION &section) {
+    return GetSectionName(section.header);
+}
+
+typedef struct G1MSTRUCTURE {
+    GResourceSectionHeader header<name="Header", read=GetSectionName>;
+
+    int32 data_start<name="Start Offset", format=hex>;
+    int32 reserved1<name="Unknown1", hidden=true>;
+    int32 section_count<name="Section Count">;
+} G1MStructure;
+
+#ifdef G1M_FILELESS_MASTER
+
+struct FILE {
+    G1MStructure header<name="Header">;
+
+    FSeek(header.data_start);
+
+    G1MSubSection sections[header.section_count]<name="Section", read=GetSubSectionName, optimize=false>;
+}File<name="G1M", open=true>;
+
+#endif // G1M_FILELESS_MASTER
+
+#endif //G1M

--- a/samples/010 Editor Binary Template/KSLT.bt
+++ b/samples/010 Editor Binary Template/KSLT.bt
@@ -1,0 +1,107 @@
+//------------------------------------------------
+//--- 010 Editor v9.1.0 Binary Template
+//
+//      File: KSLT.bt
+//   Authors: HealingBrew
+//   Version: 1.0
+//   Purpose: Parsing KSLT Screen Layout Texture Packs
+//  Category: Archives
+// File Mask: *.kslt
+//  ID Bytes: 54 4C 53 4B
+//   History:
+//   1.0    2020-01-05 - Initial file
+//------------------------------------------------
+
+LittleEndian();
+
+#include "../Model related formats/G1SharedStructures.bt"
+
+typedef struct KSLTHEADER {
+    char magic[4]<name="Magic", comment="reversed">;
+    char version[4]<name="Version", comment="reversed">;
+    int file_count<name="File Count">;
+    int file_size<name="File Size">;
+    int pointer_table_pointer<name="Pointer Table Pointer">;
+    int name_table_size<name="File Table Size">;
+    int name_count<name="Name Count", comment="If this doesn't match File Count-- panic.">;
+    int unknown7<name="Unknown 7">;
+    int unknown8<name="Unknown 8">;
+    int unknown9<name="Unknown 9">;
+    int unknown10<name="Unknown 10">;
+    int unknown11<name="Unknown 11">;
+    int unknown12<name="Unknown 12">;
+    int unknown13<name="Unknown 13">;
+    int unknown14<name="Unknown 14">;
+    int unknown15<name="Unknown 15">;
+} KTGLScreenLayoutTextureHeader;
+
+typedef struct KTSLTEXTUREPOINTER {
+    int pointer<name="Pointer">;
+    int unknown1<name="Unknown 1">;
+    int unknown2<name="Unknown 2">;
+    int unknown3<name="Unknown 3">;
+    int unknown4<name="Unknown 4">;
+} KTGLScreenLayoutTexturePointer;
+
+typedef struct KSLTMATRIX {
+    int unknown1<name="Unknown 1">;
+    int unknown2<name="Unknown 2">;
+    Matrix34 matrix<name="Matrix">;
+} KTGLScreenLayoutTextureMatrix;
+
+
+typedef struct KSLTNAME {
+    string name<name="Name">;
+} KTGLScreenLayoutTextureName;
+
+string GetKTSLName(KSLTNAME &name) {
+    return name.name;
+}
+
+enum KTSLImageType {
+    BC3 = 3
+};
+
+typedef struct KSLTIMAGEHEADER {
+    KTSLImageType type<name="Type">;
+    short width<name="Width">;
+    short height<name="Height">;
+    int unknown2<name="Unknown 2">;
+    int unknown3<name="Unknown 3">;
+    int unknown4<name="Unknown 4">;
+    int unknown5<name="Unknown 5">;
+    int unknown6<name="Unknown 6">;
+    int size<name="Size">;
+    int unknown7<name="Unknown 7">;
+    int unknown8<name="Unknown 8">;
+    int unknown9<name="Unknown 9">;
+    int unknown10<name="Unknown 10">;
+    int unknown11<name="Unknown 11">;
+    int unknown12<name="Unknown 12">;
+    int unknown13<name="Unknown 13">;
+    int unknown14<name="Unknown 14">;
+    int unknown15<name="Unknown 15">;
+    int unknown16<name="Unknown 16">;
+} KTGLScreenLayoutTextureImageHeader;
+
+typedef struct KTSLIMAGE {
+    KTGLScreenLayoutTextureImageHeader header<name="Header">;
+    byte blob[header.size]<name="Blob">;
+    local string name = names[i].name;
+} KTGLScreenLayoutTextureImage;
+
+typedef struct KSLT {
+    KTGLScreenLayoutTextureHeader header<name="Header">;
+    local int refptr = FTell();
+    KTGLScreenLayoutTextureMatrix matrix[header.file_count]<name="Matrix">;
+    FSeek(refptr + header.pointer_table_pointer);
+    KTGLScreenLayoutTexturePointer pointers[header.file_count]<name="Pointers">;
+    KTGLScreenLayoutTextureName names[header.name_count]<name="Names", read=GetKTSLName, optimize=false>;
+    local int i = 0;
+    for(i = 0; i < header.file_count; ++i) {
+        FSeek(pointers[i].pointer);
+        KTGLScreenLayoutTextureImage image<name="Image">;
+    }
+} KTGLScreenLayoutTexturePack;
+
+KTGLScreenLayoutTexturePack File<name="KSLT", open=true>;

--- a/samples/010 Editor Binary Template/msgdata.bt
+++ b/samples/010 Editor Binary Template/msgdata.bt
@@ -1,0 +1,97 @@
+//------------------------------------------------
+//--- 010 Editor v14.0 Binary Template
+//
+//      File: msgdata.bt
+//   Authors: Moonling, Sloth, bqio
+//   Version: 1.2
+//   Purpose: Parsing msgdata type files
+//  Category: Text
+// File Mask: 0.bin, 1.bin, 2.bin, 3.bin, 4.bin
+//  ID Bytes: 0C 00 00 00
+//   History: 
+//------------------------------------------------
+
+local uint i;
+
+ubyte text_flags_count(ubyte flags[], uint flag_size)
+{
+    local ubyte count;
+    for (i = 0; i < flag_size; i++) {
+        if (flags[i] == 0) {
+            count++;    
+        }
+    }
+    return count;
+}
+
+void FAlign(uint alignment)
+{
+    FSeek((FTell() + (alignment - 1)) & ~(alignment - 1));
+}
+
+LittleEndian();
+
+typedef struct POINTERTABLE {
+    uint offset<name="Offset">;
+    uint size<name="Size">;
+} PointerTable;
+
+typedef struct TABLEPOINTER {
+    uint pointer[flag_size]<name="Pointer">;
+} TablePointer;
+
+typedef struct TABLEHEADER {
+    uint magic<name="Magic">;
+    ushort table_size<name="Table size">;
+    ushort flag_size<name="Flag size">;
+    ushort number_of_entries<name="Number of entries">;
+    ushort pointer_size<name="Pointer size">;
+    uint header_size<name="Header size">;
+    ubyte flags[flag_size]<name="Flags">;
+    FAlign(4);
+    TablePointer pointers[number_of_entries]<optimize=false, name="Pointers", fgcolor=cYellow>;
+} TableHeader;
+
+typedef struct LINE {
+    char value[ReadStringLength(FTell())]<name="Value">;
+} Line;
+
+typedef struct ENTRY {
+    Line lines[flag_count]<optimize=false, name="Line", read=to_value>;
+} Entry;
+
+typedef struct TABLE {
+    TableHeader header<name="Header", fgcolor=cGreen>;
+    local ubyte flag_count;
+    flag_count = text_flags_count(header.flags, header.flag_size);
+    if (flag_count) {
+        Entry entries[header.number_of_entries]<optimize=false, fgcolor=cRed, name="Entries">;
+    }
+    FAlign(4);
+} Table;
+
+typedef struct LANGUAGEEADER {
+    uint number_of_tables<name="Number of tables", fgcolor=cRed>;
+    PointerTable pointers[number_of_tables]<name="Pointers", fgcolor=cYellow>;
+} LanguageHeader;
+
+typedef struct LANGUAGE {
+    LanguageHeader header<name="Header">;
+    Table tables[header.number_of_tables]<name="Tables", optimize=false>;
+} Language;
+
+typedef struct FILEHEADER {
+    uint number_of_languages<name="Number of languages", fgcolor=cRed>;
+    PointerTable pointers[number_of_languages]<name="Pointers", fgcolor=cYellow>;
+} FileHeader;
+
+struct FILE {
+    FileHeader header<name="Header">;
+    Language languages[header.number_of_languages]<name="Language", optimize=false>;
+} File;
+
+
+string to_value(LINE &l)
+{
+    return WStringToString(l.value, CHARSET_UTF8);
+}


### PR DESCRIPTION
Adds support for [010 Editor](https://www.sweetscape.com/010editor/) Binary Templates (`*.bt`).

## Description

010 Editor Binary Templates describe the layout of a binary file format using a C-like syntax: `struct` / `typedef struct`, `enum`, functions, the usual control flow and preprocessor directives, plus template-specific types (`ubyte`, `uint32`, `int64`, `wstring`, …), variable attributes (`<name=…, format=hex, read=…, optimize=false>`) and built-ins (`FSeek`, `FTell`, `LittleEndian`, `Printf`). 010 Editor executes a template against a file in order to parse and annotate it, so it is classified as `programming` rather than `data`.

`.bt` is not currently claimed by any other entry in `languages.yml`, so no heuristic is required.

**On the grammar:** I was unable to find a TextMate, Sublime or VS Code grammar for this language anywhere — the `source.bt` grammars that exist on GitHub are for unrelated languages (the `bt-lang` project and various behaviour-tree DSLs). `tm_scope` is therefore set to `source.c`, following the existing precedent of `B`, `DTrace`, `OpenCL`, `Pro*C`, `RPC`, `Unified Parallel C`, `X BitMap`, `X PixMap` and `XS`. Because the template syntax is largely a superset of C this highlights well in practice. Happy to change it to `tm_scope: none` if you would prefer.

**On `.1sc`:** 010 Editor scripts (`*.1sc`) use the same language, but I have deliberately left that extension out as it does not meet the usage requirements (~400 files indexed).

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.bt+%22010+Editor%22
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.bt+FSeek
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.bt+LittleEndian
    - Measured via the code search API (`extension:bt "010 Editor"`): **6,784** files, spread across **128 unique repositories** in the first 500 results, with the largest single owner accounting for ~7% of them. `FSeek` returns 4,056 and `LittleEndian` 3,512. Note that a bare `extension:bt` search (23,488) is not a good measure, as `.bt` is also used in the wild by unrelated behaviour-tree and `bt-lang` projects — hence the keyword-qualified queries above.
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/three-houses-research-team/010-binary-templates/blob/master/Model%20related%20formats/G1M.bt
      - https://github.com/three-houses-research-team/010-binary-templates/blob/master/Archive%20formats/KSLT.bt
      - https://github.com/jandk/valen/blob/main/templates/common/streamdb.bt
    - Sample license(s): MIT — Copyright (c) 2019 Three Houses Research Group ([LICENSE](https://github.com/three-houses-research-team/010-binary-templates/blob/master/LICENSE))
  - [x] I have added a color
    - Hex value: `#ffbe0c`
    - Rationale: chosen to reflect the yellow/amber of the 010 Editor application icon, which is predominantly yellow on a dark background. SweetScape does not publish official branding guidelines, so this is an approximation of the product's colour rather than an official brand value.
