### PR TITLE
Add LLVM TableGen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -953,6 +953,9 @@
 [submodule "vendor/grammars/livescript-vscode"]
 	path = vendor/grammars/livescript-vscode
 	url = https://github.com/sharktide/livescript-vscode.git
+[submodule "vendor/grammars/llvm-tablegen-grammar"]
+	path = vendor/grammars/llvm-tablegen-grammar
+	url = https://github.com/nos1dot618/llvm-tablegen-grammar.git
 [submodule "vendor/grammars/llvm.tmbundle"]
 	path = vendor/grammars/llvm.tmbundle
 	url = https://github.com/whitequark/llvm.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -912,6 +912,8 @@ vendor/grammars/lisp.tmbundle:
 - source.lisp
 vendor/grammars/livescript-vscode:
 - source.livescript
+vendor/grammars/llvm-tablegen-grammar:
+- source.tablegen
 vendor/grammars/llvm.tmbundle:
 - source.llvm
 vendor/grammars/lobster_ling:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4209,7 +4209,8 @@ LLVM TableGen:
   tm_scope: source.tablegen
   ace_mode: text
   color: "#6E8B3D"
-  aliases: tablegen
+  aliases: 
+  - tablegen
   language_id: 184265095
 LOLCODE:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4202,6 +4202,15 @@ LLVM:
   ace_mode: text
   color: "#185619"
   language_id: 191
+LLVM TableGen:
+  type: programming
+  extensions:
+  - ".td"
+  tm_scope: source.tablegen
+  ace_mode: text
+  color: "#6E8B3D"
+  aliases: tablegen
+  language_id: 184265095
 LOLCODE:
   type: programming
   extensions:

--- a/samples/LLVM TableGen/AMDGPU.td
+++ b/samples/LLVM TableGen/AMDGPU.td
@@ -1,0 +1,14 @@
+//===-- AMDGPU.td - AMDGPU dialect *- tablegen -*--------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_AMDGPU_IR_AMDGPU_TD
+#define MLIR_DIALECT_AMDGPU_IR_AMDGPU_TD
+
+include "mlir/Dialect/AMDGPU/IR/AMDGPUOps.td"
+
+#endif // MLIR_DIALECT_AMDGPU_IR_AMDGPU_TD

--- a/samples/LLVM TableGen/AMDGPUAttrs.td
+++ b/samples/LLVM TableGen/AMDGPUAttrs.td
@@ -1,0 +1,48 @@
+//===-- AMDGPUAttrs.td - AMDGPU dialect attributes *- tablegen -*----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_AMDGPU_IR_AMDGPUATTRS_TD
+#define MLIR_DIALECT_AMDGPU_IR_AMDGPUATTRS_TD
+
+include "mlir/Dialect/AMDGPU/IR/AMDGPUBase.td"
+include "mlir/Dialect/AMDGPU/IR/AMDGPUEnums.td"
+include "mlir/Dialect/LLVMIR/ROCDLAttrs.td"
+
+def AMDGPU_AddressSpaceAttr : EnumAttr<AMDGPU_Dialect, AMDGPU_AddressSpace,
+    "address_space"> {
+  let description = [{
+    AMDGPU-specific memory spaces that may not have exact analogues on other
+    GPU targets or backends.
+
+    - `fat_raw_buffer` is the memory space used when a memref is stored as
+    as a "buffer fat pointer" - that is, a buffer resource (that is set up to
+    use raw byte-level indexing) along with its offset. The AMDGPU backend
+    implements `ptr addrspace(7)` to represent these fat pointers so that
+    buffer resources (which allow advanced features like bounds checking or
+    cache swizzling) can be used like ordinary LLVM pointers or memrefs.
+    See also the `fat_raw_buffer_cast` operation
+    - `buffer_rsrc` is the memory space for `ptr addrspace(8)`, representing a
+    buffer resource. It should not be used for memrefs, since it does not support
+    indexing
+    - `fat_structured_buffer` represents `ptr addrspace(9)`, a buffer resource
+    that carries both an index and offset field, which are used for complex
+    structured indexing that is primarily seen in graphics applications. This
+    is also incompatible with the simple indexing model supported by memref.
+  }];
+}
+
+def AMDGPU_DPPPermAttr : EnumAttr<AMDGPU_Dialect, AMDGPU_DPPPerm,
+  "dpp_perm">;
+
+def AMDGPU_LoadTemporalHintAttr : EnumAttr<AMDGPU_Dialect, AMDGPU_LoadTemporalHint,
+  "load_temporal_hint">;
+
+def AMDGPU_CacheScopeAttr : EnumAttr<AMDGPU_Dialect, AMDGPU_CacheScope,
+  "cache_scope">;
+
+#endif // MLIR_DIALECT_AMDGPU_IR_AMDGPUATTRS_TD

