### PR TITLE
Add Fun language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1662,3 +1662,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/fun"]
+	path = vendor/grammars/fun
+	url = https://github.com/Funlang/funide.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -431,6 +431,8 @@ vendor/grammars/fortran.tmbundle:
 - source.fortran.modern
 vendor/grammars/fpp-tools:
 - source.fpp
+vendor/grammars/fun:
+- source.fun
 vendor/grammars/gap-tmbundle:
 - source.gap
 vendor/grammars/gemfile-lock-tmlanguage:

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -367,6 +367,15 @@ disambiguations:
     pattern: '^\s*(#version|precision|uniform|varying|vec[234])'
   - language: Filterscript
     pattern: '#include|#pragma\s+(rs|version)|__attribute__'
+- extensions: ['.fun']
+  rules:
+  - language: Fun
+    pattern:
+    - '(?m)^[ \t]*#'
+    - '(?i)\bend[ \t]+(?:if|fun|class|loop|case|try|do)\b'
+    - '(?i)\bvar[ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t]*[=(]'
+    - '\?\.'
+  - language: Standard ML
 - extensions: ['.ftl']
   rules:
   - language: FreeMarker

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2398,6 +2398,14 @@ Frege:
   tm_scope: source.haskell
   ace_mode: haskell
   language_id: 116
+Fun:
+  type: programming
+  color: "#f3d325"
+  extensions:
+  - ".fun"
+  tm_scope: none
+  ace_mode: text
+  language_id: 388617194
 Futhark:
   type: programming
   color: "#5f021f"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2403,7 +2403,7 @@ Fun:
   color: "#f3d325"
   extensions:
   - ".fun"
-  tm_scope: none
+  tm_scope: source.fun
   ace_mode: text
   language_id: 388617194
 Futhark:

--- a/samples/Fun/all.fun
+++ b/samples/Fun/all.fun
@@ -1,0 +1,96 @@
+#*======================================
+    FFFFFFFF   UU    UU   NN    NN
+    FF         UU    UU   NNN   NN
+    FFFFFFF    UU    UU   NN N  NN
+    FF         UU    UU   NN  N NN
+    FF         UU    UU   NN   NNN
+    FF          UUUUUU    NN    NN
+##======================================
+
+var out = output();
+class output()
+  var head = (s){?. s & '.'.x(20-s.length())};
+  var body = (s){?, ' '; ?. s};
+  fun close()
+    head('end');
+    ? '\r\n'.escape();
+  end fun;
+end class;
+
+var idx;
+fun closure(o)
+  var i = 0;
+  return {
+    o.body('index $i'.eval());
+    result = i;
+    i += 1;
+  };
+end fun;
+
+fun test(n, f)
+  out.head(n);
+  idx = closure(out);
+  f();
+  out.close();
+end fun;
+
+test('if', {
+  if    idx() > idx() and idx() <= idx() then # short-circuit
+    out.body('wrong');
+  elsif idx() < idx()  or idx() >= idx() then # short-circuit
+    out.body('right');
+  elsif idx() = idx() xor idx() <> idx() then
+    out.body('error');
+  else
+    out.body('error');
+  end if;
+});
+
+test('case', {
+  case idx() is # @ <- idx()
+    when idx() do
+      out.body('wrong x()');
+    when [idx(), idx()] do // or when new ...
+      out.body('wrong [x]');
+    when '^(%s)$'.format(idx()).toRegex() do
+      out.body('wrong /x/');
+    when '^($@)$'.eval().toRegex() do
+      out.body('right /x/');
+    when idx() do
+      out.body('error');
+    else
+      out.body('error');
+  end case;
+});
+
+test('loop', {
+  loop
+    exit when idx() < idx();
+  end loop;
+
+  for i = idx() to idx() step idx() loop
+    out.body((i = 2) & ' - ' & i);
+  end loop;
+
+  for k: i in [a: idx(), b: idx(), c: idx()] do // or in new ...
+    out.body('$k: $i'.eval());
+  end do;
+
+  while idx() < idx() do
+    next when idx() mod 2 = 0;
+    exit when idx() < idx();
+  end do;
+
+  out.body(idx() = 16);
+});
+
+test('try', {
+  try
+    var error() = 1 / 0;
+    idx(); error(); idx();
+  except # @ <- exception
+    out.body('$@ at $@@()'.eval()); # eval $@@ as the last error
+  finally
+    out.body('final'.x(-1)); # reverse: a.x(-1)
+  end try;
+});

