### PR TITLE
Add Bit language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1668,3 +1668,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/bit-tmlanguage"]
+	path = vendor/grammars/bit-tmlanguage
+	url = https://github.com/byteink/bit-tmlanguage

--- a/grammars.yml
+++ b/grammars.yml
@@ -305,6 +305,8 @@ vendor/grammars/bicep:
 - source.bicep
 vendor/grammars/bikeshed:
 - source.csswg
+vendor/grammars/bit-tmlanguage:
+- source.bit
 vendor/grammars/blitzmax:
 - source.blitzmax
 vendor/grammars/blueprint-grammar:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -722,6 +722,14 @@ Bison:
   - ".bison"
   ace_mode: text
   language_id: 31
+Bit:
+  type: programming
+  color: "#fe2551"
+  tm_scope: source.bit
+  extensions:
+  - ".bit"
+  ace_mode: text
+  language_id: 975880045
 BitBake:
   type: programming
   color: "#00bce4"

--- a/samples/Bit/csv.bit
+++ b/samples/Bit/csv.bit
@@ -1,0 +1,210 @@
+// Bit standard library — csv module, RFC 4180 reader and writer.
+//
+// Two exports, symmetric with std/json: `csvParse` turns CSV text into
+// `[][]string`, `csvFormat` turns `[][]string` back into text. The quoting
+// rules are the whole point (RFC 4180 §2.5-2.7) and everyone gets one of
+// them wrong quietly:
+//
+//   - a field containing `,` must be quoted;
+//   - a field containing `"` must be quoted, with each `"` inside doubled;
+//   - a field containing a newline must be quoted, and the reader must not
+//     treat that newline as a record boundary — get this one wrong and an
+//     export looks fine until a note field holds a newline, after which
+//     every later row is off by one;
+//   - a record ends in `\r\n` or `\n`, and the last record may have no
+//     terminator at all.
+//
+// `csvRecord` is a real byte-by-byte scanner tracking in-quotes state, not
+// built on `split` (quadratic on a long line, #2132, and blind to quoted
+// commas/newlines regardless). `csvScanner` accumulates each field into a
+// `[]byte` — `append`'s amortised doubling — never `s = s + c`, which is
+// quadratic per field.
+//
+// Deliberately out of scope: a configurable delimiter, header-to-struct
+// mapping, `\r\n`-vs-`\n` output selection, and a streaming `io.Reader`
+// variant. `csvFormat` always terminates with `\n`.
+
+// Parses `source` as RFC 4180 CSV: every record, each a slice of field
+// values. Fails on an unterminated quoted field (an opening `"` with no
+// matching close before the end of input) — the one input this module
+// cannot make sense of. Round-trips with `csvFormat`.
+export fn csvParse(source: string): [][]string! {
+  let records = [][]string(0)
+  let n = len(source)
+  let i = 0
+  while (i < n) {
+    let (fields, next) = csvRecord(source, i)?
+    records = append(records, fields)
+    i = next
+  }
+  return records
+}
+
+// Formats `records` as RFC 4180 CSV text: comma-separated fields, one
+// record per line, each terminated with `\n`. A field is double-quoted,
+// with any `"` inside it doubled, iff it contains a comma, a quote, or a
+// newline (`\n` or `\r`); an ordinary field is written bare.
+export fn csvFormat(records: [][]string): string {
+  let out = []byte(0)
+  let r = 0
+  while (r < len(records)) {
+    out = csvAppendRecord(out, records[r])
+    out = append(out, '\n')
+    r = r + 1
+  }
+  return string(out)
+}
+
+// --- reader ------------------------------------------------------------
+
+// Per-field state for one record scan: the field bytes accumulated so far,
+// whether any byte has been consumed for the current field (so a `"` only
+// opens a quoted field as the very first byte of that field), and whether
+// the scanner currently sits inside a quoted field. A class, hence a
+// reference type (§13.3): the two step methods below mutate it in place.
+class csvScanner {
+  fields: []string
+  field: []byte
+  fieldStarted: bool
+  inQuotes: bool
+
+  put(b: u8) {
+    this.field = append(this.field, b)
+    this.fieldStarted = true
+  }
+
+  endField() {
+    this.fields = append(this.fields, string(this.field))
+    this.field = []byte(0)
+    this.fieldStarted = false
+  }
+
+  // Consumes one step inside a quoted field at `src[i]`. A doubled `""`
+  // decodes to one literal `"` and consumes 2 bytes; any other `"` closes the
+  // quoted region (consuming 1 byte, appending nothing); anything else,
+  // including a raw `,`, `\n`, or `\r`, is data and is appended verbatim —
+  // this is the rule that keeps an embedded newline out of the record
+  // boundary. Returns the number of bytes consumed.
+  stepQuoted(src: string, i: int, n: int): int {
+    let b = src[i]
+    if (b != '"') {
+      this.put(b)
+      return 1
+    }
+    if (i + 1 < n && src[i + 1] == '"') {
+      this.put('"')
+      return 2
+    }
+    this.inQuotes = false
+    return 1
+  }
+
+  // Consumes one step outside any quoted field at `src[i]`. Returns whether
+  // the record just ended and, if so, the offset of the first byte after it
+  // (past a `\r\n` or `\n` terminator); the offset is unused when the record
+  // has not ended.
+  stepUnquoted(src: string, i: int, n: int): (bool, int) {
+    let b = src[i]
+    if (b == '"' && !this.fieldStarted) {
+      this.inQuotes = true
+      this.fieldStarted = true
+      return false, 0
+    }
+    if (b == ',') {
+      this.endField()
+      return false, 0
+    }
+    if (b == '\n') {
+      this.endField()
+      return true, i + 1
+    }
+    if (b == '\r' && i + 1 < n && src[i + 1] == '\n') {
+      this.endField()
+      return true, i + 2
+    }
+    this.put(b)
+    return false, 0
+  }
+}
+
+fn newCsvScanner(): csvScanner {
+  return csvScanner{ fields: []string(0), field: []byte(0), fieldStarted: false, inQuotes: false }
+}
+
+// Scans one CSV record starting at byte `start` of `src`, returning its
+// fields and the offset of the first byte after the record — past its
+// terminator, or `len(src)` if this is the last record and it has none.
+fn csvRecord(src: string, start: int): ([]string, int)! {
+  let n = len(src)
+  let sc = newCsvScanner()
+  let i = start
+  while (i < n) {
+    if (sc.inQuotes) {
+      i = i + sc.stepQuoted(src, i, n)
+      continue
+    }
+    let (done, next) = sc.stepUnquoted(src, i, n)
+    if (done) {
+      return sc.fields, next
+    }
+    i = i + 1
+  }
+  if (sc.inQuotes) {
+    fail newError("csv: unterminated quoted field starting before byte ${start}")
+  }
+  sc.endField()
+  return sc.fields, n
+}
+
+// --- writer --------------------------------------------------------------
+
+fn csvAppendRecord(out: []byte, row: []string): []byte {
+  let c = 0
+  while (c < len(row)) {
+    if (c > 0) {
+      out = append(out, ',')
+    }
+    out = csvAppendField(out, row[c])
+    c = c + 1
+  }
+  return out
+}
+
+fn csvAppendField(out: []byte, field: string): []byte {
+  if (!csvNeedsQuoting(field)) {
+    return appendBytes(out, field)
+  }
+  out = append(out, '"')
+  let i = 0
+  while (i < len(field)) {
+    let b = field[i]
+    if (b == '"') {
+      out = append(out, '"')
+    }
+    out = append(out, b)
+    i = i + 1
+  }
+  out = append(out, '"')
+  return out
+}
+
+fn csvNeedsQuoting(field: string): bool {
+  let i = 0
+  while (i < len(field)) {
+    let b = field[i]
+    if (b == ',' || b == '"' || b == '\n' || b == '\r') {
+      return true
+    }
+    i = i + 1
+  }
+  return false
+}
+
+fn appendBytes(out: []byte, s: string): []byte {
+  let i = 0
+  while (i < len(s)) {
+    out = append(out, s[i])
+    i = i + 1
+  }
+  return out
+}

