### PR TITLE
Make Smarty heuristic Rust regex compatible

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -997,7 +997,7 @@ disambiguations:
   - language: Go Template
     pattern: '\{\{-?\s*(\`?\"\\?\"?|\/\*\s|\w*)\b'
   - language: Smarty
-    pattern: '(?:^|[^{])\{(\*\s|\$|\/)?\w*\b'
+    pattern: '(\A|[^{])\{(\*\s|\$|\/)?\w*\b'
 - extensions: ['.ts']
   rules:
   - language: XML

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -997,7 +997,7 @@ disambiguations:
   - language: Go Template
     pattern: '\{\{-?\s*(\`?\"\\?\"?|\/\*\s|\w*)\b'
   - language: Smarty
-    pattern: '(?<!\{)\{(\*\s|\$|\/)?\w*\b'
+    pattern: '(?:^|[^{])\{(\*\s|\$|\/)?\w*\b'
 - extensions: ['.ts']
   rules:
   - language: XML


### PR DESCRIPTION
## Description

Replace the Smarty heuristic's unsupported negative lookbehind with an equivalent consuming left-context alternative. This preserves the exclusion of Go Template's `{{...}}` delimiter while allowing Rust's `regex` crate and Go to compile the rule.

Validated with the focused `.tpl` heuristic corpus (8 assertions) and a temporary Rust `regex` harness covering Smarty and Go Template delimiters.

## Checklist:

- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Existing `samples/Smarty/header.tpl` and `samples/Smarty/index.tpl` already reproduce and cover the issue.
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.