--- a/samples/Fun/calc.fun
+++ b/samples/Fun/calc.fun
@@ -1,0 +1,98 @@
+
+########################################
+# calc
+########################################
+#   Number: + - * / div mod ^
+#   Bits:   << >> (bit not/and/or/xor)
+#   String: &
+#   Time:   + -
+#   Bool:   not and or xor
+#   Regex:  =~ !~
+#   Set:    in
+#   Others: = !=(<>) < <= > >=
+#     Set/Others for any types
+########################################
+# precedence (default left association)
+########################################
+#   () [] .
+#   ^
+#   * / div mod
+#   (bit not)                   -> right
+#   (bit and/or/xor) << >>
+#   + -
+#   &
+#   = != <> < <= > >= in =~ !~  -> none
+#   not                         -> right
+#   and
+#   or xor
+########################################
+# short-circuit calculation
+########################################
+#   and
+#   or
+########################################
+
+# Number
+var n1 = 9;
+var n2 = 3.3;
+?. n1 + n2;
+?. n1 - n2;
+?. n1 * n2;
+?. n1 / n2;
+?. n1 div "4"; # Type conversions automatically
+?. n1 mod '4'; # Type conversions automatically
+?. n1 ^ 3;     # power
+
+# Bits
+n1 = 0x0f;
+n2 = 0xf0;
+?. n1 << 4;    # shift left
+?. n2 >> 4;    # shift right
+?. bit not n1;
+?. n1 bit and n2;
+?. n1 bit or  n2;
+?. n1 bit xor n2;
+
+# String
+var s1 = 'Hello';
+var s2 = ", world!";
+?. s1 & s2 & ' - ' & 10000; # Type conversions automatically
+
+# Time
+var t1 = @"2010-04-09 15:35:15";
+var t2 = @'2010-03-09 15:35:15';
+?. t1 + 100;
+?. t1 - t2;
+
+# Bool
+var b1 = true;
+var b2 = false;
+?. not not b1;
+?. not (b1 and b2);
+?. b1 or  b2;
+?. b1 xor b2;
+
+# Set
+?. "Hello" in ["Hello", "World"];
+
+# Others - Compare
+?. not 1 = 2;
+?. 1 != 2;
+?. 1 <> 2;
+?. 1 < 2;
+?. 1 <= 2;
+?. not 1 > 2;
+?. not 1 >= 2;
+
+# Null - All null values equal null (number, string, bool, etc.)
+?. null = 0;
+?. null = false;
+?. null = '';
+
+# Short-circuit calculation
+?. true  or  1 = 0; # "1 = 0" doesn't need calc
+?. false and 1 = 1; # "1 = 1" doesn't need calc
+
+# Optional
+?. Undefined?;
+?. Undefined?.Undefined?;

--- a/samples/Fun/class.fun
+++ b/samples/Fun/class.fun
@@ -1,0 +1,38 @@
+
+########################################
+# class
+########################################
+#   class name ( parameters )
+#     cmds
+#   end class;
+########################################
+
+# define a class
+class CA()
+  # test for class constructor
+  ? 'CA-constructor-starting..';
+
+  # member variable
+  var name = 'CA';
+
+  # member function
+  fun showName()
+    ?. name;
+  end fun;
+
+  fun getName()
+    return name;
+  end fun;
+
+  ?. 'DONE';
+end class;
+
+# create a class instance (object)
+var a = CA();
+
+# use the member variable of object
+?. a.name;
+
+# use the member function of object
+a.showName();
+?. a.getName();