--- a/samples/Bit/httpserver.bit
+++ b/samples/Bit/httpserver.bit
@@ -1,0 +1,75 @@
+// An HTTP server and client on the same runtime. The request handler is an
+// ordinary function value passed to the server loop; each request runs on its
+// own green thread. The server serves a fixed number of requests so the demo
+// exits (a real server calls `listenAndServe`, which runs forever).
+import { serve, get, ok, respond, Server, Exchange, Request, Response } from "std/http"
+import { hasPrefix } from "std/strings"
+
+// The handler - a plain function, used below as a value.
+fn route(req: Request): Response {
+  if (req.path == "/") {
+    return ok("hello from bit")
+  }
+  if (hasPrefix(req.path, "/echo/")) {
+    return ok(req.path[6:len(req.path)])
+  }
+  return respond(404, "not found")
+}
+
+// Dispatch one exchange through the handler value, on this green thread:
+// reads the request here, off the accept loop, so a slow or stalled peer only
+// ever blocks this one exchange.
+fn dispatch(ex: Exchange, handler: (Request) => Response) {
+  let req = ex.read() catch e {
+    ex.respond(respond(400, "")) catch e2 {
+      return
+    }
+    return
+  }
+  ex.respond(handler(req)) catch e {
+    print("handler error: ${e.message()}\n")
+  }
+}
+
+// Accept `n` requests and hand each to `handler` on its own green thread.
+fn serveN(s: Server, n: int, handler: (Request) => Response, ready: chan<int>) {
+  ready <- 0
+  let i = 0
+  while (i < n) {
+    let ex = s.accept() catch e {
+      print("accept error: ${e.message()}\n")
+      return
+    }
+    spawn dispatch(ex, handler)
+    i = i + 1
+  }
+  s.close()
+}
+
+fn main() {
+  let s = serve("127.0.0.1", 0) catch e {
+    print("serve: ${e.message()}\n")
+    return
+  }
+  let port = s.port() catch e {
+    print("port: ${e.message()}\n")
+    return
+  }
+
+  let ready = chan<int>(1)
+  spawn serveN(s, 2, route, ready)
+  let started = <- ready
+
+  let base = "http://127.0.0.1:${port}"
+  let home = get("${base}/") catch e {
+    print("get /: ${e.message()}\n")
+    return
+  }
+  print("GET / -> ${home.status} ${home.body}\n")
+
+  let echoed = get("${base}/echo/green-threads") catch e {
+    print("get /echo: ${e.message()}\n")
+    return
+  }
+  print("GET /echo/green-threads -> ${echoed.status} ${echoed.body}\n")
+}