--- a/samples/LLVM TableGen/AMDGPUBase.td
+++ b/samples/LLVM TableGen/AMDGPUBase.td
@@ -1,0 +1,126 @@
+//===-- AMDGPUBase.td - AMDGPU dialect base *- tablegen -*-----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_AMDGPU_IR_AMDGPUBASE_TD
+#define MLIR_DIALECT_AMDGPU_IR_AMDGPUBASE_TD
+
+include "mlir/IR/DialectBase.td"
+
+def AMDGPU_Dialect : Dialect {
+  let name = "amdgpu";
+  let cppNamespace = "::mlir::amdgpu";
+  let useStrictPropertiesInAssemblyFormat = 1;
+  let description = [{
+    The `AMDGPU` dialect provides wrappers around AMD-specific functionality
+    and LLVM intrinsics. These wrappers should be used in conjunction with
+    more generic dialects, such as `gpu` and `vector`, when generating LLVM IR
+    that will eventually be executed on AMD hardware.
+
+    # What goes here?
+    In many cases, AMD GPU functionality can be accessed either though generic
+    operations (such as those in the `gpu`, `vector`, or `math`) or through
+    the `rocdl` dialect's intrinsic wrappers. However, there are instances where
+    AMD-specific functionally benefits from a wrapper around the underlying
+    LLVM intrinsics.
+
+    In general terms, operations or types should be added to this dialect when they
+    wrap some AMD-specific functionality in a way that makes it work better with the
+    MLIR ecosystem and its types or when those buitins would be needlessly
+    complex to work with (such as if they features magic constants at the LLVM level).
+
+    An additional set of operations that belong in this dialect are those that
+    have chipset-specific differences that can be abstracted over in a useful way.
+
+    To give some concrete examples:
+
+    - `amdgpu.mfma` and `amdgpu.wmma` exist in order to make a large set of
+      intrinsics more compatible with the MLIR type system (such as by allowing
+      8-bit float vectors to be passed as `vector<N x f8E4M3FN>` or
+      `vector<N x f8E4M2>` instead of as packed 32-bit integers whose element type
+      is controlled by separate operator-level constants. These operations also
+      allow the same `amdgpu.mfma` operation to be used regardless of the target
+      chip.
+    - `amdgpu.swizzle_bitmode` provides a wrapper around the `ds.swizzle` intrinsic,
+      allowing a wider range of types (such as `vector<2xf16>`) to be used natively
+      and eliminating the need to pack the and, or, and xor components using opaque
+      shifts.
+    - Operations like `amdgpu.gather_to_lds` provide `memref`-ized wrappers around
+      intrinsics that take a pointer, and are nontrivial enough to justify inclusion
+      in this dialect.
+
+
+    Note that simple intrinsics like `rocdl.sin` or `rocdl.s.barrier` should not
+    receive wrapper operations, as nothing is gained from the duplicate operation.
+    As a rule of thumb, if an operation's rewrite in AMDGPUToROCDL would be only
+    a `replaceOpWithNewOp` call, no AMDGPU dialect operation is needed.
+
+    # Design guidelines
+
+    Operations should leverage MLIR's "standard" types where possible. MLIR has
+    a more extensible type system than LLVM (especially in the area of small floats)
+    and those types should be used to create more ergonomic wrappers. In particular,
+    intrinsics that take pointers should have wrappers in this dialect that take
+    `memref` arguments and indices.
+
+    Operations should use properties or attributes in cases where the underlying
+    intrinsic uses `immarg`s (except in cases where that attribute can be represented
+    in the type system).
+
+    If it is possible to generalize the types of an operation, it should be done.
+    For example, the underlying operations for permutations and swizzles always
+    take 32-bit operands. Their AMDGPU wrappers can take any type, and will apply
+    padding and expansion to multiple instructions as needed. This makes these
+    operations easier to target because it hides the bitcasts and extracts
+    until the final lowering.
+
+    When the underlying operation uses magic constants, those should be presented
+    in a more programmer-friendly fashion, such as through enums or though
+    using separate arguments that are later combined. (For example, see the
+    design of the `amdgpu.dpp` and `amdgpu.fat_raw_buffer_cast` operations.)
+    However, in the case where an immediate argument corresponds directly to an
+    enum in the backend compiler, that enum should be in the ROCDL dialect
+    instead.
+
+    If sufficiently similar functionality on multiple hardware generations can be
+    encapsulated into a single operation, it should be done. The lowering to
+    intrinsics should either throw an error when an unsupported capability is
+    used or ignore it. Which of these is two failure modes is more appropriate
+    depends on the nature of the feature, but errors are a safe default choice.
+
+    # Documentation guidelines
+
+    AMDGPU dialect operations should document how any abstractions they introduce
+    translate to LLVM intrinsics or hardware operations.
+
+    While documenting the semantics of the underlying operations is not required,
+    is preferred to provide an overview of the operation's functionality,
+    especially in cases where the documentation is widely distributed. Someone
+    looking at an AMDGPU dialect operation should be able to generally understand
+    what it does and have found the keywords they'll need for more detail.
+
+    Operation documentation should include usage examples.
+
+    Note that this dialect uses LLVM's gfx numbers to refer to individual
+    architectures/chipsets and not product names or codenames.
+  }];
+
+
+  let dependentDialects = [
+    "ROCDL::ROCDLDialect",
+    "arith::ArithDialect",
+    "gpu::GPUDialect"
+  ];
+  let useDefaultAttributePrinterParser = 1;
+  let useDefaultTypePrinterParser = 1;
+  let extraClassDeclaration = [{
+    void registerAttributes();
+    void registerTypes();
+  }];
+}
+
+#endif // MLIR_DIALECT_AMDGPU_IR_AMDGPUBASE_TD

--- a/samples/LLVM TableGen/AMDGPUEnums.td
+++ b/samples/LLVM TableGen/AMDGPUEnums.td
@@ -1,0 +1,85 @@
+//===-- AMDGPUEnums.td - AMDGPU dialect enums *- tablegen -*---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_AMDGPU_IR_AMDGPUENUMS_TD
+#define MLIR_DIALECT_AMDGPU_IR_AMDGPUENUMS_TD
+
+include "mlir/Dialect/AMDGPU/IR/AMDGPUBase.td"
+include "mlir/IR/EnumAttr.td"
+include "mlir/IR/Properties.td"
+
+//===----------------------------------------------------------------------===//
+// AMDGPU general enum  definitions
+//===----------------------------------------------------------------------===//
+
+def AMDGPU_AddressSpace : I32Enum<"AddressSpace",
+    "AMDGPU-specific address spaces",
+    [
+      I32EnumCase<"FatRawBuffer",        0, "fat_raw_buffer">,
+      I32EnumCase<"BufferRsrc",          1, "buffer_rsrc">,
+      I32EnumCase<"FatStructuredBuffer", 2, "fat_structured_buffer">,
+    ]> {
+  let cppNamespace = "::mlir::amdgpu";
+}
+
+def AMDGPU_DPPPerm : I32Enum<"DPPPerm",
+    "The possible permutations for a DPP operation",
+    [
+      I32EnumAttrCase<"quad_perm",  0>,
+      I32EnumAttrCase<"row_shl",    1>,
+      I32EnumAttrCase<"row_shr",    2>,
+      I32EnumAttrCase<"row_ror",    3>,
+      I32EnumAttrCase<"wave_shl",   4>,
+      I32EnumAttrCase<"wave_shr",   5>,
+      I32EnumAttrCase<"wave_ror",   6>,
+      I32EnumAttrCase<"wave_rol",   7>,
+      I32EnumAttrCase<"row_mirror", 8>,
+      I32EnumAttrCase<"row_half_mirror", 9>,
+      I32EnumAttrCase<"row_bcast_15", 10>,
+      I32EnumAttrCase<"row_bcast_31", 11>
+    ]> {
+  let cppNamespace = "::mlir::amdgpu";
+}
+
+def AMDGPU_LoadTemporalHint : I32Enum<"LoadTemporalHint",
+    "AMDGPU-specific prefetch temporal hints for load instructions. "
+    "RT - regular temporal for both near and far caches; "
+    "NT - non-temporal for both near and far caches; "
+    "HT - high-priority temporal for both near and far caches; "
+    "LU - last-use; "
+    "NT_RT - non-temporal for near cache(s) and regular for far caches; "
+    "RT_NT - regular for near cache(s) and non-temporal for far caches; "
+    "NT_HT - non-temporal for near cache(s) and high-priority temporal for far caches",
+    [
+      I32EnumCase<"RT",    0>,
+      I32EnumCase<"NT",    1>,
+      I32EnumCase<"HT",    2>,
+      I32EnumCase<"LU",    3>,
+      I32EnumCase<"NT_RT", 4>,
+      I32EnumCase<"RT_NT", 5>,
+      I32EnumCase<"NT_HT", 6>
+    ]> {
+  let cppNamespace = "::mlir::amdgpu";
+}
+
+def AMDGPU_CacheScope : I32Enum<"Scope",
+    "AMDGPU-specific cache scopes. "
+    "WGP - workgroup processor (CUs); "
+    "SE - shader engine (GL2); "
+    "DEV - device; "
+    "SYS - system",
+    [
+      I32EnumCase<"WGP",    0>,
+      I32EnumCase<"SE",     1>,
+      I32EnumCase<"DEV",    2>,
+      I32EnumCase<"SYS",    3>
+    ]> {
+  let cppNamespace = "::mlir::amdgpu";
+}
+
+#endif // MLIR_DIALECT_AMDGPU_IR_AMDGPUENUMS_TD

--- a/samples/LLVM TableGen/AMDGPUTypes.td
+++ b/samples/LLVM TableGen/AMDGPUTypes.td
@@ -1,0 +1,97 @@
+//===-- AMDGPUTypes.td - AMDGPU dialect types *- tablegen -*---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_AMDGPU_IR_AMDGPUTYPES_TD
+#define MLIR_DIALECT_AMDGPU_IR_AMDGPUTYPES_TD
+
+include "mlir/Dialect/AMDGPU/IR/AMDGPUBase.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinTypeInterfaces.td"
+
+//===----------------------------------------------------------------------===//
+// AMDGPU Type definitions
+//===----------------------------------------------------------------------===//
+
+class AMDGPU_Type<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<AMDGPU_Dialect, name, traits> {
+  let mnemonic = typeMnemonic;
+}
+
+def AMDGPU_TDMBaseType : AMDGPU_Type<"TDMBase", "tdm_base"> {
+  let summary = "Pair of base addresses that move data between LDS and global storage.";
+  let description = [{
+    This type is opaque and it is used to represent a struct of two addresses.
+    One address is in LDS while the other is in global memory.
+
+    The value defined by this operation is only intended to be used by
+    amdgpu.tdm_make_descriptor.
+  }];
+  let parameters = (ins "Type":$elementType);
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "Type":$elementType), [{
+      return $_get(elementType.getContext(), elementType);
+    }]>
+  ];
+  let assemblyFormat = "`<` $elementType `>`";
+}
+
+def AMDGPU_TDMGatherBaseType : AMDGPU_Type<"TDMGatherBase", "tdm_gather_base"> {
+  let summary = "Pair of base addresses that move data between LDS and global storage.";
+  let description = [{
+    This type is opaque and it is used to represent a struct of two addresses.
+    One address is in LDS while the other is in global memory.
+
+    This operation is similar to amdgpu.tdm_make_base but intended to be
+    used in gather mode.
+
+    The value defined by this operation is only intended to be used by
+    amdgpu.tdm_make_gather_descriptor.
+  }];
+  let parameters = (ins "Type":$elementType, "Type":$indexType);
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "Type":$elementType, "Type": $indexType), [{
+      return $_get(elementType.getContext(), elementType, indexType);
+    }]>
+  ];
+  let assemblyFormat = "`<` $elementType `,` $indexType`>`";
+  let genVerifyDecl = 1;
+}
+
+def AMDGPU_TDMDescriptorType : AMDGPU_Type<"TDMDescriptor", "tdm_descriptor"> {
+  let summary = "Descriptors used in tensor store/load operations.";
+  let description = [{
+    This type is opaque and corresponds to the two or four descriptor groups
+    used in tensor_load_to_lds or tensor_store_from_lds.
+  }];
+}
+
+def AMDGPU_DsBarrierStateType : AMDGPU_Type<"DsBarrierState", "ds_barrier_state",
+    [MemRefElementTypeInterface]> {
+  let summary = "State of an in-LDS barrier.";
+  let description = [{
+    Type that encodes the state of an in-LDS barrier as used by the atomic barrier
+    instructions introduced on gfx1250.
+
+    It consists of a 29-bit count of the number of pending arrivals at the barrier (the
+    *pending count*) in bits [28:0], a 3-bit *phase* in bits [31:29], and the 32-bit count
+    to re-initialize the pending count to on phase change (the *init count*) in bits [63:32].
+
+    When an instruction (either one of the explicit arrival primitives or tensor data
+    movement) *arrives* at such a barrier, the pending count is decremented. If this
+    decrement would cause the pending count to underflow, the count is instead reset
+    to the init count and the phase is decremented (wrapping back to 0). When the
+    phase is decremented, sleeping waves are woken up so they can check the barrier.
+
+    The barrier state resides in LDS, but an old barrier state can be returned from atomic
+    arrival instructions or though atomic loads.
+
+    This feature is not available prior to gfx1250.
+  }];
+}
+
+#endif // MLIR_DIALECT_AMDGPU_IR_AMDGPUTYPES_TD

