### PR TITLE
Add PlainScript language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6032,6 +6032,19 @@ Pkl:
   tm_scope: source.pkl
   ace_mode: text
   language_id: 288822799
+PlainScript:
+  type: programming
+  color: "#2b4d3a"
+  extensions:
+  - ".pln"
+  aliases:
+  - plain
+  - pln
+  group: PlainScript
+  searchable: true
+  tm_scope: none
+  ace_mode: text
+  language_id: 392632896
 PlantUML:
   type: data
   color: "#fbbd16"

--- a/samples/PlainScript/basics.pln
+++ b/samples/PlainScript/basics.pln
@@ -1,0 +1,14 @@
+// PlainScript 1.0.2-latest: variables, values, and output.
+
+remember name as "Ada"
+remember visitCount as 3
+let greeting be `Hello, ${name}!`
+
+show greeting
+show visitCount + 1
+
+if visitCount is at least 3
+    show "Returning visitor"
+otherwise
+    show "First visit"
+done

--- a/samples/PlainScript/bots.pln
+++ b/samples/PlainScript/bots.pln
@@ -1,0 +1,13 @@
+// PlainScript 1.0.2-latest: Telegram bot handlers.
+
+bot env("TELEGRAM_BOT_TOKEN")
+
+when someone sends "/start"
+    reply "Welcome to PlainScript"
+done
+
+when someone sends matching "/echo (.+)"
+    reply "echo"
+done
+
+start telegram bot

--- a/samples/PlainScript/collections.pln
+++ b/samples/PlainScript/collections.pln
@@ -1,0 +1,15 @@
+// PlainScript 1.0.2-latest: lists, objects, and collection helpers.
+
+remember numbers as list with 4, 7, 2, 9
+gather each number in numbers giving number * 2
+filter each number in numbers when number is at least 8
+show numbers
+
+remember values as list with 3, 1, 3, 2
+remember uniqueValues as unique(values)
+remember ordered as sort(values)
+show uniqueValues
+show ordered
+
+remember profile as {name: "Ada", active: true}
+show profile.name

--- a/samples/PlainScript/functions.pln
+++ b/samples/PlainScript/functions.pln
@@ -1,0 +1,17 @@
+// PlainScript 1.0.2-latest: functions, defaults, and returns.
+
+make greet(name)
+    give `Hello, ${name}!`
+done
+
+make add(a, b)
+    give a + b
+done
+
+make label(name as "guest")
+    give `User: ${name}`
+done
+
+show greet("Ada")
+show add(2, 3)
+show label()

--- a/samples/PlainScript/hello.pln
+++ b/samples/PlainScript/hello.pln
@@ -1,0 +1,2 @@
+// PlainScript 1.0.2-latest: hello world.
+show "Hello, PlainScript!"

--- a/samples/PlainScript/mongo.pln
+++ b/samples/PlainScript/mongo.pln
@@ -1,0 +1,33 @@
+// PlainScript 1.0.2-latest: MongoDB.
+//
+// The `mongo` statement binds a connection to a MongoDB instance using the
+// official `mongodb` driver. Give it a connection string and an optional
+// database name:
+//
+//     mongo "<connection-string>" [db "<name>"]
+//
+// After connecting, the `remember ... as query` and `insert`/`update`/`delete`
+// blocks run against the bound database. MongoDB understands a light SQL-like
+// subset here:
+//
+//   - SELECT <fields|*> FROM <collection>            (query)
+//   - INSERT INTO <collection> (a, b) VALUES (?, ?)  (insert)
+//
+// Swap the connection string below for your own server to run this file.
+
+mongo "mongodb://localhost:27017" db "testdb"
+
+// Fetch every user document. The result of the query block is stored in the
+// `users` variable so it can be inspected or returned later.
+remember users as query
+    SELECT * FROM users
+done
+show users
+
+// Insert a new user document from a PlainScript variable. Field names and the
+// order they appear in VALUES must match the column list.
+remember name as "Ada"
+remember email as "ada@example.com"
+insert
+    INSERT INTO users (name, email) VALUES ({name}, {email})
+done

--- a/samples/PlainScript/rest-api.pln
+++ b/samples/PlainScript/rest-api.pln
@@ -1,0 +1,8 @@
+// PlainScript 1.0.2-latest: JSON REST route.
+web app
+route get "/api/status"
+    reply json
+        status is "ok"
+    done
+done
+start 3000

--- a/samples/PlainScript/server.pln
+++ b/samples/PlainScript/server.pln
@@ -1,0 +1,6 @@
+// PlainScript 1.0.2-latest: minimal server.
+web app
+route get "/"
+    reply "Hello from PlainScript"
+done
+start 3000


### PR DESCRIPTION
Adds support for **PlainScript**, an intent-oriented programming language that compiles to Node.js, using the `.pln` extension.

## Description

PlainScript is an intent-oriented programming language that compiles readable, sentence-like `.pln` source into JavaScript. This PR registers PlainScript in Linguist so GitHub can detect and highlight `.pln` files, and adds real-world sample files so the classifier can recognize the language.

Changes:
- Added the `PlainScript` entry to `lib/linguist/languages.yml` (type `programming`, extension `.pln`, aliases `plain`/`pln`, color `#2b4d3a`, `searchable: true`, `tm_scope: none`, `ace_mode: text`).
- Added 8 real-world `.pln` sample files under `samples/PlainScript/`, taken verbatim from the language's official examples directory.

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=extension%3Apln+NOT+is%3Afork
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/ayoistooslick/plainscript/tree/main/examples
    - Sample license(s):
      - MIT License (https://github.com/ayoistooslick/plainscript/blob/main/LICENSE)
  - [ ] I have included a syntax highlighting grammar: PlainScript does not yet have an upstream TextMate grammar, so the language is marked `tm_scope: none` per Linguist convention.
  - [x] I have added a color
    - Hex value: `#2b4d3a`
    - Rationale: A deep green, selected to match the language's natural/plain-language branding.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension. The `.pln` extension is not claimed by any other language in Linguist, so no heuristic is required.
