### PR TITLE
Add Altair and Pegassus IR languages

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -9660,3 +9660,21 @@ xBase:
   tm_scope: source.harbour
   ace_mode: text
   language_id: 421
+Altair:
+  type: programming
+  color: "#2B6CB0"
+  extensions:
+  - ".at"
+  - ".atc"
+  tm_scope: source.altair
+  ace_mode: text
+  language_id: 999001
+
+Pegassus IR:
+  type: programming
+  color: "#EAB308"
+  extensions:
+  - ".ir"
+  tm_scope: source.pegassus-ir
+  ace_mode: text
+  language_id: 999002

--- a/samples/Altair/game.at
+++ b/samples/Altair/game.at
@@ -1,0 +1,120 @@
+altair.doc;
+    name = "Altair RPG"
+    version = "1.6"
+    author = "Victor"
+create altair.doc
+
+class Player;
+    text name = "" disk
+    numeric health = 100 ram
+    numeric score = 0 ram
+
+    fun takeDamage numeric amount;
+        health -= amount
+        if health < 0;
+            health = 0
+        break
+    break
+
+    fun heal numeric amount;
+        health += amount
+        if health > 100;
+            health = 100
+        break
+    break
+
+    fun isAlive -> bool;
+        return health > 0
+    break
+
+    fun addScore numeric points;
+        score += points
+    break
+create class
+
+fun calculateDamage -> numeric numeric base, numeric multiplier;
+    return base * multiplier
+break
+
+numeric sessionScore = 0 orbit;
+    1 = create temp
+    2 = active ram
+    3 = inactive cache
+    4 = finish disk
+break
+
+object hero = Player() ram weight 900
+text playerName = user input "Como te llamas?" auto
+hero.name = playerName
+
+log "Bienvenido, " + hero.name + "!"
+
+sessionScore migrate 2
+
+snapshot create "inicio"
+
+numeric turns = 0 ram
+while turns < 3;
+    turns += 1
+    log ""
+    log "-- Turno " + turns + " --"
+
+    choose enemyAction;
+        50% = ataca
+        30% = descansa
+        20% = huye
+    define
+
+    log "Enemigo: " + enemyAction
+
+    if enemyAction == "ataca";
+        numeric dmg = calculateDamage(15, 1) ram
+        hero.takeDamage(dmg)
+        log hero.name + " recibe " + dmg + " de danio. Salud: " + hero.health
+    elif enemyAction == "descansa";
+        log "El enemigo descansa..."
+    else;
+        log "El enemigo huye!"
+        exit
+    break
+
+    choose loot;
+        60% = nada
+        30% = pocion
+        10% = espada
+    define
+
+    if loot == "pocion";
+        hero.heal(20)
+        hero.addScore(10)
+        sessionScore += 10
+        log hero.name + " usa una pocion. Salud: " + hero.health
+    elif loot == "espada";
+        hero.addScore(50)
+        sessionScore += 50
+        log hero.name + " encuentra una espada! +50 puntos"
+    break
+
+    if hero.isAlive();
+        log hero.name + " sigue en pie con " + hero.health + " de salud"
+    else;
+        log hero.name + " ha muerto!"
+        exit
+    break
+break
+
+sessionScore migrate 4
+
+log ""
+log "==============================="
+log "Fin del juego"
+log "Jugador: " + hero.name
+log "Salud final: " + hero.health
+log "Score del personaje: " + hero.score
+log "Score de sesion: " + sessionScore
+log "==============================="
+
+snapshot create "final"
+log "Partida guardada en snapshot: final"
+
+release turns

--- a/samples/Altair/hello.at
+++ b/samples/Altair/hello.at
@@ -1,0 +1,20 @@
+altair.doc;
+    name = "Hello"
+    version = "1.0"
+    author = "Altair"
+create altair.doc
+
+log "Hola desde Altair v1.6!"
+
+numeric x = 42 ram
+log "El valor de x es: " + x
+
+text msg = "Altair Language" ram
+log "Lenguaje: " + msg
+
+bool activo = true ram
+if activo;
+    log "Sistema activo"
+else;
+    log "Sistema inactivo"
+break