--- a/samples/Bit/json_parse.bit
+++ b/samples/Bit/json_parse.bit
@@ -1,0 +1,616 @@
+// Bit standard library — json module, strict-JSON recursive-descent parser.
+//
+// Consumes the flat token stream `lex` (stdlib/json/lex.bit) produces and
+// builds a `Json` tree (stdlib/json/value.bit). Strict RFC 8259 only: no
+// comments, no trailing commas — JSONC is a separate, later task layered on
+// top of this file. Every malformed shape (bad token sequence, invalid
+// escape, number that doesn't match the grammar, depth-limit token) is a
+// parse error via the fallible return, never a panic: this parser only ever
+// consumes untrusted input.
+//
+// Duplicate object keys: this parser keeps every entry, in source order,
+// rather than deduping while building `JsonObject`. `jsonGet` (value.bit)
+// already resolves duplicate keys last-wins, and it is the only sanctioned
+// way callers read a key (#1479), so keeping all entries and letting that one
+// place own the policy is simpler than enforcing it twice.
+//
+// JSONC (#1479's accepted grammar — narrow, explicit, NOT JSON5):
+//
+//   - `//` line comments: from `//` to end of line, anywhere whitespace is
+//     currently allowed.
+//   - `/* */` block comments: non-nesting, anywhere whitespace is currently
+//     allowed. An unterminated `/*` is a parse error.
+//   - Trailing commas: a single trailing `,` is allowed before `}` or `]`
+//     (`[1, 2,]` and `{"a": 1,}` are valid). More than one trailing comma, or
+//     a leading comma, is still a parse error.
+//   - Explicitly OUT OF SCOPE: unquoted object keys, single-quoted strings,
+//     hex numbers, `NaN`/`Infinity`, or any other JSON5 leniency.
+//
+// `jsoncParse` is this same grammar with comments (`Parser.allowComments`,
+// which lex.bit's scanner reads) and one trailing comma
+// (`Parser.allowTrailingComma`) switched on; `jsonParse` stays strict RFC 8259
+// so a caller that wants to reject comments still can.
+
+// Deliberately NOT importing `strings.parseInt`: it rejects i64 MIN by design
+// (its own doc comment — "the parser accumulates a positive magnitude and
+// would overflow representing it"), which would route -9223372036854775808 to
+// `JsonFloat` and silently rewrite it (#2285). `parseJsonInt` below does its
+// own digit accumulation so this module can accept the full i64 range.
+
+// Starting capacity for a `JsonObject`'s entries and a `JsonArray`'s items
+// (#2293). `append` doubles FROM 1 (runtime/root/slices.bit:185), so a
+// container built from an empty slice reallocates its backing at 1, 2 and 4 —
+// three extra `gc_alloc`s and three copies to hold four elements, and real
+// documents are overwhelmingly made of small objects and short arrays. Starting
+// at 4 holds the common case in the slice's first buffer and leaves the
+// doubling to take over unchanged above it. The cost is a 4-word buffer for an
+// empty `{}`/`[]` that would otherwise get a 0-word one; the 32-byte object
+// header (runtime/ABI.md §1) is paid either way, so that is 32 bytes, not a
+// class of waste.
+const jsonSmallCap = 4
+
+// Slots in a parser's object-key cache (#4358). Direct-mapped and
+// self-evicting: one slot per index, never scanned, never grown, so a document
+// with a million distinct keys costs the same 16 words as one with four. A
+// power of two, so the index is a mask. 16 holds a record shape's key set — a
+// real document repeats the same handful of keys across sibling objects and
+// across nesting depths.
+const jsonKeyCacheSlots = 16
+
+// A cursor over the token stream, plus the original source (decoding a string
+// or number needs to slice raw bytes back out of it).
+// `allowTrailingComma` and `allowComments` are JSONC-only (both false for
+// strict `jsonParse`): the first lets `parseObject`/`parseArray` accept one
+// trailing `,` before the closer, the second switches on lex.bit's comment
+// handling.
+//
+// STREAMING (#2293), not a materialized `[]Token`. This parser is a pure
+// forward cursor — it peeks one token and never looks back — so the whole
+// stream never needed to exist at once. It used to: `lex(source)` built one
+// `Token` per token, and a class is a heap object in Bit, so a 9 MB document
+// cost 3.6M `gc_alloc`s plus a 3.6M-word backing array, all of it LIVE for the
+// entire parse and therefore re-marked by every collection the parse triggers.
+// Driving `lexNext` directly and reading the current token off `p.lx`'s own
+// `kind`/`start`/`end` fields makes tokenization allocation-free.
+class Parser {
+  src: string,
+  lx: Lexer,
+  allowComments: bool,
+  allowTrailingComma: bool,
+  // `internKey`'s table. Empty until the first escape-free object key, so a
+  // document with no objects — or none with keys — never pays for it.
+  keyCache: []string,
+}
+
+// A parser positioned on `source`'s first token. Priming here rather than
+// lazily keeps every `p.lx.kind` read below unconditional.
+fn newParser(source: string, allowComments: bool, allowTrailingComma: bool): Parser {
+  let p = Parser{
+    src: source,
+    lx: newLexer(source),
+    allowComments: allowComments,
+    allowTrailingComma: allowTrailingComma,
+    keyCache: []string(0, 0),
+  }
+  lexNext(p.lx, allowComments, false)
+  return p
+}
+
+// Moves past the token under the cursor. At `Eof` — the stream's fixed final
+// token — it stays put, so nothing walks past the end however many times a
+// caller asks.
+fn advance(p: Parser) {
+  if (p.lx.kind != TokenKind.Eof) {
+    lexNext(p.lx, p.allowComments, false)
+  }
+}
+
+// An upper bound on the tokens `p.src` can still yield: every token consumes at
+// least one source byte, plus the one `Eof`. Replaces the old `len(p.toks) + 1`
+// now that the stream is not materialized — same purpose (a statically provable
+// loop bound, never a real limit), same guarantee.
+fn tokenBound(p: Parser): int {
+  return len(p.src) + 1
+}
+
+// One value out of `p`'s token stream, optionally surrounded by whitespace
+// (already stripped by the lexer) and nothing else. Shared by `jsonParse` and
+// `jsoncParse` — they differ only in how `p` was built (which lexer, and
+// whether a trailing comma is allowed), not in this top-level shape check.
+fn parseTopLevel(p: Parser): Json! {
+  let v = parseValue(p)?
+  if (p.lx.kind != TokenKind.Eof) {
+    fail posError(p.src, "json: trailing garbage after value", p.lx.start)
+  }
+  return v
+}
+
+// Parses `source` as strict JSON (RFC 8259): one value, optionally
+// surrounded by whitespace, and nothing else. No comments, no trailing
+// commas — see `jsoncParse` for the JSONC extension.
+export fn jsonParse(source: string): Json! {
+  return parseTopLevel(newParser(source, false, false))?
+}
+
+// Parses `source` as JSONC (this file's header comment documents the exact
+// grammar): strict JSON plus `//`/`/* */` comments and a single trailing
+// comma before `}`/`]`. Everything else — number/string decoding, depth
+// limit, error-vs-panic behavior — is identical to `jsonParse`.
+export fn jsoncParse(source: string): Json! {
+  return parseTopLevel(newParser(source, true, true))?
+}
+
+// --- error positions -------------------------------------------------
+
+// A 1-based (line, column) position, matching compiler/diagnostics.bit's own
+// `--> file:LINE:COL` rendering so a user reading a jsonParse error next to a
+// compiler diagnostic does not have to learn two numbering systems.
+class JsonPos { line: int, column: int }
+
+// Resolves byte offset `offset` in `src` to a 1-based (line, column).
+// Matches compiler/diagnostics.bit's `locate`: `column` counts BYTES, not
+// runes — cheaper (no UTF-8 decoding on the error path) and consistent with
+// the compiler's own column numbers, which are byte-based too — and only
+// `\n` advances the line, so a `\r\n` pair is one line break, not two.
+// `offset` may equal `len(src)` (an error at EOF, e.g. an unterminated
+// object): the loop below still runs to completion and reports the position
+// just past the last byte, never an out-of-range value or a silent zero.
+//
+// O(offset): a full scan from the start of `src`. Only ever called from
+// `posError`, below, while building an error — the success path never
+// touches this, so a well-formed document of any size pays nothing extra
+// (#2293 is about exactly that path).
+fn jsonLocate(src: string, offset: int): JsonPos {
+  let stop = offset
+  if (stop > len(src)) {
+    stop = len(src)
+  }
+  let line = 1
+  let lineStart = 0
+  let i = 0
+  while (i < stop) {
+    if (src[i] == '\n') {
+      line = line + 1
+      lineStart = i + 1
+    }
+    i = i + 1
+  }
+  return JsonPos{ line: line, column: stop - lineStart + 1 }
+}
+
+// Builds a parse error carrying `msg` plus its byte offset and line:column in
+// `src`, e.g. `"json: expected ',' or '}' in object at byte 410 (line 1,
+// column 411)"` (#2286). The byte offset is the load-bearing part — what a
+// program slices or seeks with; line:column is what a human reads, in the
+// same 1-based numbering compiler/diagnostics.bit uses for `--> file:L:C`.
+fn posError(src: string, msg: string, offset: int): error {
+  let loc = jsonLocate(src, offset)
+  return newError("${msg} at byte ${offset} (line ${loc.line}, column ${loc.column})")
+}
+
+// An `Invalid` token can come from four places in the lexer (scanOpen on a
+// depth-cap hit, scanString on an unterminated string, an unterminated `/*`
+// (JSONC only), everything else), and the token itself carries no reason —
+// only a span. The source byte at that span disambiguates deterministically:
+// `scanOpen` is the only path that marks a `{`/`[` byte `Invalid` (a plain
+// unexpected `{`/`[` always lexes as `LBrace`/`LBracket`), `scanString` is
+// the only path that marks a `"` byte `Invalid`, and an unterminated `/*`
+// is the only `Invalid` starting on `/` whose span is more than one byte (a
+// lone stray `/` is always a single-byte `Invalid`).
+fn describeInvalid(src: string, start: int, end: int): string {
+  let c = src[start]
+  if (c == '{' || c == '[') {
+    return "json: max nesting depth exceeded"
+  }
+  if (c == '"') {
+    return "json: unterminated string"
+  }
+  if (c == '/' && end - start > 1) {
+    return "json: unterminated block comment"
+  }
+  return "json: unexpected character in input"
+}
+
+fn parseValue(p: Parser): Json! {
+  let kind = p.lx.kind
+  // Captured before `advance` overwrites the cursor: the span belongs to the
+  // token being consumed, not to the one after it.
+  let start = p.lx.start
+  let end = p.lx.end
+  if (kind == TokenKind.LBrace) {
+    return parseObject(p)?
+  }
+  if (kind == TokenKind.LBracket) {
+    return parseArray(p)?
+  }
+  if (kind == TokenKind.StringTok) {
+    advance(p)
+    return Json.JsonString(decodeStringLiteral(p.src, start, end)?)
+  }
+  if (kind == TokenKind.NumberTok) {
+    advance(p)
+    return decodeNumber(p.src, start, end)?
+  }
+  if (kind == TokenKind.TrueTok) {
+    advance(p)
+    return Json.JsonBool(true)
+  }
+  if (kind == TokenKind.FalseTok) {
+    advance(p)
+    return Json.JsonBool(false)
+  }
+  if (kind == TokenKind.NullTok) {
+    advance(p)
+    return Json.JsonNull
+  }
+  if (kind == TokenKind.Invalid) {
+    fail posError(p.src, describeInvalid(p.src, start, end), start)
+  }
+  fail posError(p.src, "json: unexpected token, expected a value", start)
+}
+
+// `{` was already peeked by the caller. Every entry is kept, including a
+// repeated key — see this file's header comment for why.
+fn parseObject(p: Parser): Json! {
+  advance(p)
+  let entries = []JsonEntry(0, jsonSmallCap)
+  if (p.lx.kind == TokenKind.RBrace) {
+    advance(p)
+    return Json.JsonObject(entries)
+  }
+  // Bounded by the token count: each iteration consumes at least a key, a
+  // colon, a value, and a comma, so the loop cannot outrun a finite stream.
+  let guard = 0
+  let bound = tokenBound(p)
+  while (guard <= bound) {
+    if (p.lx.kind != TokenKind.StringTok) {
+      fail posError(p.src, "json: expected string key", p.lx.start)
+    }
+    let keyStart = p.lx.start
+    let keyEnd = p.lx.end
+    advance(p)
+    let key = decodeObjectKey(p, keyStart, keyEnd)?
+    if (p.lx.kind != TokenKind.Colon) {
+      fail posError(p.src, "json: expected ':' after object key", p.lx.start)
+    }
+    advance(p)
+    let val = parseValue(p)?
+    entries = append(entries, JsonEntry{ key: key, value: val })
+    if (p.lx.kind == TokenKind.RBrace) {
+      advance(p)
+      return Json.JsonObject(entries)
+    }
+    if (p.lx.kind != TokenKind.Comma) {
+      fail posError(p.src, "json: expected ',' or '}' in object", p.lx.start)
+    }
+    advance(p)
+    // JSONC: a single trailing comma closes the object right here. A second
+    // one does not — the cursor would be `Comma` again, so the loop falls
+    // through to "expected string key" on the next iteration.
+    if (p.allowTrailingComma && p.lx.kind == TokenKind.RBrace) {
+      advance(p)
+      return Json.JsonObject(entries)
+    }
+    guard = guard + 1
+  }
+  fail posError(p.src, "json: object nesting exceeds token bound", p.lx.start)
+}
+
+// `[` was already peeked by the caller.
+fn parseArray(p: Parser): Json! {
+  advance(p)
+  let items = []Json(0, jsonSmallCap)
+  if (p.lx.kind == TokenKind.RBracket) {
+    advance(p)
+    return Json.JsonArray(items)
+  }
+  let guard = 0
+  let bound = tokenBound(p)
+  while (guard <= bound) {
+    let v = parseValue(p)?
+    items = append(items, v)
+    if (p.lx.kind == TokenKind.RBracket) {
+      advance(p)
+      return Json.JsonArray(items)
+    }
+    if (p.lx.kind != TokenKind.Comma) {
+      fail posError(p.src, "json: expected ',' or ']' in array", p.lx.start)
+    }
+    advance(p)
+    // JSONC: a single trailing comma closes the array right here. A second
+    // one does not — the cursor would be `Comma` again, so `parseValue` on the
+    // next iteration rejects it ("unexpected token, expected a value").
+    if (p.allowTrailingComma && p.lx.kind == TokenKind.RBracket) {
+      advance(p)
+      return Json.JsonArray(items)
+    }
+    guard = guard + 1
+  }
+  fail posError(p.src, "json: array nesting exceeds token bound", p.lx.start)
+}
+
+// --- numbers -----------------------------------------------------------
+
+// Validates RFC 8259 §6's number grammar over `src[start:end]` and classifies
+// it in the same pass: `0` invalid, `1` an integer literal (no `.`/`e`/`E`),
+// `2` a float literal. `lex`'s own comment says it "does not reject a
+// malformed literal — that check belongs to the parser task consuming this
+// stream"; this is that check.
+//
+// Span-based (#2293) rather than taking a `string`: `decodeNumber` used to
+// materialize `src[t.start:t.end]` before validating it, then scan that same
+// substring twice more (`contains(text, ".")`, `contains(text, "e"/"E")`) to
+// decide int vs float. Every JSON number in a document takes this path, so on
+// a large document that was one throwaway allocation (`rtStringSlice` copies)
+// plus three full scans per number for information this single pass already
+// has by the time it returns. `decodeNumber` now only slices `src` when it
+// actually needs an owned `string` — the float path, where `parseFloat` takes
+// one.
+// The integer part (`'0' | [1-9][0-9]*`) at `src[i:end]`, returning the
+// position just past it, or -1 if `src[i]` does not start a valid one. Split
+// out of `classifyJsonNumber` (#2448).
+fn classifyIntPart(src: string, i: int, end: int): int {
+  if (src[i] == '0') {
+    return i + 1
+  }
+  if (src[i] >= '1' && src[i] <= '9') {
+    let j = i + 1
+    while (j < end && isDigit(src[j])) {
+      j = j + 1
+    }
+    return j
+  }
+  return -1
+}
+
+// Whether an optional `.digit+` fraction starts at `src[i]`. A predicate so
+// `classifyJsonNumber` can fold it into `isFloat` without `classifyFraction`
+// having to return a second value: a class return allocated one heap object
+// per number token (#3617).
+fn hasFraction(src: string, i: int, end: int): bool {
+  return i < end && src[i] == '.'
+}
+
+// The optional `.digit+` fraction at `src[i:end]`, returning the position
+// just past it -- `i` unchanged when there is no fraction -- or -1 for a
+// malformed one (a '.' with no digit after it). Split out of
+// `classifyJsonNumber` (#2448).
+fn classifyFraction(src: string, i: int, end: int): int {
+  if (!hasFraction(src, i, end)) {
+    return i
+  }
+  let j = i + 1
+  if (j >= end || !isDigit(src[j])) {
+    return -1
+  }
+  while (j < end && isDigit(src[j])) {
+    j = j + 1
+  }
+  return j
+}
+
+fn isExpMarker(c: u8): bool {
+  return c == 'e' || c == 'E'
+}
+
+// Whether an optional `[eE][+-]?digit+` exponent starts at `src[i]`.
+fn hasExponent(src: string, i: int, end: int): bool {
+  return i < end && isExpMarker(src[i])
+}
+
+// The optional `[eE][+-]?digit+` exponent at `src[i:end]`, same
+// position/-1 convention as `classifyFraction`. Split out of
+// `classifyJsonNumber` (#2448).
+fn classifyExponent(src: string, i: int, end: int): int {
+  if (!hasExponent(src, i, end)) {
+    return i
+  }
+  let j = i + 1
+  if (j < end && (src[j] == '+' || src[j] == '-')) {
+    j = j + 1
+  }
+  if (j >= end || !isDigit(src[j])) {
+    return -1
+  }
+  while (j < end && isDigit(src[j])) {
+    j = j + 1
+  }
+  return j
+}
+
+fn classifyJsonNumber(src: string, start: int, end: int): int {
+  let i = start
+  if (i >= end) {
+    return 0
+  }
+  if (src[i] == '-') {
+    i = i + 1
+  }
+  if (i >= end) {
+    return 0
+  }
+  i = classifyIntPart(src, i, end)
+  if (i < 0) {
+    return 0
+  }
+  let isFloat = hasFraction(src, i, end)
+  i = classifyFraction(src, i, end)
+  if (i < 0) {
+    return 0
+  }
+  isFloat = isFloat || hasExponent(src, i, end)
+  i = classifyExponent(src, i, end)
+  if (i < 0) {
+    return 0
+  }
+  if (i != end) {
+    return 0
+  }
+  if (isFloat) {
+    return 2
+  }
+  return 1
+}
+
+// True when `s` matches RFC 8259 §6's number grammar (see
+// `classifyJsonNumber`, which does the actual walk). Kept as a `string`
+// entry point for `cst_parse.bit`, which already holds a decoded raw span as
+// a `string` rather than a `(src, start, end)` triple.
+fn isValidJsonNumber(s: string): bool {
+  return classifyJsonNumber(s, 0, len(s)) != 0
+}
+
+// A literal with no `.`/`e`/`E` that fits `i64` decodes to `JsonInt`; anything
+// wider, or with a fraction/exponent, decodes to `JsonFloat` via the
+// runtime's own `parseFloat` primitive so it can never drift a ULP from the
+// canonical parse (#1479's number-handling decision).
+fn decodeNumber(src: string, start: int, end: int): Json! {
+  let kind = classifyJsonNumber(src, start, end)
+  if (kind == 0) {
+    fail posError(src, "json: invalid number literal", start)
+  }
+  if (kind == 2) {
+    return Json.JsonFloat(parseFloat(src[start:end]))
+  }
+  let iv = parseJsonIntSpan(src, start, end) catch _ {
+    return Json.JsonFloat(parseFloat(src[start:end]))
+  }
+  return Json.JsonInt(iv)
+}
+
+// The i64 that the integral literal `src[start:end]` (already validated by
+// `classifyJsonNumber` — optional `-`, then only digits) denotes, over the
+// FULL i64 range including MIN (-9223372036854775808). The literal's
+// magnitude alone has no positive i64 representation, so a positive
+// accumulator (as `strings.parseInt` uses) always overflows one past `i64`
+// MAX before the sign is applied; this accumulates negatively instead, which
+// has exactly the headroom the positive side lacks. Fails (falling back to
+// `JsonFloat` in `decodeNumber`) only when the magnitude exceeds even that.
+//
+// Span-based (#2293), not a `text: string` parameter: `decodeNumber` used to
+// materialize the literal into its own string before calling this, purely so
+// this could re-index it — a wasted allocation and copy for what is already
+// a validated slice of `src`.
+fn parseJsonIntSpan(src: string, start: int, end: int): i64! {
+  let i = start
+  let neg = false
+  if (src[i] == '-') {
+    neg = true
+    i = i + 1
+  }
+  // i64 MIN = -9223372036854775808 = -922337203685477580 * 10 - 8.
+  let minDiv10 = i64(-922337203685477580)
+  let minMod10 = i64(8)
+  let v = i64(0)
+  while (i < end) {
+    let d = i64(src[i] - '0')
+    if (v < minDiv10 || (v == minDiv10 && d > minMod10)) {
+      fail posError(src, "json: number out of i64 range", start)
+    }
+    v = v * 10 - d
+    i = i + 1
+  }
+  if (neg) {
+    return v
+  }
+  // Positive side: v accumulated as if negative, so negate back, but reject
+  // i64 MIN itself (v == i64 MIN has no positive negation).
+  if (v == minDiv10 * 10 - minMod10) {
+    fail posError(src, "json: number out of i64 range", start)
+  }
+  return 0 - v
+}
+
+// --- strings -------------------------------------------------------------
+
+// An object key's decoded text: `decodeStringLiteral` with its escape-free
+// branch routed through this parser's key cache (#4358). An escaped key still
+// goes through the Builder — it does not borrow `src`, so there is nothing to
+// share. Interning changes a key's IDENTITY, never its bytes, and nothing here
+// compares keys by identity (`jsonGet` uses `==`), so `"a\u0062"` and `"ab"`
+// stay the same key and `"a\"b"` stays a different one, exactly as before.
+fn decodeObjectKey(p: Parser, tokStart: int, tokEnd: int): string! {
+  let start = tokStart + 1
+  let end = tokEnd - 1
+  let firstEscape = scanEscape(p.src, start, end)?
+  if (firstEscape < 0) {
+    return internKey(p, start, end)
+  }
+  return decodeEscaped(p.src, start, end, firstEscape)?
+}
+
+// A string equal to `src[start:end]`, reusing the one this parser already made
+// for that key when it has seen it before.
+//
+// WHY KEYS AND NOT VALUES: the escape-free path returns `src[start:end]`, a
+// fresh 24-byte header object (#3897) even though it borrows the source bytes
+// rather than copying them. Keys are the one part of a document that repeats —
+// bench/cases/json is 150,000 records over the same four keys, so 600,000
+// headers naming one of four strings — while values do not repeat.
+//
+// The slot mixes the first byte, the last byte and the length, so keys sharing
+// a prefix (`user_id`/`user_name`) land apart. A collision costs a miss, never
+// a wrong answer: the occupant is compared byte for byte against the span
+// before it is reused, and a miss overwrites the slot. An empty slot holds the
+// zero-value string, of length 0, so it can only "match" a zero-length key —
+// and answering `""` for a `""` key is correct.
+fn internKey(p: Parser, start: int, end: int): string {
+  let n = end - start
+  if (n == 0) {
+    return ""
+  }
+  if (len(p.keyCache) == 0) {
+    p.keyCache = []string(jsonKeyCacheSlots, jsonKeyCacheSlots)
+  }
+  let mixed = int(p.src[start]) ^ (int(p.src[end - 1]) << 3) ^ n
+  let slot = mixed & (jsonKeyCacheSlots - 1)
+  let cached = p.keyCache[slot]
+  if (len(cached) == n && spanEqualsKey(p.src, start, cached, n)) {
+    return cached
+  }
+  let fresh = p.src[start:end]
+  p.keyCache[slot] = fresh
+  return fresh
+}
+
+// True when `src`'s `n` bytes from `start` are `key`'s `n` bytes. Reads the
+// span in place — the point of the cache is to answer before materializing the
+// slice, so this cannot be a string `==`. The caller has already checked
+// `len(key) == n`, which bounds both walks.
+fn spanEqualsKey(src: string, start: int, key: string, n: int): bool {
+  let i = 0
+  while (i < n) {
+    if (src[start + i] != key[i]) {
+      return false
+    }
+    i = i + 1
+  }
+  return true
+}
+
+// Decodes a `StringTok`'s raw span (quotes included, escapes raw — see
+// lex.bit) into its string value: every RFC 8259 §7 escape, including a
+// `\uXXXX` surrogate pair for an astral codepoint. An invalid escape is a
+// parse error, never a panic. `lex` only ever emits `StringTok` for a span
+// that found its closing quote, so `[start+1, end-1)` is always the content
+// between the quotes.
+//
+// Fast path (#2293): most JSON strings — object keys, plain text values —
+// carry no `\` escape at all. A single pre-scan for the first `\` (a raw
+// control byte is invalid either way and fails immediately) lets an
+// escape-free span return as a direct sub-slice of `src`, with no Builder
+// call at all. Skipping this made the escape-decoding loop below run once
+// per byte even for a string with zero escapes: `Builder.writeByte` copies
+// the whole accumulated buffer on every call (#2112), so decoding an L-byte
+// escape-free string cost O(L^2). A string that does contain an escape still
+// goes through the byte-by-byte loop from that point on, batched from one
+// Builder call per escape-free run instead of one per byte.
+fn decodeStringLiteral(src: string, tokStart: int, tokEnd: int): string! {
+  let start = tokStart + 1
+  let end = tokEnd - 1
+  let firstEscape = scanEscape(src, start, end)?
+  if (firstEscape < 0) {
+    return src[start:end]
+  }
+  return decodeEscaped(src, start, end, firstEscape)?
+}

