### PR TITLE
Add support for MM2 (Minimal Meta 2)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4957,6 +4957,20 @@ Mirah:
   codemirror_mode: ruby
   codemirror_mime_type: text/x-ruby
   language_id: 232
+MM2:
+  type: programming
+  color: "#00E5FF"
+  aliases:
+  - Minimal Meta 2
+  - mm2
+  - MM2
+  extensions:
+  - ".mm2"
+  tm_scope: source.mm2
+  ace_mode: lisp
+  codemirror_mode: commonlisp
+  codemirror_mime_type: text/x-common-lisp
+  language_id: 859203112
 Modelica:
   type: programming
   color: "#de1d31"

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -410,6 +410,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **MiniZinc Data:** [Dekker1/vscode-minizinc](https://github.com/Dekker1/vscode-minizinc)
 - **Mint:** [mint-lang/mint-vscode](https://github.com/mint-lang/mint-vscode)
 - **Mirah:** [atom/language-ruby](https://github.com/atom/language-ruby)
+- **MM2:** [mieraf-tadesse/vscode-mm2](https://github.com/mieraf-tadesse/vscode-mm2)
 - **Modelica:** [BorisChumichev/modelicaSublimeTextPackage](https://github.com/BorisChumichev/modelicaSublimeTextPackage)
 - **Modula-2:** [harogaston/Sublime-Modula-2](https://github.com/harogaston/Sublime-Modula-2)
 - **Modula-3:** [newgrammars/m3](https://github.com/newgrammars/m3)


### PR DESCRIPTION
### Summary
Adds language support and syntax highlighting for **MM2 (Minimal Meta 2)** file (`.mm2`).

- **Grammar Repository**: https://github.com/mieraf-one/MM2-vscode-extension/tree/main/vscode-mm2
- **VS Code Extension**: https://marketplace.visualstudio.com/items?itemName=mieraf-tadesse.mm2-syntax
- **License**: MIT
- **Extensions**: `.mm2`

### Verification & Usage Proof
- Public repository with `.mm2` code: https://github.com/mieraf-one/MM2-pipline