--- a/samples/LLVM TableGen/BasicPtxBuilderInterface.td
+++ b/samples/LLVM TableGen/BasicPtxBuilderInterface.td
@@ -1,0 +1,176 @@
+//===- BasicPtxBuilderInterface.td - PTX builder interface -*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines the interface to build PTX (Parallel Thread Execution) from NVVM Ops 
+// automatically. It is used by NVVM to LLVM pass. 
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BASICPTXBUILDER_OP_INTERFACE
+#define BASICPTXBUILDER_OP_INTERFACE
+
+include "mlir/IR/EnumAttr.td"
+include "mlir/Dialect/GPU/IR/CompilationAttrInterfaces.td"
+include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
+
+//===----------------------------------------------------------------------===//
+// Basic PTX Builder Interface
+//===----------------------------------------------------------------------===//
+
+def PtxPredicate : Optional<I1>;
+
+def BasicPtxBuilderOpInterface : OpInterface<"BasicPtxBuilderInterface"> {
+  let description = [{
+    This interface is used to generate inline assembly with PTX for basic 
+    operations. It's utilized in the `convert-nvvm-to-llvm pass` to lower 
+    NVVM Ops that implement this interface to PTX (parallel thread execution) 
+    using inline assembly Ops. Interface methods play a crucial role in this 
+    lowering process.
+
+    Here's an example of an Op with the `BasicPtxBuilderOpInterface`:    
+    ```tablegen
+      def NVVM_SpecialOp : NVVM_Op<"special.op",
+          [DeclareOpInterfaceMethods<BasicPtxBuilderOpInterface>]>,  
+        Results<(outs LLVM_Type:$res)>,
+        Arguments<(ins LLVM_i64ptr_any:$op1, I32:$op2)> {
+        ...
+        let extraClassDefinition = [{
+          std::string $cppClass::getPtx() { 
+            return std::string("special.op %0, %1, %2;"); 
+          }
+     } ];
+    ```
+
+    In the above NVVM Op example:
+    ```mlir
+      %0 = nvvm.special.op %1, %2 : !llvm.ptr, i32 -> i32
+    ```
+
+    The `convert-nvvm-to-llvm` pass generates the inline assembly like below. 
+    The order of arguments is retained, and the read and write modifiers are 
+    set based on the input and result types:
+    ```mlir
+      %0 = llvm.inline_asm 
+                has_side_effects 
+                asm_dialect = 
+                att "special.op %0, %1, %2;", "=r,l,r" %arg0, %arg1 
+                : (!llvm.ptr, i32) -> i32
+    ```
+  }];
+  let cppNamespace = "::mlir::NVVM";
+  let methods = [
+    InterfaceMethod<
+        /*desc=*/[{
+          Optional function for setting a predicate, which 
+          always returns a `PtxPredicate` value of type i1. If no predicate is 
+          provided, the instruction is unguarded; otherwise, it's guarded by the 
+          predicate value. The `PtxPredicate` value must always be the last argument. 
+          The provided PTX code by `getPtx` should not include the predicate usage.
+          The interface automatically handles predicate usage in the generated
+          PTX code when necessary.
+        }],
+        /*retType=*/"std::optional<::mlir::Value>",
+        /*methodName=*/"getPredicate",
+        /*args=*/(ins),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/"return {};"
+      >,
+    InterfaceMethod<
+        /*desc=*/[{ Returns PTX assembly with operand number. }],
+        /*retType=*/"std::string",
+        /*methodName=*/"getPtx"
+      >,
+    InterfaceMethod<
+        /*desc=*/[{
+          This function indicates whether the operation is supported by LLVM 
+          intrinsics. It's particularly useful for operations that have 
+          specific cases with LLVM intrinsic support.
+        }],
+        /*retType=*/"bool",
+        /*methodName=*/"hasIntrinsic",
+        /*args=*/(ins),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/"return false;"
+      >,
+    InterfaceMethod<
+        /*desc=*/[{Return whether the operation has memory side effects.}],
+        /*retType=*/"bool",
+        /*methodName=*/"hasSideEffect",
+        /*args=*/(ins),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/"return true;"
+      >,
+    InterfaceMethod<
+        /*desc=*/[{
+          Return whether a memory clobber ("~{memory}") is appended to the
+          constraints of the generated inline assembly. It informs LLVM that
+          the PTX may read or write memory beyond its listed operands, so
+          optimizations must not reorder memory accesses across it.
+        }],
+        /*retType=*/"bool",
+        /*methodName=*/"hasMemoryClobber",
+        /*args=*/(ins),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/"return false;"
+      >,
+
+    InterfaceMethod<
+        /*desc=*/[{Helper function to generate i32 constant value.}],
+        /*retType=*/"::mlir::Value",
+        /*methodName=*/"makeConstantI32",
+        /*args=*/(ins "::mlir::RewriterBase &":$rewriter, "int" : $val),
+        /*methodBody=*/"",
+        /*defaultImpl=*/ [{
+            mlir::Operation* op = $_op;
+            return LLVM::ConstantOp::create(rewriter,
+              op->getLoc(), rewriter.getIntegerType(32), val);
+        }]
+     >,
+     InterfaceMethod<
+         /*desc=*/[{ 
+            This function supplies the necessary arguments for passing PTX code,
+            following this order:
+             1) Adds results 
+             2) Adds operands 
+             3) Adds attributes
+             Returns true if the OP is going to do register mapping itself
+          }],
+         /*retType=*/"bool",
+         /*methodName=*/"getAsmValues",
+         /*args=*/(ins "::mlir::RewriterBase &":$rewriter, 
+         "llvm::SmallVectorImpl<std::pair<mlir::Value, mlir::NVVM::PTXRegisterMod>>&" : $asmValues         
+         ),
+         /*methodBody=*/"",
+         /*defaultImpl=*/ [{         
+           mlir::Operation* op = $_op;
+           
+           // Step 1. Add results
+            for (auto val : op->getResults()) 
+              asmValues.push_back({val, mlir::NVVM::PTXRegisterMod::Write});
+
+           // Step 2. Add operands
+           for (auto val : op->getOperands()) 
+            asmValues.push_back({val, mlir::NVVM::PTXRegisterMod::Read});
+           
+           // Step 3. Add inherent attributes.
+           op->getName().walkInherentAttrs(
+               op, [&](llvm::StringRef, mlir::Attribute &attr) {
+                 if (auto intAttr = dyn_cast<mlir::IntegerAttr>(attr)) {
+                   ::mlir::Value val =
+                       makeConstantI32(rewriter, intAttr.getInt());
+                   asmValues.push_back(
+                       {val, mlir::NVVM::PTXRegisterMod::Read});
+                 }
+               });
+           return false; // No manual mapping needed
+         }]
+       >
+  ];
+}
+
+#endif // BASICPTXBUILDER_OP_INTERFACE

