### PR TITLE
Recognize M routine commands in .m heuristics

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -561,7 +561,8 @@ disambiguations:
     # Dot-indented commands, global assignments, and WRITE newline controls.
     - '(?i)^[ \t]+(?:\.[ \t]+)+(?:d(?:o)?|f(?:or)?|i(?:f)?|n(?:ew)?|q(?:uit)?|s(?:et)?|w(?:rite)?)[ \t:]'
     - '(?i)^[ \t]+s(?:et)?[ \t]+\^[%a-z][a-z0-9]*(?:\(|=)'
-    - '(?i)^[ \t]+w(?:rite)?[ \t]+(?:!|[^;\r\n]*,!)'
+    # A formatting delimiter after ! distinguishes WRITE from w != value.
+    - '(?i)^[ \t]+w(?:rite)?[ \t]+(?:!|[^;\r\n]*,!)(?:[,!#?]|[ \t]*(?:;|\r?$))'
   - language: Wolfram Language
     and:
       - pattern: '\(\*'

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -556,7 +556,12 @@ disambiguations:
   - language: MUF
     pattern: '^: '
   - language: M
-    pattern: '^\s*;'
+    pattern:
+    - '^\s*;'
+    # Dot-indented commands, global assignments, and WRITE newline controls.
+    - '(?i)^[ \t]+(?:\.[ \t]+)+(?:d(?:o)?|f(?:or)?|i(?:f)?|n(?:ew)?|q(?:uit)?|s(?:et)?|w(?:rite)?)[ \t:]'
+    - '(?i)^[ \t]+s(?:et)?[ \t]+\^[%a-z][a-z0-9]*(?:\(|=)'
+    - '(?i)^[ \t]+w(?:rite)?[ \t]+(?:!|[^;\r\n]*,!)'
   - language: Wolfram Language
     and:
       - pattern: '\(\*'

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -708,12 +708,13 @@ class TestHeuristics < Minitest::Test
   end
 
   def test_m_by_heuristics
-    ambiguous = all_fixtures("Objective-C", "cocoa_monitor.m")
+    ambiguous = all_fixtures("Objective-C", "cocoa_monitor.m") +
+                all_fixtures("M", "mileage.m")
     assert_heuristics({
       "Objective-C" => all_fixtures("Objective-C", "*.m") - ambiguous,
       "Mercury" => all_fixtures("Mercury", "*.m"),
       "MUF" => all_fixtures("MUF", "*.m"),
-      "M" => all_fixtures("M", "MDB.m"),
+      "M" => all_fixtures("M", "*.m") - ambiguous,
       "Wolfram Language" => all_fixtures("Wolfram Language", "*.m") - all_fixtures("Wolfram Language", "Problem12.m"),
       "MATLAB" => all_fixtures("MATLAB", "create_ieee_paper_plots.m"),
       "Limbo" => all_fixtures("Limbo", "*.m"),


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Recognize M/MUMPS routines without standalone semicolon comments using dot-indented commands, `SET ^global` assignments, and `WRITE` newline controls. Require a formatting delimiter after `!` to distinguish abbreviated `WRITE` from expressions such as `w != value`. Existing `.m` rule ordering is unchanged.

Expand heuristic coverage to the existing M samples, recognizing seven that previously had no heuristic match: `arrays.m`, `fibonacci.m`, `forloop.m`, `helloworld.m`, `ifelse.m`, `indirectfunctions.m`, and `nesting.m`. Leave `mileage.m` to classification rather than matching generic `quit` expressions.

These forms also occur in [VPE routines](https://github.com/shabiel/VPE/blob/b1780afef7db73f8b696a36e0ec415031646d8a9/Routines/XVEMD.m#L40-L53) and [YottaDB routines](https://github.com/YottaDB/YDBTest/blob/bf8967c92b0ab3f24908555cd76363904f650826/com/fixtp.m#L14-L49). No sample files, language metadata, or grammars are added.

Linux heuristic, pedantic, strategy, and sample tests pass (1,861 tests, 7,489 assertions). Ruby/Go/Rust regex compatibility passes with only the existing allowlisted exceptions; full Linguist detection is unchanged across all 97 competing `.m` samples and fixtures.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s): N/A — reuses existing samples; no new sample code is copied.
    - Sample license(s): N/A — no new samples.
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.