### PR TITLE
Add support for Nyx programming language (.nyx)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5369,6 +5369,14 @@ Nushell:
   codemirror_mode: shell
   codemirror_mime_type: text/x-sh
   language_id: 446573572
+Nyx:
+  type: programming
+  color: "#7c4dff"
+  extensions:
+  - ".nyx"
+  tm_scope: source.nyx
+  ace_mode: text
+  language_id: 0
 OASv2-json:
   type: data
   color: "#85ea2d"

--- a/samples/Nyx/concurrency.nyx
+++ b/samples/Nyx/concurrency.nyx
@@ -1,0 +1,67 @@
+// std.concurrency — Structured Concurrency, Async Nurseries & Zero-Copy Isolate Region Transfer
+// Architectural Milestone: v0.24 Certified Production Standard
+
+export struct Nursery {
+    id: u64,
+    active_tasks: i32,
+    cancelled: bool,
+}
+
+export struct IsolateRegion {
+    region_id: u64,
+    bytes_allocated: usize,
+    capacity: usize,
+}
+
+export struct IsolateChannel<T> {
+    channel_id: u64,
+    closed: bool,
+}
+
+extern "C" {
+    fn nyx_nursery_open(region_ptr: *void) -> *void;
+    fn nyx_nursery_spawn(nursery: *void, task_fn: *void, arg: *void);
+    fn nyx_nursery_await_all(nursery: *void) -> bool;
+    fn nyx_nursery_cancel(nursery: *void);
+    fn nyx_nursery_close(nursery: *void);
+
+    fn nyx_isolate_region_new(capacity: usize) -> *void;
+    fn nyx_isolate_region_alloc(region: *void, size: usize) -> *void;
+    fn nyx_isolate_channel_new() -> *void;
+    fn nyx_isolate_channel_send(ch: *void, region: *void) -> bool;
+    fn nyx_isolate_channel_recv(ch: *void) -> *void;
+    fn nyx_isolate_region_free(region: *void);
+    fn nyx_isolate_channel_free(ch: *void);
+}
+
+// Opens a structured nursery bound to the caller's lexical region
+export fn open_nursery() -> *void {
+    return nyx_nursery_open(null);
+}
+
+// Spawns an async task bound deterministically to a nursery
+export fn spawn_task(nursery: *void, task_fn: fn(), arg: *void) {
+    nyx_nursery_spawn(nursery, task_fn, arg);
+}
+
+// Awaits all child tasks in the nursery to complete (deterministic lifetime join)
+export fn await_nursery(nursery: *void) -> bool {
+    let result = nyx_nursery_await_all(nursery);
+    nyx_nursery_close(nursery);
+    return result;
+}
+
+// Creates an isolated thread-local region for zero-copy lock-free transfer
+export fn create_isolate(capacity: usize) -> *void {
+    return nyx_isolate_region_new(capacity);
+}
+
+// Sends full single ownership of an entire isolate region to another thread (O(1) pointer swap)
+export fn send_isolate(ch: *void, region: *void) -> bool {
+    return nyx_isolate_channel_send(ch, region);
+}
+
+// Receives full single ownership of an isolate region in the destination thread
+export fn recv_isolate(ch: *void) -> *void {
+    return nyx_isolate_channel_recv(ch);
+}

--- a/samples/Nyx/simple.nyx
+++ b/samples/Nyx/simple.nyx
@@ -1,0 +1,3 @@
+fn main() {
+    println("no imports test")
+}


### PR DESCRIPTION
## Description
This pull request adds support for the **Nyx** programming language (.nyx).

Nyx is a compiled, zero-GC systems programming language developed by 9jaonCloud Engineering. It utilizes compile-time static region inference ((1)$ bump allocation arenas) and zero-cost typing boundaries, eliminating garbage collection pauses for real-time audio DSP, embedded avionics, capability microkernels (NyxOS), and high-throughput cloud infrastructure.

Website: https://nyx.9jaoncloud.com.ng/
Repository: https://github.com/9jaoncloud/nyx

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used on GitHub.com.
    - Search results:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.nyx+fn
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/9jaoncloud/nyx/blob/master/examples/hello.nyx
      - https://github.com/9jaoncloud/nyx/blob/master/std/concurrency.nyx
    - Sample license(s): MIT
  - [x] I have included a syntax highlighting grammar:
    - VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=9jaoncloud.nyx-systems
    - Repository grammar: https://github.com/9jaoncloud/nyx/tree/master/vscode-extension
  - [x] I have added a color
    - Hex value: #7c4dff
    - Rationale: Nyx official primary brand purple used across documentation and tooling.