--- a/samples/Pegassus IR/call_ret.ir
+++ b/samples/Pegassus IR/call_ret.ir
@@ -1,0 +1,8 @@
+push 7
+call add1
+print
+end
+lab add1
+push 1
+add
+ret

--- a/samples/Pegassus IR/fact.ir
+++ b/samples/Pegassus IR/fact.ir
@@ -1,0 +1,20 @@
+push 1
+store 0
+push 5
+store 1
+lab f
+load 0
+load 1
+mul
+store 0
+load 1
+push 1
+sub
+store 1
+load 1
+push 0
+gt
+jnz f
+load 0
+print
+end

--- a/samples/Pegassus IR/hello.ir
+++ b/samples/Pegassus IR/hello.ir
@@ -1,0 +1,3 @@
+pushs "hello pegassus"
+prints
+end

--- a/samples/Pegassus IR/itoa_atoi.ir
+++ b/samples/Pegassus IR/itoa_atoi.ir
@@ -1,0 +1,9 @@
+push 42
+itoa
+prints
+pushs "\n"
+prints
+pushs "  -99x"
+atoi
+print
+end

--- a/samples/Pegassus IR/lib_bits_demo.ir
+++ b/samples/Pegassus IR/lib_bits_demo.ir
@@ -1,0 +1,14 @@
+jmp main
+include pegbits.ir
+lab main
+push 255
+store 240
+call bit_popcnt
+print
+push 8
+store 240
+push 1
+store 241
+call bit_shl
+print
+end

--- a/samples/Pegassus IR/lib_math_demo.ir
+++ b/samples/Pegassus IR/lib_math_demo.ir
@@ -1,0 +1,16 @@
+jmp main
+include pegmath.ir
+lab main
+push 2
+store 240
+push 10
+store 241
+call math_pow
+print
+push 12
+store 240
+push 18
+store 241
+call math_gcd
+print
+end

--- a/samples/Pegassus IR/lib_str_demo.ir
+++ b/samples/Pegassus IR/lib_str_demo.ir
@@ -1,0 +1,8 @@
+jmp main
+include pegstr.ir
+lab main
+push 12345
+store 240
+call str_from_int
+prints
+end

--- a/samples/Pegassus IR/loop_sum.ir
+++ b/samples/Pegassus IR/loop_sum.ir
@@ -1,0 +1,20 @@
+push 0
+store 0
+push 1
+store 1
+lab loop
+load 0
+load 1
+add
+store 0
+load 1
+push 1
+add
+store 1
+load 1
+push 10
+le
+jnz loop
+load 0
+print
+halt

--- a/samples/Pegassus IR/with_std.ir
+++ b/samples/Pegassus IR/with_std.ir
@@ -1,0 +1,8 @@
+jmp main
+include pegstd.ir
+lab main
+push -42
+store 240
+call std_abs
+print
+end