--- a/samples/Bit/regex.bit
+++ b/samples/Bit/regex.bit
@@ -1,0 +1,144 @@
+// std/regex: RE2-style pattern matching, matched by a Pike-VM NFA
+// simulation rather than backtracking. compile()/mustCompile() build an
+// immutable Regex; matches/find/findAll search it; split/replaceAll/
+// replaceFirst use those matches to cut or rewrite text. See
+// docs/stdlib/regex.md for the full syntax.
+
+import { compile, mustCompile } from "std/regex"
+import { join } from "std/strings"
+
+// compile() is fallible: a malformed pattern is a `regex: <reason> at
+// offset <n>` error, not a panic — the right shape when the pattern comes
+// from outside the program (a user, a config file) and cannot be trusted.
+fn showCompileError() {
+  let re = compile("[a-") catch e {
+    println("compile(\"[a-\") failed: ${e.message()}")
+    return
+  }
+  println("unexpectedly compiled: ${re.pattern()}")
+}
+
+// mustCompile() panics instead of returning an error — the right shape for
+// a pattern the author controls, known good at write time and typically
+// compiled once, then shared. matches() is an unanchored yes/no check.
+fn showMatches() {
+  let identifier = mustCompile("^[A-Za-z_][A-Za-z0-9_]*$")
+  println("matches(\"count_1\")  = ${identifier.matches("count_1")}")
+  println("matches(\"2count\")   = ${identifier.matches("2count")}")
+  println("matches(\"my-count\") = ${identifier.matches("my-count")}")
+}
+
+// find() returns Option<Match> — None when there is no match anywhere in
+// the subject. Matching over the Option is the idiom: it forces both the
+// found and not-found cases to be handled, like any other Option here.
+fn showFind() {
+  let email = mustCompile("[a-z0-9.]+@[a-z0-9.]+")
+  let withAddress = "contact: admin@example.com for support"
+  match (email.find(withAddress)) {
+    Some(m) => println("found: ${m.text(withAddress)}")
+    None => println("no match")
+  }
+  let withoutAddress = "no address in this line"
+  match (email.find(withoutAddress)) {
+    Some(m) => println("found: ${m.text(withoutAddress)}")
+    None => println("no match")
+  }
+}
+
+// findAll() scans left to right for non-overlapping matches. `limit` is NOT
+// "how many to skip first": negative means unlimited, 0 returns
+// immediately with zero matches (never "unlimited" — the guess a reader
+// used to a 0-means-default convention would make), and a positive limit
+// caps the count.
+fn showFindAll() {
+  let word = mustCompile("\\bfox\\b")
+  let s = "the quick fox jumps over the lazy fox while another fox watches"
+  let unlimited = word.findAll(s, -1)
+  println("findAll(s, -1): ${len(unlimited)} occurrence(s) of \"fox\"")
+  let zero = word.findAll(s, 0)
+  println("findAll(s, 0):  ${len(zero)} occurrence(s) (0 means none, not unlimited)")
+  let capped = word.findAll(s, 2)
+  println("findAll(s, 2):  ${len(capped)} occurrence(s) (capped)")
+}
+
+// A named capture group, (?P<name>...), is the most useful shape in
+// practice: pull a structured field out of matched text by name instead of
+// counting parentheses. Read back with Match.named(); the plain numeric
+// index still works too, via Match.group(i), 1-based (group(0) is always
+// the whole match).
+fn showNamedGroups() {
+  let iso = mustCompile("(?P<year>[0-9]{4})-(?P<month>[0-9]{2})-(?P<day>[0-9]{2})")
+  println("pattern:     ${iso.pattern()}")
+  println("groupCount:  ${iso.groupCount()}")
+  println("groupNames:  [${join(iso.groupNames(), ", ")}]")
+
+  let line = "log entry from 2024-03-09: service restarted"
+  match (iso.find(line)) {
+    Some(m) => {
+      println("matched \"${m.text(line)}\" at [${m.start}, ${m.end})")
+      match (m.named("year")) {
+        Some(g) => println("year (named):    ${g.text(line)}")
+        None => println("year: not captured")
+      }
+      match (m.group(2)) {
+        Some(g) => println("month (group 2): ${g.text(line)}")
+        None => println("month: not captured")
+      }
+    }
+    None => println("no date found")
+  }
+}
+
+// replaceAll() rewrites every match; replaceFirst() only the leftmost one.
+// Both expand a `$`-template against that match's own capture groups —
+// `${name}` for a named group here; `\$` escapes the interpreted string's
+// own interpolation so the literal template text (with its real `${...}`)
+// reaches replaceAll/replaceFirst unchanged.
+fn showReplace() {
+  let iso = mustCompile("(?P<year>[0-9]{4})-(?P<month>[0-9]{2})-(?P<day>[0-9]{2})")
+  let dates = "start: 2024-03-09, end: 2024-04-01"
+  let repl = "\${month}/\${day}/\${year}"
+  println("replaceAll:   ${iso.replaceAll(dates, repl)}")
+  println("replaceFirst: ${iso.replaceFirst(dates, repl)}")
+}
+
+// split() cuts a subject at each non-overlapping match, using the same
+// limit convention as findAll: negative is unlimited, 0 returns
+// immediately with no pieces, and a positive limit caps the piece count —
+// the final piece absorbs everything left, matches included.
+fn showSplit() {
+  let ws = mustCompile("\\s+")
+  let s = "  the   quick brown  fox "
+  let all = ws.split(s, -1)
+  println("split(s, -1): ${len(all)} piece(s): [${join(all, "|")}]")
+  let zero = ws.split(s, 0)
+  println("split(s, 0):  ${len(zero)} piece(s)")
+  let two = ws.split(s, 2)
+  println("split(s, 2):  ${len(two)} piece(s): [${join(two, "|")}]")
+}
+
+// (?i) makes the whole pattern case-insensitive, using full Unicode simple
+// case folding — not just ASCII A-Z/a-z.
+fn showCaseInsensitive() {
+  let ci = mustCompile("(?i)^hello$")
+  println("matches(\"HELLO\") = ${ci.matches("HELLO")}")
+  println("matches(\"hello\") = ${ci.matches("hello")}")
+  println("matches(\"Hxllo\") = ${ci.matches("Hxllo")}")
+}
+
+fn main() {
+  showCompileError()
+  showMatches()
+  showFind()
+  showFindAll()
+  showNamedGroups()
+  showReplace()
+  showSplit()
+  showCaseInsensitive()
+}
+
+// The guarantee behind every call above: matching runs a Pike-VM NFA
+// simulation in O(len(input) x len(program)) time, never backtracking —
+// there are no backreferences and no lookaround, because both require
+// backtracking to evaluate. No pattern this module accepts can blow up on
+// adversarial input.