--- a/samples/LLVM TableGen/LLVMDialect.td
+++ b/samples/LLVM TableGen/LLVMDialect.td
@@ -1,0 +1,135 @@
+//===-- LLVMDialect.td - LLVM IR dialect definition --------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVMIR_DIALECT
+#define LLVMIR_DIALECT
+
+include "mlir/IR/DialectBase.td"
+
+def LLVM_Dialect : Dialect {
+  let name = "llvm";
+  let cppNamespace = "::mlir::LLVM";
+
+  let hasConstantMaterializer = 1;
+  let useDefaultAttributePrinterParser = 1;
+  let hasRegionArgAttrVerify = 1;
+  let hasRegionResultAttrVerify = 1;
+  let hasOperationAttrVerify = 1;
+
+  let discardableAttrs = (ins
+    /// Attribute encoding size and type of GPU workgroup attributions.
+    "WorkgroupAttributionAttr":$workgroup_attribution
+  );
+
+  let extraClassDeclaration = [{
+    static StringRef getTargetAttrName() { return "llvm.target"; }
+    /// Name of the data layout attributes.
+    static StringRef getDataLayoutAttrName() { return "llvm.data_layout"; }
+    static StringRef getNoAliasScopesAttrName() { return "noalias_scopes"; }
+    static StringRef getAliasScopesAttrName() { return "alias_scopes"; }
+    static StringRef getAccessGroupsAttrName() { return "access_groups"; }
+    static StringRef getIdentAttrName() { return "llvm.ident"; }
+    static StringRef getModuleFlags() { return "llvm.module.flags"; }
+    static StringRef getCommandlineAttrName() { return "llvm.commandline"; }
+    static StringRef getMmraAttrName() { return "llvm.mmra"; }
+
+    /// Names of llvm parameter attributes.
+    static StringRef getAlignAttrName() { return "llvm.align"; }
+    static StringRef getAllocAlignAttrName() { return "llvm.allocalign"; }
+    static StringRef getAllocatedPointerAttrName() { return "llvm.allocptr"; }
+    static StringRef getByValAttrName() { return "llvm.byval"; }
+    static StringRef getByRefAttrName() { return "llvm.byref"; }
+    static StringRef getNoUndefAttrName() { return "llvm.noundef"; }
+    static StringRef getDereferenceableAttrName() { return "llvm.dereferenceable"; }
+    static StringRef getDereferenceableOrNullAttrName() { return "llvm.dereferenceable_or_null"; }
+    static StringRef getElementTypeAttrName() { return "llvm.elementtype"; }
+    static StringRef getInAllocaAttrName() { return "llvm.inalloca"; }
+    static StringRef getInRegAttrName() { return "llvm.inreg"; }
+    static StringRef getNestAttrName() { return "llvm.nest"; }
+    static StringRef getNoAliasAttrName() { return "llvm.noalias"; }
+    static StringRef getNoCaptureAttrName() { return "llvm.nocapture"; }
+    static StringRef getNoFreeAttrName() { return "llvm.nofree"; }
+    static StringRef getNonNullAttrName() { return "llvm.nonnull"; }
+    static StringRef getPreallocatedAttrName() { return "llvm.preallocated"; }
+    static StringRef getRangeAttrName() { return "llvm.range"; }
+    static StringRef getReadonlyAttrName() { return "llvm.readonly"; }
+    static StringRef getReturnedAttrName() { return "llvm.returned"; }
+    static StringRef getSExtAttrName() { return "llvm.signext"; }
+    static StringRef getStackAlignmentAttrName() { return "llvm.alignstack"; }
+    static StringRef getStructRetAttrName() { return "llvm.sret"; }
+    static StringRef getWritableAttrName() { return "llvm.writable"; }
+    static StringRef getWriteOnlyAttrName() { return "llvm.writeonly"; }
+    static StringRef getDeadOnUnwindAttrName() { return "llvm.dead_on_unwind"; }
+    static StringRef getDeadOnReturnAttrName() { return "llvm.dead_on_return"; }
+    static StringRef getNoFPClassAttrName() { return "llvm.nofpclass"; }
+    static StringRef getZExtAttrName() { return "llvm.zeroext"; }
+    static StringRef getOpBundleSizesAttrName() { return "op_bundle_sizes"; }
+    static StringRef getOpBundleTagsAttrName() { return "op_bundle_tags"; }
+    // TODO Restrict the usage of this to parameter attributes once there is an
+    // alternative way of modeling memory effects on FunctionOpInterface.
+    /// Name of the attribute that will cause the creation of a readnone memory
+    /// effect when lowering to the LLVMDialect.
+    static StringRef getReadnoneAttrName() { return "llvm.readnone"; }
+
+    /// Verifies if the given string is a well-formed data layout descriptor.
+    /// Uses `reportError` to report errors.
+    static LogicalResult verifyDataLayoutString(
+        StringRef descr, llvm::function_ref<void (const Twine &)> reportError);
+
+    /// Name of the target triple attribute.
+    static StringRef getTargetTripleAttrName() { return "llvm.target_triple"; }
+
+    /// Name of the C wrapper emission attribute.
+    static StringRef getEmitCWrapperAttrName() {
+      return "llvm.emit_c_interface";
+    }
+
+    /// Name of the module level assembly attribute.
+    static StringRef getModuleLevelAsmAttrName() { return "llvm.module_asm"; }
+
+    /// Name of the dependent libraries attribute.
+    static StringRef getDependentLibrariesAttrName() {
+      return "llvm.dependent_libraries";
+    }
+
+    /// Names of known llvm module flag keys.
+    static StringRef getModuleFlagKeyCGProfileName() {
+      return "CG Profile";
+    }
+    static StringRef getModuleFlagKeyProfileSummaryName() {
+      return "ProfileSummary";
+    }
+
+    /// Returns `true` if the given type is compatible with the LLVM dialect.
+    static bool isCompatibleType(Type);
+
+
+    Type parseType(DialectAsmParser &p) const override;
+    void printType(Type, DialectAsmPrinter &p) const override;
+
+  private:
+    /// Verifies a parameter attribute attached to a parameter of type
+    /// paramType.
+    LogicalResult verifyParameterAttribute(Operation *op,
+                                           Type paramType,
+                                           NamedAttribute paramAttr);
+
+    /// Register all types.
+    void registerTypes();
+
+    /// A cache storing compatible LLVM types that have been verified. This
+    /// can save us lots of verification time if there are many occurrences
+    /// of some deeply-nested aggregate types in the program.
+    ThreadLocalCache<DenseSet<Type>> compatibleTypes;
+
+    /// Register the attributes of this dialect.
+    void registerAttributes();
+  }];
+}
+
+#endif  // LLVMIR_DIALECT

