### PR TITLE
Add ArkTS language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -293,6 +293,9 @@
 [submodule "vendor/grammars/applescript.tmbundle"]
 	path = vendor/grammars/applescript.tmbundle
 	url = https://github.com/textmate/applescript.tmbundle
+[submodule "vendor/grammars/arkTS"]
+	path = vendor/grammars/arkTS
+	url = https://github.com/ohosvscode/arkTS.git
 [submodule "vendor/grammars/asciidoc.tmbundle"]
 	path = vendor/grammars/asciidoc.tmbundle
 	url = https://github.com/zuckschwerdt/asciidoc.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -236,6 +236,8 @@ vendor/grammars/api-blueprint-sublime-plugin:
 - text.html.markdown.source.gfm.mson
 vendor/grammars/applescript.tmbundle:
 - source.applescript
+vendor/grammars/arkTS:
+- source.ets
 vendor/grammars/asciidoc.tmbundle:
 - text.html.asciidoc
 vendor/grammars/asp-syntax-highlight:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -423,6 +423,16 @@ Arc:
   tm_scope: none
   ace_mode: text
   language_id: 20
+ArkTS:
+  type: programming
+  color: "#0080ff"
+  extensions:
+  - ".ets"
+  tm_scope: source.ets
+  ace_mode: typescript
+  codemirror_mode: javascript
+  codemirror_mime_type: application/typescript
+  language_id: 56341321
 AsciiDoc:
   type: prose
   color: "#73a0c5"

--- a/samples/ArkTS/EntryAbility.ets
+++ b/samples/ArkTS/EntryAbility.ets
@@ -1,0 +1,44 @@
+import { AbilityConstant, ConfigurationConstant, UIAbility, Want } from '@kit.AbilityKit';
+import { hilog } from '@kit.PerformanceAnalysisKit';
+import { window } from '@kit.ArkUI';
+
+const DOMAIN = 0x0000;
+
+export default class EntryAbility extends UIAbility {
+  onCreate(want: Want, launchParam: AbilityConstant.LaunchParam): void {
+    this.context.getApplicationContext().setColorMode(ConfigurationConstant.ColorMode.COLOR_MODE_NOT_SET);
+    hilog.info(DOMAIN, 'testTag', '%{public}s', 'Ability onCreate');
+  }
+
+  onDestroy(): void {
+    hilog.info(DOMAIN, 'testTag', '%{public}s', 'Ability onDestroy');
+  }
+
+  onWindowStageCreate(windowStage: window.WindowStage): void {
+    // Main window is created, set main page for this ability
+    hilog.info(DOMAIN, 'testTag', '%{public}s', 'Ability onWindowStageCreate');
+
+    windowStage.loadContent('pages/Index', (err) => {
+      if (err.code) {
+        hilog.error(DOMAIN, 'testTag', 'Failed to load the content. Cause: %{public}s', JSON.stringify(err));
+        return;
+      }
+      hilog.info(DOMAIN, 'testTag', 'Succeeded in loading the content.');
+    });
+  }
+
+  onWindowStageDestroy(): void {
+    // Main window is destroyed, release UI related resources
+    hilog.info(DOMAIN, 'testTag', '%{public}s', 'Ability onWindowStageDestroy');
+  }
+
+  onForeground(): void {
+    // Ability has brought to foreground
+    hilog.info(DOMAIN, 'testTag', '%{public}s', 'Ability onForeground');
+  }
+
+  onBackground(): void {
+    // Ability has back to background
+    hilog.info(DOMAIN, 'testTag', '%{public}s', 'Ability onBackground');
+  }
+}

--- a/samples/ArkTS/EntryBackupAbility.ets
+++ b/samples/ArkTS/EntryBackupAbility.ets
@@ -1,0 +1,16 @@
+import { hilog } from '@kit.PerformanceAnalysisKit';
+import { BackupExtensionAbility, BundleVersion } from '@kit.CoreFileKit';
+
+const DOMAIN = 0x0000;
+
+export default class EntryBackupAbility extends BackupExtensionAbility {
+  async onBackup() {
+    hilog.info(DOMAIN, 'testTag', 'onBackup ok');
+    await Promise.resolve();
+  }
+
+  async onRestore(bundleVersion: BundleVersion) {
+    hilog.info(DOMAIN, 'testTag', 'onRestore ok %{public}s', JSON.stringify(bundleVersion));
+    await Promise.resolve();
+  }
+}

