### PR TITLE
Add MicroC language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -94,6 +94,9 @@
 [submodule "vendor/grammars/MagicPython"]
 	path = vendor/grammars/MagicPython
 	url = https://github.com/MagicStack/MagicPython
+[submodule "vendor/grammars/MicroC-grammar"]
+	path = vendor/grammars/MicroC-grammar
+	url = https://github.com/false-info/MicroC-grammar.git
 [submodule "vendor/grammars/Modelica"]
 	path = vendor/grammars/Modelica
 	url = https://github.com/BorisChumichev/modelicaSublimeTextPackage

--- a/grammars.yml
+++ b/grammars.yml
@@ -76,6 +76,8 @@ vendor/grammars/MagicPython:
 - source.regexp.python
 - text.python.console
 - text.python.traceback
+vendor/grammars/MicroC-grammar:
+- source.microc
 vendor/grammars/Modelica:
 - source.modelica
 vendor/grammars/NSIS:

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -580,6 +580,8 @@ disambiguations:
     pattern: '(?i)^[ \t]*(\/\*\s*)?MessageId=|^\.$'
   - language: M4
     pattern: '^dnl|^divert\((?:-?\d+)?\)|^\w+\(`[^\r\n]*?''[),]'
+  - language: MicroC
+    pattern: '^\s*head\s*\([^)\r\n]*\)\s*\{'
   - language: Monkey C
     pattern: '\b(?:using|module|function|class|var)\s+\w'
 - extensions: ['.md']

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4551,6 +4551,7 @@ Luau:
   interpreters:
   - luau
   language_id: 365050359
+
 M:
   type: programming
   aliases:
@@ -4862,6 +4863,17 @@ Metal:
   codemirror_mode: clike
   codemirror_mime_type: text/x-c++src
   language_id: 230
+MicroC:
+  type: programming
+  color: "#FF0000"
+  aliases:
+  - microc
+  extensions:
+  - ".mc"
+  tm_scope: none
+  ace_mode: c_cpp
+  codemirror_mode: clike
+  codemirror_mime_type: text/x-csrc
 Microsoft Developer Studio Project:
   type: data
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4870,7 +4870,7 @@ MicroC:
   - microc
   extensions:
   - ".mc"
-  tm_scope: none
+  tm_scope: source.microc
   ace_mode: c_cpp
   codemirror_mode: clike
   codemirror_mime_type: text/x-csrc

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4865,8 +4865,6 @@ Metal:
 MicroC:
   type: programming
   color: "#FF0000"
-  aliases:
-  - microc
   extensions:
   - ".mc"
   tm_scope: source.microc

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4551,7 +4551,6 @@ Luau:
   interpreters:
   - luau
   language_id: 365050359
-
 M:
   type: programming
   aliases:
@@ -4874,6 +4873,7 @@ MicroC:
   ace_mode: c_cpp
   codemirror_mode: clike
   codemirror_mime_type: text/x-csrc
+  language_id: 621875351
 Microsoft Developer Studio Project:
   type: data
   extensions:

--- a/samples/MicroC/basics.mc
+++ b/samples/MicroC/basics.mc
@@ -1,0 +1,10 @@
+head(custom) {
+    fn main() {
+        I64 x = 0
+
+        while (x <= 10) {
+            pin("%I64\n", x)
+            x = x + 1
+        }
+    }
+}

--- a/samples/MicroC/minimum-number.mc
+++ b/samples/MicroC/minimum-number.mc
@@ -1,0 +1,12 @@
+head(custom) {
+    fn smallest(I64 a, I64 b) {
+        if (a <= b) {
+            return a
+        }
+        return b
+    }
+    fn main() {
+        I64 result = smallest(9859285082058292, 9492389428498249829)
+        pin("the smallest is:%I64\n", result)
+    }
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -401,6 +401,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Mermaid:** [Alhadis/language-mermaid](https://github.com/Alhadis/language-mermaid)
 - **Meson:** [TingPing/language-meson](https://github.com/TingPing/language-meson)
 - **Metal:** [mikomikotaishi/c.tmbundle](https://github.com/mikomikotaishi/c.tmbundle)
+- **MicroC:** [false-info/MicroC-grammar](https://github.com/false-info/MicroC-grammar)
 - **Microsoft Visual Studio Solution:** [Nixinova/NovaGrammars](https://github.com/Nixinova/NovaGrammars)
 - **MiniScript:** [ayecue/miniscript-textmate-linguist](https://github.com/ayecue/miniscript-textmate-linguist)
 - **MiniYAML:** [OpenRA/atom-miniyaml](https://github.com/OpenRA/atom-miniyaml)

--- a/vendor/licenses/git_submodule/MicroC-grammar.dep.yml
+++ b/vendor/licenses/git_submodule/MicroC-grammar.dep.yml
@@ -1,0 +1,33 @@
+---
+name: MicroC-grammar
+version: 3b8a31ec7cb348ee04c718945cca117f08eb0933
+type: git_submodule
+homepage: https://github.com/false-info/MicroC-grammar.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2026 falseinfo
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+- sources: README.md
+  text: MIT
+notices: []


### PR DESCRIPTION
## Description

Adds support for the MicroC programming language.

This PR adds:

- MicroC to `languages.yml`
- `.mc` support
- `source.microc` TextMate grammar
- heuristics using MicroC's `head(...) {` syntax to distinguish it from Monkey C
- MicroC samples
- generated language ID and grammar/sample metadata

Tests:

`2036 runs, 40615 assertions, 0 failures, 0 errors, 1 skips`

## Checklist:

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A%2A.mc+%22head%28%22
  - [x] I have included usage samples:
    - https://github.com/false-info/MicroC
  - [x] I have included a syntax highlighting grammar:
    - https://github.com/false-info/MicroC-grammar
  - [x] I have added a color
    - Hex value: `#FF0000`
    - Rationale: MicroC project branding.
  - [x] I have updated the heuristics to distinguish MicroC from other languages using `.mc`.

The shared `.mc` extension is distinguished using MicroC's mandatory `head(...) {` construct.