--- a/vendor/grammars/altair.tmLanguage.json
+++ b/vendor/grammars/altair.tmLanguage.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Altair",
+  "scopeName": "source.altair",
+  "fileTypes": ["at", "atc"],
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#strings" },
+    { "include": "#numbers" },
+    { "include": "#keywords" },
+    { "include": "#types" },
+    { "include": "#storage" },
+    { "include": "#constants" },
+    { "include": "#functions" },
+    { "include": "#operators" },
+    { "include": "#identifiers" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.semicolon.altair",
+          "match": ";.*$"
+        },
+        {
+          "name": "comment.block.altair",
+          "begin": "/\\*",
+          "end": "\\*/"
+        }
+      ]
+    },
+    "strings": {
+      "name": "string.quoted.double.altair",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "constant.character.escape.altair",
+          "match": "\\\\."
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.hex.altair",
+          "match": "\\b0x[0-9a-fA-F]+\\b"
+        },
+        {
+          "name": "constant.numeric.float.altair",
+          "match": "\\b\\d+\\.\\d+([eE][+-]?\\d+)?\\b"
+        },
+        {
+          "name": "constant.numeric.integer.altair",
+          "match": "\\b\\d+\\b"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.altair",
+          "match": "\\b(if|elif|else|while|foreach|for|try|catch|fun|class|return|exit|break|create|define|choose|include|snapshot|migrate|weight|auto)\\b"
+        },
+        {
+          "name": "keyword.other.altair",
+          "match": "\\b(log|print|input|user)\\b"
+        }
+      ]
+    },
+    "types": {
+      "name": "storage.type.altair",
+      "match": "\\b(numeric|text|bool|list|object|token|void)\\b"
+    },
+    "storage": {
+      "name": "storage.modifier.altair",
+      "match": "\\b(ram|orbit|cache|disk|temp|active|inactive|finish)\\b"
+    },
+    "constants": {
+      "name": "constant.language.altair",
+      "match": "\\b(true|false|null|nil)\\b"
+    },
+    "functions": {
+      "patterns": [
+        {
+          "name": "entity.name.function.altair",
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=\\()"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.altair",
+          "match": "(==|!=|<=|>=|<|>|\\+|\\-|\\*|/|%|=|\\+=|\\-=|\\*=|/=|&&|\\|\\||!)"
+        },
+        {
+          "name": "keyword.operator.pointer.altair",
+          "match": "(p#|lba%)"
+        }
+      ]
+    },
+    "identifiers": {
+      "name": "variable.other.altair",
+      "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
+    }
+  }
+}

--- a/vendor/grammars/pegassus-ir.tmLanguage.json
+++ b/vendor/grammars/pegassus-ir.tmLanguage.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Pegassus IR",
+  "scopeName": "source.pegassus-ir",
+  "fileTypes": ["ir"],
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#strings" },
+    { "include": "#directives" },
+    { "include": "#labels" },
+    { "include": "#opcodes" },
+    { "include": "#numbers" },
+    { "include": "#identifiers" }
+  ],
+  "repository": {
+    "comments": {
+      "name": "comment.line.semicolon.pegassus-ir",
+      "match": ";.*$"
+    },
+    "strings": {
+      "name": "string.quoted.double.pegassus-ir",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "constant.character.escape.pegassus-ir",
+          "match": "\\\\."
+        }
+      ]
+    },
+    "directives": {
+      "patterns": [
+        {
+          "name": "keyword.control.directive.pegassus-ir",
+          "match": "^\\s*(const|lab|include)\\b"
+        }
+      ]
+    },
+    "labels": {
+      "name": "entity.name.label.pegassus-ir",
+      "match": "^\\s*lab\\s+([a-zA-Z_][a-zA-Z0-9_]*)"
+    },
+    "opcodes": {
+      "name": "keyword.opcode.pegassus-ir",
+      "match": "\\b(push|pushs|pop|load|store|add|sub|mul|div|mod|neg|and|or|xor|not|shl|shr|eq|ne|lt|le|gt|ge|jmp|jnz|jz|call|ret|print|prints|halt|end|itoa|atoi)\\b"
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.hex.pegassus-ir",
+          "match": "\\b0x[0-9a-fA-F]+\\b"
+        },
+        {
+          "name": "constant.numeric.integer.pegassus-ir",
+          "match": "\\b\\d+\\b"
+        }
+      ]
+    },
+    "identifiers": {
+      "name": "variable.other.pegassus-ir",
+      "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds two new programming languages used by the Altair / Pegassus stack:

| Language       | Extensions   | Color     | Description |
|----------------|--------------|-----------|-------------|
| **Altair**     | `.at`, `.atc`| `#2B6CB0` | Low level compiled language |
| **Pegassus IR**| `.ir`        | `#EAB308` | Intermediate representation / bytecode assembly |

## Changes

- [x] Entries added to `lib/linguist/languages.yml`
- [x] TextMate grammars added (`vendor/grammars/`)
- [x] Samples added under `samples/Altair` and `samples/Pegassus IR`

## References

- Altair: https://github.com/victios7/Altair
- Pegassus: https://github.com/victios7/pegassus-altair