--- a/samples/Bit/staticserver.bit
+++ b/samples/Bit/staticserver.bit
@@ -1,0 +1,390 @@
+// A static file server - the `serve`-a-directory shape, in Bit.
+//
+// A demonstration AND a test: it creates a small site in a temp directory, serves
+// it, fetches every interesting path through the real HTTP client, checks the
+// answers, and exits non-zero if any is wrong. The examples harness runs it on
+// every change, so the serving logic below cannot rot.
+//
+// server/serve.bit in the SEPARATE repo byteink/bit-website holds its own
+// fileResponse/mimeFor and, as of #3953, its own COPY of what is now
+// std/path's safePath — this example imports the real one instead of
+// keeping a third copy. That website copy is still separate and ungated
+// from here: a fix to std/path's safePath is not mirrored there
+// automatically, and nothing mechanical will catch that divergence either.
+//
+// The serving logic is `fileResponse` plus `mimeFor` - about forty lines. The
+// rest is the harness that proves it.
+//
+// Deliberately NOT here: TLS. Traefik terminates it on the byteink cluster, so a
+// server behind it speaks plain HTTP on a container port and never touches a
+// certificate. Half the risk surface of a public server, removed by deployment
+// shape rather than by code.
+
+import { serve, get, respond, Server, Exchange, Request, Response } from "std/http"
+import { readFile, writeFile, mkdir, remove, exists, isDir, isSymlink } from "std/fs"
+import { hasSuffix, contains, indexOf } from "std/strings"
+import { safePath } from "std/path"
+
+// How many requests the demo serves before shutting down. A real deployment
+// calls the accept loop forever; an example must terminate, and the examples
+// harness kills anything that does not (_tests_/bit/examplesgate.bit's deadline).
+// One more than `main`'s `expect`/`expectBlocked` call count, or the extra
+// request dials a server that already closed.
+const demoRequests = 7
+
+// The directory served. A single value so the traversal guard and the file
+// lookup cannot disagree about what "inside" means.
+class Site { root: string }
+
+// --- #2397 regression fixture -----------------------------------------------
+//
+// A directory OUTSIDE `Site.root`, holding one file the server must never
+// serve, and a symbolic link INSIDE `Site.root` pointing at it. Fixed paths
+// alongside `Site.root`'s own, for the same reason: this is a regression
+// test for one specific escape, not a general-purpose fixture.
+const escapeOutsideDir = "/tmp/bit-staticserver-outside"
+const escapeMarker = "OUTSIDE THE SITE ROOT\n"
+
+// --- the actual server ------------------------------------------------------
+
+// The response for one request path.
+//
+// Three rules, in this order, because the order is the security property:
+//  1. Reject anything that could escape `root` BEFORE touching the filesystem.
+//  2. Map a directory-ish path to its index.html.
+//  3. Read the file, or 404.
+fn fileResponse(site: Site, path: string): Response {
+  if (!safePath(path)) {
+    // 400, not 404: the request is malformed, and answering 404 would invite a
+    // caller to keep guessing paths.
+    return respond(400, "bad request path\n")
+  }
+
+  let rel = path
+  if (rel == "/" || hasSuffix(rel, "/")) {
+    rel = "${rel}index.html"
+  }
+
+  let full = "${site.root}${rel}"
+  // A directory reached without a trailing slash would otherwise be read as a
+  // file, which fails with a confusing error instead of an honest 404.
+  if (isDir(full)) {
+    full = "${full}/index.html"
+  }
+
+  // `safePath` above is lexical and answers BEFORE any syscall (rule 1) - it
+  // cannot see a symbolic link planted INSIDE the root, and `isDir` just
+  // above and `readFile` just below both FOLLOW links. So ask the filesystem
+  // directly, now that `full` is fully composed: walk every component below
+  // `site.root` and refuse if any is a link. 404, not 400 - the request was
+  // well formed, the filesystem answered otherwise.
+  if (hasSymlinkComponent(site.root, full)) {
+    return respond(404, "not found\n")
+  }
+
+  let body = readFile(full) catch e {
+    return respond(404, "not found\n")
+  }
+  return Response{ status: 200, contentType: mimeFor(full), headers: "", body: body }
+}
+
+// Whether any path component of `full` strictly below `root` is a symbolic
+// link - walked from `root` outward, never testing only the leaf:
+// `<root>/a/b.txt` escapes just as well when `a` is the link as when the
+// file itself is. `full` always has `root` as an exact prefix here
+// (`fileResponse` composes it that way, with no trailing slash on `root`),
+// so scanning starts right after the separator between them and each `/`
+// found after that marks the end of one more component to probe.
+fn hasSymlinkComponent(root: string, full: string): bool {
+  let i = len(root) + 1
+  while (i < len(full)) {
+    if (full[i] == '/') {
+      if (isSymlink(full[0:i])) {
+        return true
+      }
+    }
+    i = i + 1
+  }
+  return isSymlink(full)
+}
+
+// Content-Type from the file extension. Only what this site actually serves,
+// plus the few a static site grows into. An unknown extension gets
+// application/octet-stream - a browser downloads it instead of guessing, which
+// is the safe default when the server does not know what it is handing over.
+fn mimeFor(path: string): string {
+  if (hasSuffix(path, ".html")) {
+    return "text/html; charset=utf-8"
+  }
+  if (hasSuffix(path, ".css")) {
+    return "text/css; charset=utf-8"
+  }
+  if (hasSuffix(path, ".js")) {
+    return "text/javascript; charset=utf-8"
+  }
+  if (hasSuffix(path, ".json")) {
+    return "application/json; charset=utf-8"
+  }
+  if (hasSuffix(path, ".svg")) {
+    return "image/svg+xml"
+  }
+  if (hasSuffix(path, ".png")) {
+    return "image/png"
+  }
+  if (hasSuffix(path, ".ico")) {
+    return "image/x-icon"
+  }
+  if (hasSuffix(path, ".txt")) {
+    return "text/plain; charset=utf-8"
+  }
+  // The installers: text/plain so a browser SHOWS the script a stranger is about
+  // to pipe into their shell, instead of downloading an opaque blob. Anyone
+  // sensible reads it first, and the content type is what lets them.
+  if (hasSuffix(path, ".sh")) {
+    return "text/plain; charset=utf-8"
+  }
+  if (hasSuffix(path, ".ps1")) {
+    return "text/plain; charset=utf-8"
+  }
+  if (hasSuffix(path, ".xml")) {
+    return "application/xml; charset=utf-8"
+  }
+  // A file with NO extension at all is text by convention - README, LICENSE,
+  // Makefile. Handing those back as octet-stream makes a browser download a text
+  // file instead of showing it.
+  //
+  // Narrower than it looks: this is the no-dot case only. An UNKNOWN extension
+  // still falls through to octet-stream below, because there the server has been
+  // told a type it does not recognise and guessing text would be a guess.
+  if (!hasExtension(path)) {
+    return "text/plain; charset=utf-8"
+  }
+  return "application/octet-stream"
+}
+
+// Does the final path segment carry a `.`? Scanned from the end so a dot in a
+// PARENT directory (`/v1.2/notes`) cannot be mistaken for this file's extension.
+fn hasExtension(path: string): bool {
+  let i = len(path)
+  while (i > 0) {
+    let c = path[i - 1]
+    if (c == '/') {
+      return false
+    }
+    if (c == '.') {
+      return true
+    }
+    i = i - 1
+  }
+  return false
+}
+
+// One exchange, on its own green thread: reads the request here, off the
+// accept loop, so a slow or stalled peer only ever blocks this one exchange.
+fn handle(ex: Exchange, site: Site) {
+  let req = ex.read() catch e {
+    ex.respond(respond(400, "bad request\n")) catch e2 {
+      return
+    }
+    return
+  }
+  ex.respond(fileResponse(site, req.path)) catch e {
+    print("respond: ${e.message()}\n")
+  }
+}
+
+// The accept loop, bounded for the demo. A deployment would drop the counter and
+// loop forever; nothing else about it would change.
+fn serveFiles(s: Server, site: Site, n: int, ready: chan<int>) {
+  ready <- 0
+  let i = 0
+  while (i < n) {
+    let ex = s.accept() catch e {
+      print("accept: ${e.message()}\n")
+      return
+    }
+    spawn handle(ex, site)
+    i = i + 1
+  }
+  s.close()
+}
+
+// --- the self-test ----------------------------------------------------------
+
+// `: int` because this returns an exit code - a failed check must fail the
+// examples harness, not just print. Returning normally would exit 0 and a broken
+// traversal guard would pass CI silently.
+fn main(): int {
+  let site = Site{ root: "/tmp/bit-staticserver-demo" }
+  setupSite(site)
+  if (!makeEscapeLink(site.root)) {
+    print("setup: could not create the #2397 symlink fixture\n")
+    cleanupSite(site)
+    return 1
+  }
+
+  let s = serve("127.0.0.1", 0) catch e {
+    print("serve: ${e.message()}\n")
+    return 1
+  }
+  let port = s.port() catch e {
+    print("port: ${e.message()}\n")
+    return 1
+  }
+
+  let ready = chan<int>(1)
+  spawn serveFiles(s, site, demoRequests, ready)
+  let started = <- ready
+
+  let base = "http://127.0.0.1:${port}"
+  let failures = 0
+
+  // A directory request serves its index.
+  failures = failures + expect(base, "/", 200, "<h1>home</h1>")
+  // An explicit file.
+  failures = failures + expect(base, "/index.html", 200, "<h1>home</h1>")
+  // A nested path, and the stylesheet's content type.
+  failures = failures + expect(base, "/style.css", 200, "body{}")
+  failures = failures + expect(base, "/docs/", 200, "<h1>docs</h1>")
+  // A missing file is 404, not a crash.
+  failures = failures + expect(base, "/nope.html", 404, "not found")
+  // Traversal is refused before the filesystem is touched. /etc/passwd exists on
+  // every host this runs on, so a server that resolved this would leak it.
+  failures = failures + expect(base, "/../../../../etc/passwd", 400, "bad request path")
+  // #2397: a symlink placed INSIDE the root, pointing outside it. `safePath`
+  // cannot see this - it is lexical and answers before any syscall - so this
+  // is the one check here that exercises the filesystem-facing half of the
+  // guard rather than the request-string half.
+  failures = failures + expectBlocked(base, "/escape/secret.txt")
+
+  cleanupEscapeLink(site.root)
+  cleanupSite(site)
+
+  if (failures > 0) {
+    print("staticserver: ${failures} check(s) FAILED\n")
+    return 1
+  }
+  print("staticserver: all checks passed\n")
+  return 0
+}
+
+// Fetches `base + path` and checks status and body. Prints one line per check
+// either way, so a failure in CI says which case broke.
+//
+// It prints `path`, never the full URL, and that is load-bearing rather than
+// cosmetic: the port is EPHEMERAL (serve(host, 0)), and
+// scripts/selfhost-diffexamples.sh compares this program's stdout, built by the
+// pinned stage0 and built by this tree, byte for byte. Printing the URL made
+// every run a DIFF - the gate reported a miscompile when the only difference was
+// a kernel-assigned port.
+fn expect(base: string, path: string, status: int, bodyHas: string): int {
+  let res = get("${base}${path}") catch e {
+    print("FAIL ${path}: ${e.message()}\n")
+    return 1
+  }
+  if (res.status != status) {
+    print("FAIL ${path}: status ${res.status}, want ${status}\n")
+    return 1
+  }
+  if (len(bodyHas) > 0 && !contains(res.body, bodyHas)) {
+    print("FAIL ${path}: body ${res.body}, want it to contain ${bodyHas}\n")
+    return 1
+  }
+  print("ok   ${path} -> ${res.status}\n")
+  return 0
+}
+
+// Fetches `base + path` and asserts the traversal guard blocked it: status
+// 404, and the response never carries `escapeMarker` (the outside file's
+// exact contents). Two checks rather than `expect`'s one, because a leaked
+// body that happens to also 404 is exactly the failure this must catch.
+fn expectBlocked(base: string, path: string): int {
+  let res = get("${base}${path}") catch e {
+    print("FAIL ${path}: ${e.message()}\n")
+    return 1
+  }
+  if (res.status != 404) {
+    print("FAIL ${path}: status ${res.status}, want 404\n")
+    return 1
+  }
+  if (contains(res.body, escapeMarker)) {
+    print("FAIL ${path}: response leaked content from outside the root\n")
+    return 1
+  }
+  print("ok   ${path} -> ${res.status} (blocked)\n")
+  return 0
+}
+
+// A tiny site on disk: a home page, a stylesheet, and a subdirectory with its own
+// index, which is what exercises the directory-to-index rule.
+fn setupSite(site: Site) {
+  mkdir(site.root) catch e {
+    print("setup: mkdir ${site.root}: ${e.message()}\n")
+  }
+  mkdir("${site.root}/docs") catch e {
+    print("setup: mkdir docs: ${e.message()}\n")
+  }
+  writeFile("${site.root}/index.html", "<h1>home</h1>\n") catch e {
+    print("setup: ${e.message()}\n")
+  }
+  writeFile("${site.root}/style.css", "body{}\n") catch e {
+    print("setup: ${e.message()}\n")
+  }
+  writeFile("${site.root}/docs/index.html", "<h1>docs</h1>\n") catch e {
+    print("setup: ${e.message()}\n")
+  }
+}
+
+// The #2397 fixture: a directory OUTSIDE `root` holding one file, and a
+// symbolic link named `escape` INSIDE `root` pointing at it. `std/fs` has no
+// `symlink` (and a link cannot be committed to the repo as a plain file), so
+// - exactly as `_tests_/cases/fs_walk_symlink.bit` does for the same reason -
+// the link comes from a shell script run with `osRun`.
+fn makeEscapeLink(root: string): bool {
+  if (!exists(escapeOutsideDir)) {
+    mkdir(escapeOutsideDir) catch _ {
+      return false
+    }
+  }
+  writeFile("${escapeOutsideDir}/secret.txt", escapeMarker) catch _ {
+    return false
+  }
+  let script = "${escapeOutsideDir}/link.sh"
+  // `-f`: idempotent against a symlink left by a prior run that crashed
+  // before `cleanupEscapeLink` ran, same as `site.root`'s own fixed path.
+  let body = "#!/bin/sh\nln -sf '${escapeOutsideDir}' '${root}/escape' || exit 1\n"
+  writeFile(script, body) catch _ {
+    return false
+  }
+  if (fsChmod(script, 448) != 0) { // 0o700: owner rwx only
+    return false
+  }
+  return osRun(script, []string(0)) == 0
+}
+
+// Best-effort: a leftover temp file is not worth failing a run over, but the
+// language will not accept an empty `catch` - and it is right not to, since that
+// is exactly how a real error gets swallowed. So each one says what it ignored.
+fn cleanupSite(site: Site) {
+  rm("${site.root}/docs/index.html")
+  rm("${site.root}/index.html")
+  rm("${site.root}/style.css")
+  rm("${site.root}/docs")
+  rm(site.root)
+}
+
+// Tears down the #2397 fixture. `rm` on `escape` unlinks the LINK, never the
+// directory behind it (the same contract `std/fs.remove` gives `fs.walk`'s
+// own symlink test), so `escapeOutsideDir` survives to be removed on its own.
+fn cleanupEscapeLink(root: string) {
+  rm("${root}/escape")
+  rm("${escapeOutsideDir}/link.sh")
+  rm("${escapeOutsideDir}/secret.txt")
+  rm(escapeOutsideDir)
+}
+
+fn rm(path: string) {
+  remove(path) catch e {
+    print("cleanup: ${path}: ${e.message()}\n")
+  }
+}