--- a/samples/LLVM TableGen/MathBase.td
+++ b/samples/LLVM TableGen/MathBase.td
@@ -1,0 +1,45 @@
+//===- MathBase.td - Base definitions for math dialect ------*- tablegen -*-==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef MATH_BASE
+#define MATH_BASE
+include "mlir/IR/OpBase.td"
+def Math_Dialect : Dialect {
+  let name = "math";
+  let useStrictPropertiesInAssemblyFormat = 1;
+  let cppNamespace = "::mlir::math";
+  let description = [{
+    The math dialect is intended to hold mathematical operations on integer and
+    floating types beyond simple arithmetics. Each operation works on scalar, vector
+    or tensor type. On vector and tensor type operations apply elementwise unless
+    explicitly specified otherwise. As an example, the floating point absolute value
+    can be expressed as:
+
+    ```mlir
+    // Scalar absolute value.
+    %a = math.absf %b : f64
+
+    // Vector elementwise absolute value.
+    %f = math.absf %g : vector<4xf32>
+
+    // Tensor elementwise absolute value.
+    %x = math.absf %y : tensor<4x?xf8>
+    ```
+
+    Some floating-point operations may specify rounding modes and/or fast-math
+    flags. In the absence of an explicit rounding mode, the math dialect uses
+    this default round mode for internal purposes such as constant folding and
+    canonicalization: round-to-nearest, ties-to-even. The runtime behavior of
+    operations without an explicit rounding mode is deferred to the target
+    backend and may differ from the default math rounding mode.
+  }];
+  let hasConstantMaterializer = 1;
+  let dependentDialects = [
+    "::mlir::arith::ArithDialect"
+  ];
+}
+#endif // MATH_BASE

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -347,6 +347,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Kusto:** [mmanela/kusto-sublime](https://github.com/mmanela/kusto-sublime)
 - **LFE:** [textmate/lisp.tmbundle](https://github.com/textmate/lisp.tmbundle)
 - **LLVM:** [whitequark/llvm.tmbundle](https://github.com/whitequark/llvm.tmbundle)
+- **LLVM TableGen:** [nos1dot618/llvm-tablegen-grammar](https://github.com/nos1dot618/llvm-tablegen-grammar)
 - **LOLCODE:** [KrazIvan/LOLCODE-grammar-vscode](https://github.com/KrazIvan/LOLCODE-grammar-vscode)
 - **LSL:** [textmate/secondlife-lsl.tmbundle](https://github.com/textmate/secondlife-lsl.tmbundle)
 - **LTspice Symbol:** [Alhadis/language-pcb](https://github.com/Alhadis/language-pcb)

--- a/vendor/licenses/git_submodule/llvm-tablegen-grammar.dep.yml
+++ b/vendor/licenses/git_submodule/llvm-tablegen-grammar.dep.yml
@@ -1,0 +1,244 @@
+---
+name: llvm-tablegen-grammar
+version: beba76306bb69474c2c0d81e71ae4ce52205a529
+type: git_submodule
+homepage: https://github.com/nos1dot618/llvm-tablegen-grammar.git
+license: other
+licenses:
+- sources: LICENSE.txt
+  text: |
+    ==============================================================================
+    The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+    ==============================================================================
+
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+        TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+        1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+        2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+        3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+        4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+        5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+        6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+        7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+        8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+        9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+
+        END OF TERMS AND CONDITIONS
+
+        APPENDIX: How to apply the Apache License to your work.
+
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "[]"
+          replaced with your own identifying information. (Don't include
+          the brackets!)  The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+
+        Copyright [yyyy] [name of copyright owner]
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+
+
+    ---- LLVM Exceptions to the Apache 2.0 License ----
+
+    As an exception, if, as a result of your compiling your source code, portions
+    of this Software are embedded into an Object form of such source code, you
+    may redistribute such embedded portions in such Object form without complying
+    with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+    In addition, if you combine or link compiled forms of this Software with
+    software that is licensed under the GPLv2 ("Combined Software") and if a
+    court of competent jurisdiction determines that the patent provision (Section
+    3), the indemnity provision (Section 9) or other Section of the License
+    conflicts with the conditions of the GPLv2, you may retroactively and
+    prospectively choose to deem waived or otherwise exclude such Section(s) of
+    the License, but only in their entirety and only with respect to the Combined
+    Software.
+
+    ==============================================================================
+    Software from third parties included in the LLVM Project:
+    ==============================================================================
+    The LLVM Project contains third party software which is under different license
+    terms. All such code will be identified clearly using at least one of two
+    mechanisms:
+    1) It will be in a separate directory tree with its own `LICENSE.txt` or
+       `LICENSE` file at the top containing the specific license and restrictions
+       which apply to that software, or
+    2) It will contain specific license and restriction terms at the top of every
+       file.
+notices: []

--- a/vendor/licenses/git_submodule/llvm-tablegen-grammar.dep.yml
+++ b/vendor/licenses/git_submodule/llvm-tablegen-grammar.dep.yml
@@ -3,7 +3,7 @@ name: llvm-tablegen-grammar
 version: beba76306bb69474c2c0d81e71ae4ce52205a529
 type: git_submodule
 homepage: https://github.com/nos1dot618/llvm-tablegen-grammar.git
-license: other
+license: apache-2.0
 licenses:
 - sources: LICENSE.txt
   text: |


### PR DESCRIPTION
Adds **LLVM TableGen** as a supported language in GitHub Linguist.

This adds:

* `.td` as the file extension for LLVM TableGen.
* The [llvm-tablegen](https://github.com/nos1dot618/llvm-tablegen-grammar) grammar as a Linguist grammar submodule.
* Real-world TableGen samples from the LLVM MLIR project.
* A dedicated language color.
* An automated workflow in the `llvm-tablegen-grammar` repository that synchronizes its grammar with the upstream [llvm/vscode-mlir](https://github.com/llvm/vscode-mlir/blob/main/tablegen-grammar.json) grammar.

The Linguist grammar dependency is intentionally **`llvm-tablegen-grammar` rather than `llvm/vscode-mlir` directly**. The `llvm-tablegen-grammar` repository serves as the dedicated grammar source for Linguist while keeping the upstream TableGen grammar synchronized with `llvm/vscode-mlir`.

This allows Linguist to consume a stable, dedicated grammar repository without directly depending on the broader `llvm/vscode-mlir` repository.

## Checklist:

* [ ] **I am adding a new extension to a language.**
* [x] **I am adding a new language.**
  * [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    * Search results for `.td` (~ 250k results):
      * <https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.td>
  * [x] I have included a real-world usage sample for all extensions added in this PR:
    * Sample source(s):
      * https://github.com/llvm/llvm-project/tree/main/mlir/include/mlir/Dialect/AMDGPU
      * https://github.com/llvm/llvm-project/tree/main/mlir/include/mlir/Dialect/NVGPU
    * Sample license(s):
      * Apache License 2.0 with LLVM Exceptions
  * [x] I have included a syntax highlighting grammar: https://github.com/nos1dot618/llvm-tablegen-grammar
  * [x] I have added a color
    * Hex value: `#6E8B3D`
    * Rationale: An olive green was chosen to provide a distinct color for LLVM TableGen while being visually associated with the LLVM ecosystem.
  * [x] ~I have updated the heuristics to distinguish my language from others using the same extension.~
    * No changes to the heuristics are necessary because no other language currently uses the `.td` extension in Linguist.
* [ ] **I am fixing a misclassified language**
* [ ] **I am changing the source of a syntax highlighting grammar**
* [ ] **I am updating a grammar submodule**
* [x] **I am adding new or changing current functionality**
  * [x] I have added or updated the tests for the new or changed functionality.
* [ ] **I am changing the color associated with a language**

## Additional Notes

- fixes: #7945