### PR TITLE
Recognize Befunge instruction rows in .bf files

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -166,6 +166,10 @@ disambiguations:
     - '\sfprintf\s*\('
   - language: Brainfuck
     pattern: '(>\+>|>\+<)'
+  - language: Befunge
+    # Direction-bounded instruction rows containing a stack or branch opcode.
+    # Quoted strings are allowed, but prose and comment prefixes are not.
+    pattern: '^[ \t]*[<>^v](?:[0-9+*/%!`<>^v?\\$.,&#pg~@ \t-]|"[^"\r\n]*")*[:|_](?:[0-9+*/%!`<>^v?\\$.,&#pg~@ \t:|_-]|"[^"\r\n]*")*[<>^v][ \t]*\r?$'
 - extensions: ['.bi']
   rules:
   - language: FreeBASIC

--- a/test/fixtures/Generic/bf/nil/comments.bf
+++ b/test/fixtures/Generic/bf/nil/comments.bf
@@ -1,0 +1,14 @@
+namespace Routing
+{
+    /*
+        > input : output <
+        ^                 v
+        < < < < < < < < < <
+    */
+    class Direction
+    {
+        // >:1-:v
+        // ^    <
+        public const int Step = 1;
+    }
+}

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -314,9 +314,10 @@ class TestHeuristics < Minitest::Test
   def test_bf_by_heuristics
     assert_heuristics({
       "Beef" => all_fixtures("Beef", "*.bf"),
+      "Befunge" => all_fixtures("Befunge", "*.bf"),
       "Brainfuck" => all_fixtures("Brainfuck", "*.bf"),
       "HyPhy" => all_fixtures("HyPhy", "*.bf"),
-      nil => all_fixtures("Befunge", "*.bf"),
+      nil => Dir.glob("#{fixtures_path}/Generic/bf/nil/*.bf"),
     })
   end
 


### PR DESCRIPTION
## Description

Recognize direction-bounded Befunge instruction rows in `.bf` files without relying on the classifier. Require a stack or branch opcode outside quoted strings, while preserving existing Beef, HyPhy, and Brainfuck precedence. The pattern is linear in Ruby and compatible with Go and Rust.

Covers all five existing Befunge samples and adds an original regression fixture for ordinary Beef comments. No external sample code is added. The rule also recognizes public programs such as [a postfix calculator](https://github.com/catseye/Befunge-93/blob/8fe4065c0415b6f6fa6f699798fa9b64737aadc1/eg/rpn.bf) and [an aphorism generator](https://github.com/catseye/Befunge-93/blob/8fe4065c0415b6f6fa6f699798fa9b64737aadc1/eg/ea.bf).

## Checklist:

- [x] **I am adding new or changing current functionality**
  - [x] I have added or updated the tests for the new or changed functionality.