--- a/samples/Bit/wordcount.bit
+++ b/samples/Bit/wordcount.bit
@@ -1,0 +1,77 @@
+// Concurrent word count: one green thread per file, results merged over a
+// channel. The whole program is the tutorial's capstone.
+import { writeFile, readFile, remove } from "std/fs"
+import { toLower } from "std/strings"
+
+// Split on anything that is not a letter, lowercasing as we go, and tally.
+fn countWords(text: string): map<string, int> {
+  let counts = map<string, int>()
+  let word = ""
+  let i = 0
+  while (i <= len(text)) {
+    // One past the end flushes the final word.
+    let isLetter = false
+    if (i < len(text)) {
+      let c = text[i]
+      isLetter = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+    }
+    if (isLetter) {
+      word = word + text[i:i + 1]
+    } else if (len(word) > 0) {
+      let w = toLower(word)
+      counts[w] = counts[w] + 1 // an absent key reads as 0
+      word = ""
+    }
+    i = i + 1
+  }
+  return counts
+}
+
+// Read one file and send its tally. A read error sends an empty tally, so the
+// collector always receives exactly one message per spawned worker.
+fn worker(path: string, out: chan<map<string, int>>) {
+  let text = readFile(path) catch ""
+  out <- countWords(text)
+}
+
+// Fan out one green thread per path, then fold every tally into one.
+fn countFiles(paths: []string): map<string, int> {
+  let results = chan<map<string, int>>(len(paths))
+  for p of paths {
+    spawn worker(p, results)
+  }
+
+  let total = map<string, int>()
+  let i = 0
+  while (i < len(paths)) {
+    let part = <- results
+    for (word, n) of part {
+      total[word] = total[word] + n
+    }
+    i = i + 1
+  }
+  return total
+}
+
+fn setup(paths: []string): ()! {
+  writeFile(paths[0], "the quick brown fox")?
+  writeFile(paths[1], "the lazy dog and THE fox")?
+  writeFile(paths[2], "a fox, a dog, the end")?
+}
+
+fn main() {
+  let paths = ["/tmp/bit-wc-1.txt", "/tmp/bit-wc-2.txt", "/tmp/bit-wc-3.txt"]
+  setup(paths) catch e {
+    println("setup failed: ${e.message()}")
+    return
+  }
+
+  let counts = countFiles(paths)
+  println("distinct words: ${len(counts)}")
+  println("the=${counts["the"]} fox=${counts["fox"]} dog=${counts["dog"]}")
+  println("missing=${counts["absent"]}")
+
+  for p of paths {
+    remove(p) catch println("could not remove ${p}")
+  }
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -70,6 +70,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Bicep:** [azure/bicep](https://github.com/azure/bicep)
 - **Bikeshed:** [tabatkins/bikeshed](https://github.com/tabatkins/bikeshed)
 - **Bison:** [Alhadis/language-grammars](https://github.com/Alhadis/language-grammars)
+- **Bit:** [byteink/bit-tmlanguage](https://github.com/byteink/bit-tmlanguage)
 - **BitBake:** [yoctoproject/vscode-bitbake](https://github.com/yoctoproject/vscode-bitbake)
 - **Blade:** [jawee/language-blade](https://github.com/jawee/language-blade)
 - **BlitzBasic:** [textmate/blitzmax.tmbundle](https://github.com/textmate/blitzmax.tmbundle)

--- a/vendor/licenses/git_submodule/bit-tmlanguage.dep.yml
+++ b/vendor/licenses/git_submodule/bit-tmlanguage.dep.yml
@@ -1,0 +1,31 @@
+---
+name: bit-tmlanguage
+version: d31380d74048f2389b461e1b5950ffcba3054ea7
+type: git_submodule
+homepage: https://github.com/byteink/bit-tmlanguage
+license: mit
+licenses:
+- sources: LICENSE
+  text: |2
+        MIT License
+
+        Copyright (c) 2026 byteink
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+notices: []


### PR DESCRIPTION
Adds [Bit](https://bitlang.org), a compiled, garbage-collected systems language. Compiler, runtime and standard library live in [byteink/bit](https://github.com/byteink/bit).

## Description

Adds the `Bit` entry, the `source.bit` grammar as a submodule, and six samples. Added with `script/add-grammar`; the file set matches #8167.

A note on usage before you spend time on this. `extension:bit` returns 12,192 files, but that number is misleading. 1,736 of them are byteink/bit itself, and a sample of the rest is mostly unrelated to this language — `paladin-t/bitty`, `openbsd/xenocara`, `hoglet67/BeebFpga`, chroma test fixtures, Namecoin domain files. Bit code outside its own repo is close to zero right now.

So I've left the adoption checkbox unticked. If you'd rather close this until the extension is actually in the wild, that's a fair call. Happy to add a heuristic separating Bit from the existing `.bit` users if you'd prefer to keep it open.

## Checklist:

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.bit
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.bit+%22fn+main%22
    - Unticked on purpose — see the note above.
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s), all from [byteink/bit](https://github.com/byteink/bit):
      - `staticserver.bit` — https://github.com/byteink/bit/blob/main/examples/staticserver/staticserver.bit
      - `httpserver.bit` — https://github.com/byteink/bit/blob/main/examples/httpserver/httpserver.bit
      - `regex.bit` — https://github.com/byteink/bit/blob/main/examples/regex/regex.bit
      - `wordcount.bit` — https://github.com/byteink/bit/blob/main/examples/wordcount/wordcount.bit
      - `csv.bit` — https://github.com/byteink/bit/blob/main/stdlib/csv/csv.bit
      - `json_parse.bit` — https://github.com/byteink/bit/blob/main/stdlib/json/parse.bit
    - Sample license(s): Apache-2.0, all six. I'm the copyright holder.
  - [x] I have included a syntax highlighting grammar: https://github.com/byteink/bit-tmlanguage (MIT, scope `source.bit`)
  - [x] I have added a color
    - Hex value: `#fe2551`
    - Rationale: the language's existing brand colour, used across [bitlang.org](https://bitlang.org) and its docs. Not randomly picked.
  - No heuristic: `.bit` isn't claimed by any language in `languages.yml`, so there's no same-extension collision to resolve.