--- a/samples/ArkTS/Index.ets
+++ b/samples/ArkTS/Index.ets
@@ -1,0 +1,191 @@
+import { hilog } from '@kit.PerformanceAnalysisKit'
+
+@Entry
+@Component
+struct Index {
+  @State currentTime: string = ''
+  @State isConnected: boolean = false
+  @State systemInfo: SystemInfo | null = null
+
+  aboutToAppear() {
+    this.updateTime()
+    this.checkNetworkStatus()
+    this.getSystemInfo()
+
+    setInterval(() => {
+      this.updateTime()
+    }, 1000)
+  }
+
+  build() {
+    Column() {
+      // 顶部状态栏
+      this.buildStatusBar()
+
+      // 主要内容区域
+      this.buildMainContent()
+
+      // 底部操作区域
+      this.buildActionArea()
+    }
+    .width('100%')
+    .height('100%')
+    .backgroundColor('#F5F5F5')
+    .padding(16)
+  }
+
+  @Builder
+  buildStatusBar() {
+    Row() {
+      Text('My App')
+        .fontSize(18)
+        .fontWeight(FontWeight.Bold)
+        .fontColor('#333333')
+
+      Blank()
+
+      Row() {
+        Image("icon.png")
+          .width(16)
+          .height(16)
+          .fillColor(this.isConnected ? '#00C851' : '#FF4444')
+
+        Text(this.isConnected ? 'Connected' : 'Disconnected')
+          .fontSize(12)
+          .fontColor(this.isConnected ? '#00C851' : '#FF4444')
+          .margin({ left: 4 })
+      }
+    }
+    .width('100%')
+    .padding({ bottom: 16 })
+  }
+
+  @Builder
+  buildMainContent() {
+    Column() {
+      // 时间显示
+      Text(this.currentTime)
+        .fontSize(32)
+        .fontWeight(FontWeight.Bold)
+        .fontColor('#007AFF')
+        .margin({ bottom: 24 })
+
+      // 系统信息卡片
+      if (this.systemInfo) {
+        this.buildSystemInfoCard()
+      }
+
+      // 功能按钮区域
+      this.buildFeatureButtons()
+    }
+    .width('100%')
+    .layoutWeight(1)
+    .justifyContent(FlexAlign.Center)
+  }
+
+  @Builder
+  buildSystemInfoCard() {
+    Column() {
+      Text('System information')
+        .fontSize(16)
+        .fontWeight(FontWeight.Medium)
+        .margin({ bottom: 12 })
+
+      Row() {
+        Text('Device model:')
+          .fontSize(14)
+          .fontColor('#666666')
+
+        Text(this.systemInfo?.deviceModel || 'Unknown')
+          .fontSize(14)
+          .fontColor('#333333')
+          .margin({ left: 8 })
+      }
+      .width('100%')
+      .justifyContent(FlexAlign.SpaceBetween)
+      .margin({ bottom: 8 })
+
+      Row() {
+        Text('System version:')
+          .fontSize(14)
+          .fontColor('#666666')
+
+        Text(this.systemInfo?.osVersion || 'Unknown')
+          .fontSize(14)
+          .fontColor('#333333')
+          .margin({ left: 8 })
+      }
+      .width('100%')
+      .justifyContent(FlexAlign.SpaceBetween)
+    }
+    .width('100%')
+    .backgroundColor(Color.White)
+    .borderRadius(12)
+    .padding(16)
+    .margin({ bottom: 24 })
+  }
+
+  @Builder
+  buildFeatureButtons() {
+    Row() {
+      Button('Refresh status')
+        .onClick(() => {
+          this.checkNetworkStatus()
+          this.getSystemInfo()
+        })
+        .backgroundColor('#007AFF')
+        .borderRadius(8)
+        .layoutWeight(1)
+        .margin({ right: 8 })
+
+      Button('Settings')
+        .onClick(() => {
+          hilog.info(0x0000, 'testTag', 'Navigate to settings...')
+        })
+        .backgroundColor(Color.Transparent)
+        .border({ width: 1, color: '#007AFF' })
+        .borderRadius(8)
+        .layoutWeight(1)
+    }
+    .width('100%')
+  }
+
+  @Builder
+  buildActionArea() {
+    Row() {
+      Text('My footer')
+        .fontSize(12)
+        .fontColor('#999999')
+    }
+    .width('100%')
+    .justifyContent(FlexAlign.Center)
+  }
+
+  private updateTime() {
+    const now = new Date()
+    this.currentTime = now.toLocaleTimeString('zh-CN', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit'
+    })
+  }
+
+  private checkNetworkStatus() {
+    this.isConnected = Math.random() > 0.3
+  }
+
+  private getSystemInfo() {
+    this.systemInfo = {
+      deviceModel: 'HarmonyOS Device',
+      osVersion: 'HarmonyOS 6.0.0',
+      apiLevel: 20
+    }
+  }
+}
+
+interface SystemInfo {
+  deviceModel: string
+  osVersion: string
+  apiLevel: number
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -42,6 +42,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Apex:** [forcedotcom/apex-tmLanguage](https://github.com/forcedotcom/apex-tmLanguage)
 - **Apollo Guidance Computer:** [Alhadis/language-agc](https://github.com/Alhadis/language-agc)
 - **AppleScript:** [textmate/applescript.tmbundle](https://github.com/textmate/applescript.tmbundle)
+- **ArkTS:** [ohosvscode/arkTS](https://github.com/ohosvscode/arkTS)
 - **AsciiDoc:** [zuckschwerdt/asciidoc.tmbundle](https://github.com/zuckschwerdt/asciidoc.tmbundle)
 - **AspectJ:** [pchaigno/sublime-aspectj](https://github.com/pchaigno/sublime-aspectj)
 - **Assembly:** [Nessphoro/sublimeassembly](https://github.com/Nessphoro/sublimeassembly)

--- a/vendor/licenses/git_submodule/arkTS.dep.yml
+++ b/vendor/licenses/git_submodule/arkTS.dep.yml
@@ -1,0 +1,31 @@
+---
+name: arkTS
+version: 25fda87a6677c3e92f3b7ed41adbab82c3847929
+type: git_submodule
+homepage: https://github.com/ohosvscode/arkTS.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2025 Naily Zero
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
<!--- ArkTS language support, superseding #7742. -->

## Description
This PR supersedes #7742, whose contributor branch is not writable from this account. It adds ArkTS support using the current official `ohosvscode/arkTS` grammar. The grammar was imported on an Ubuntu GitHub Actions runner with Linguist's required `script/add-grammar` flow; the successful run is https://github.com/mouse233/linguist/actions/runs/33896929190.

The grammar source is pinned at `25fda87a6677c3e92f3b7ed41adbab82c3847929`; its TextMate grammar is `packages/vscode/syntaxes/ets.tmLanguage.json` with scope `source.ets`. The final branch is a single commit whose tree exactly matches the successful CI-generated tree.

## Checklist:
- [ ] **I am adding a new extension to a language.**

- [x] **I am adding a new language.**
  - [x] The `.ets` extension has sufficient indexed usage on GitHub, excluding forks. Current GitHub Code Search counts are 6,176 files for `NOT is:fork extension:ets HarmonyOS` and 19,040 for `NOT is:fork extension:ets ArkTS` (both above Linguist's 2,000-file threshold):
    - https://github.com/search?type=code&q=NOT+is%3Afork+extension%3Aets+HarmonyOS
    - https://github.com/search?type=code&q=NOT+is%3Afork+extension%3Aets+ArkTS
  - [x] I have included representative real-world ArkTS samples for the extension:
    - Sample source(s):
      - Termony: https://github.com/TermonyHQ/Termony
      - ClashBox: https://github.com/xiaobaigroup/ClashBox/tree/master
      - HarmonyOS-Haps: https://github.com/Zitann/HarmonyOS-Haps
    - Sample license(s): MIT; the samples were created specifically for #7742 under the MIT license, as stated in that PR.
  - [x] I have included a syntax highlighting grammar: https://github.com/ohosvscode/arkTS
    - Grammar file: `packages/vscode/syntaxes/ets.tmLanguage.json`
    - TextMate scope: `source.ets`
  - [x] I have added a color
    - Hex value: `#0080ff`
    - Rationale: This is the ArkTS color used in the original proposal and keeps ArkTS visually aligned with its TypeScript relationship.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension. `.ets` is a new, unique extension in Linguist, so no heuristic is required.

The generated language ID (`56341321`), grammar registry, sorted submodule entry, vendor documentation, and license cache were produced by the successful CI import run.