--- a/samples/Fun/cmd-monitor.fun
+++ b/samples/Fun/cmd-monitor.fun
@@ -1,0 +1,52 @@
+// Copyright (c) 2010-2026 Zhang Weidong <zwd@funlang.org>
+// SPDX-License-Identifier: MIT
+
+use "lib-cwinapi.fun";
+use "lib-cstruct.fun";
+use 'lib-time.fun';
+use 'lib-os.fun';
+var tk = tick();
+
+var getLen  = CWin32API('user32.dll', 'int GetWindowTextLength(HWND hWnd);');
+var getText = CWin32API('user32.dll', 'int GetWindowText(HWND hWnd, LPTSTR lpString, int nMaxCount);');
+var enumWin = CWin32API('user32.dll', 'BOOL EnumWindows(BOOL CALLBACK (HWND, LPARAM) lpEnumFunc, LPARAM lParam);');
+var showWin = 'user32'.getapi('ShowWindow', 'ii:i');
+
+var cmds;
+enumWin.args.lpEnumFunc = enumProc;
+enumWin.args.lParam = 0;
+loop
+  cmds = new [];
+  enumWin.call();
+  var ii = 0;
+  for i = 0 to 9 loop
+    tk.get();
+    sleep(100); //超时未醒, 系统慢
+    if tk.get() > 150 and cmds.@count() > 0 then
+      ii += 1;
+      if ii > 5 then //放过黑窗切换
+        for k: v in cmds do
+          showWin(k * 1, 2); //最小化之
+        end do;
+        exit;
+      end if;
+    end if;
+  end loop;
+end loop;
+
+fun enumProc(hWnd, lParam)
+  getLen.args.hWnd = hWnd;
+  var len = getLen.call();
+  if len <= 0 then return 1; end if;
+
+  var buf = 0.toChar().x(len + 1);
+  getText.args.hWnd = hWnd;
+  getText.args.lpString = buf;
+  getText.args.nMaxCount = len + 1;
+  var l = getText.call();
+  var title = getText.args.lpString.substr(len: l); //?. title;
+  if title =~ /\bcmd\.exe\b/i then
+    cmds.[hWnd] = title;
+  end if;
+  return 1;
+end fun;

--- a/samples/Fun/fractal-benchmark.fun
+++ b/samples/Fun/fractal-benchmark.fun
@@ -1,0 +1,38 @@
+fun mandelbrot(ci, y)
+  var cr = y - 0.5;
+  var zi = 0;
+  var zr = 0;
+
+  for i = 1 to 1000 loop
+    var zr2  = zr * zr;
+    var zi2  = zi * zi;
+    if zi2 + zr2 > 16 then
+      return i;
+    end if;
+    var temp = zr * zi;
+    zr = zr2 - zi2 + cr;
+    zi = temp + temp + ci;
+  end loop;
+  return 0;
+end fun;
+
+fun main()
+  for y = -39 to 38 loop
+    var s = ''; //?. '';
+    for x = -39 to 38 do
+      if mandelbrot(x/40, y/40) = 0 then
+        s &= '*'; //? '*';
+      else
+        s &= ' '; //? ' ';
+      end if;
+    end do;
+    ?. s; //
+  end loop;
+  //?. '';
+end fun;
+
+use 'lib-time.fun';
+var t = tick();
+?. t.show();
+main();
+?. t.show();

--- a/samples/Fun/lib-base.fun
+++ b/samples/Fun/lib-base.fun
@@ -1,0 +1,53 @@
+// Copyright (c) 2010-2026 Zhang Weidong <zwd@funlang.org>
+// SPDX-License-Identifier: MIT
+
+########################################
+# lib-base
+########################################
+
+fun ifval (condition, vtrue, vfalse)
+  if condition then
+    return vtrue;
+  else
+    return vfalse;
+  end if;
+end fun;
+var ifv    = ifval;
+var ifb(c) = ifv(c, true, false);
+var iff(c, t, f) = ifv(c(), t, f);
+var iffa(c, t, f) = ifa(c(), t, f);
+
+fun ifa (condition, atrue, afalse)
+  if condition then
+    return atrue ();
+  else
+    return afalse();
+  end if;
+end fun;
+
+fun forloop (start, end1, step1, action, set)
+  result = set;
+  for i = start to end1 step step1 do
+    result = action(i, result) or result;
+  end do;
+end fun;
+var forto  = forloop;
+var forE(num, action, set) = forto(1, num, 1, action, set);
+
+var filter = (start, end1, step1, cond, action){
+  result = [];
+  forto(start, end1, step1, (i, ret){
+    if cond(i, ret) then
+      action(i, ret);
+    end if;
+    result = ret;
+  }, result);
+};
+var filter1(s, e, c, a) = filter(s, e, 1, c, a);
+
+fun foreach (set1, action)
+  for k: v in set1 do
+    action(v, k);
+  end do;
+end fun;
+var forin  = foreach;

--- a/samples/Fun/lib-json.fun
+++ b/samples/Fun/lib-json.fun
@@ -1,0 +1,44 @@
+// Copyright (c) 2010-2026 Zhang Weidong <zwd@funlang.org>
+// SPDX-License-Identifier: MIT
+
+########################################
+# lib-json
+########################################
+#   built-in (2)
+########################################
+#     set.@toJson (format, json, isGbk, fd, kvd=32)   # save set as JSON/FD string
+#     str.getJson (json=false, fd=false, sse = false) # load str as JSON/FD set/list/tree
+########################################
+# 1. format param of @toJson()
+#    default 0, format levels
+#    join (concat) if format = -1
+# 2. json param of @toJson()
+#    default false, name quoted as "name"
+# 3. fd param of @toJson()/getJson()
+#    format 0 - indent 2 white-space
+#           1 - >
+#           2 - n>
+#               n from 1 to 2,3... level
+#    kvd   32 - default whitespace
+#    sse false- sse decompress
+########################################
+
+fun JSON()
+  fun Parse(s)
+    result = s.getJson(json: true);
+  end fun;
+
+  fun Stringify(s, level)
+    result = s.@toJson(level, json: true);
+  end fun;
+end fun;
+
+fun FD()
+  fun Parse(s, sse)
+    result = s.getJson(fd: true, sse: sse);
+  end fun;
+
+  fun Stringify(s, level, kvd)
+    result = s.@toJson(level, fd: true, kvd: kvd or 32);
+  end fun;
+end fun;

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -515,6 +515,13 @@ class TestHeuristics < Minitest::Test
     })
   end
 
+  def test_fun_by_heuristics
+    assert_heuristics({
+      "Fun" => all_fixtures("Fun"),
+      "Standard ML" => all_fixtures("Standard ML")
+    }, alt_name="file.fun")
+  end
+
   def test_ftl_by_heuristics
     assert_heuristics({
       "Fluent" => all_fixtures("Fluent", "*.ftl"),

--- a/vendor/licenses/git_submodule/fun.dep.yml
+++ b/vendor/licenses/git_submodule/fun.dep.yml
@@ -1,0 +1,31 @@
+---
+name: fun
+version: 31b8146e0e597802fb32363c81fa1d3715be454f
+type: git_submodule
+homepage: https://github.com/Funlang/funide
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2010-2026 Zhang Weidong <zwd@funlang.org>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
Add the Fun scripting language (https://funlang.org) to Linguist.

The `.fun` extension was previously exclusive to Standard ML, so a heuristic is added to disambiguate Fun from Standard ML based on Fun's distinctive syntax (line comments starting with '#', `end <keyword>` block terminators, `var <name> =` declarations, and the `?.` print operator). Standard ML remains the default for `.fun` files that do not match those markers.

Samples are taken verbatim from the MIT-licensed Funlang/fun repository (copyright Zhang Weidong), including its demo programs and standard library modules.

<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am adding a new extension to a language.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.FOOBAR+KEYWORDS
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.FOOBAR+KEYWORDS
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [https://www.funlang.org/demo/]
    - Sample license(s): MIT
  - [x] I have included a syntax highlighting grammar: [https://github.com/Funlang/funide/blob/main/syntaxes/fun.tmLanguage.yaml]
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#f3d325`
    - Rationale: <!-- Please specify why you chose this color (if it was randomly selected, please say so); it helps arbitrate future requests to change a language's color -->
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  - Old: [URL to grammar repo]
  - New: [URL to grammar repo]

- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

- [ ] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [URL to public discussion]
    - [Optional: URL to official branding guidelines for the language]
