### PR TITLE
Add Quarkdown language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1097,6 +1097,9 @@
 [submodule "vendor/grammars/quakec-syntax"]
 	path = vendor/grammars/quakec-syntax
 	url = https://github.com/4LT/quakec-syntax.git
+[submodule "vendor/grammars/quarkdown-tm-grammar-lspless"]
+	path = vendor/grammars/quarkdown-tm-grammar-lspless
+	url = https://github.com/quarkdown-labs/quarkdown-tm-grammar-lspless.git
 [submodule "vendor/grammars/quint-grammars"]
 	path = vendor/grammars/quint-grammars
 	url = https://github.com/informalsystems/quint-grammars.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1599,3 +1599,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/quarkdown-tm-grammar-lspless"]
+	path = vendor/grammars/quarkdown-tm-grammar-lspless
+	url = https://github.com/quarkdown-labs/quarkdown-tm-grammar-lspless.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1007,6 +1007,9 @@ vendor/grammars/quake:
 - source.quake
 vendor/grammars/quakec-syntax:
 - source.quakec
+vendor/grammars/quarkdown-tm-grammar-lspless:
+- text.html.markdown
+- text.quarkdown
 vendor/grammars/quint-grammars:
 - source.quint
 vendor/grammars/r.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6261,6 +6261,17 @@ QuakeC:
   ace_mode: text
   tm_scope: source.quakec
   language_id: 472308069
+Quarkdown:
+  type: prose
+  color: "#7a9b9b"
+  wrap: true
+  ace_mode: markdown
+  codemirror_mode: gfm
+  codemirror_mime_type: text/x-gfm
+  extensions:
+  - ".qd"
+  tm_scope: text.quarkdown
+  language_id: 1028408713
 QuickBASIC:
   type: programming
   color: "#008080"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6263,7 +6263,7 @@ QuakeC:
   language_id: 472308069
 Quarkdown:
   type: prose
-  color: "#7a9b9b"
+  color: "#376d6e"
   wrap: true
   ace_mode: markdown
   codemirror_mode: gfm

--- a/samples/Quarkdown/example.qd
+++ b/samples/Quarkdown/example.qd
@@ -1,0 +1,38 @@
+.docname {My recipes}
+.doctype {plain}
+.doclang {English}
+.theme {paperwhite} layout:{minimal}
+
+.docauthors
+	- John Doe
+	  - website: example.com
+
+# Chocolate cake
+
+.row alignment:{spacebetween}
+	Easy
+	
+	20-25 min
+	
+	8 servings
+
+> Tip: this recipe pairs well with a *ganache glaze*.
+
+## Ingredients
+
+- All-purpose flour
+- Cocoa powder
+- Sugar
+- Salt
+- Eggs
+- Oil
+
+## Nutritional info
+
+.csv {info.csv}
+
+## Credits
+
+.foreach {.docauthors}
+	name info:
+	Thanks to .name: .info::get {website}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -513,6 +513,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Qt Script:** [atom/language-javascript](https://github.com/atom/language-javascript)
 - **Quake:** [newgrammars/quake](https://github.com/newgrammars/quake)
 - **QuakeC:** [4LT/quakec-syntax](https://github.com/4LT/quakec-syntax)
+- **Quarkdown:** [wooorm/markdown-tm-language](https://github.com/wooorm/markdown-tm-language)
 - **QuickBASIC:** [QB64Official/vscode](https://github.com/QB64Official/vscode)
 - **Quint:** [informalsystems/quint-grammars](https://github.com/informalsystems/quint-grammars)
 - **R:** [textmate/r.tmbundle](https://github.com/textmate/r.tmbundle)

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -513,7 +513,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Qt Script:** [atom/language-javascript](https://github.com/atom/language-javascript)
 - **Quake:** [newgrammars/quake](https://github.com/newgrammars/quake)
 - **QuakeC:** [4LT/quakec-syntax](https://github.com/4LT/quakec-syntax)
-- **Quarkdown:** [wooorm/markdown-tm-language](https://github.com/wooorm/markdown-tm-language)
+- **Quarkdown:** [quarkdown-labs/quarkdown-tm-grammar-lspless](https://github.com/quarkdown-labs/quarkdown-tm-grammar-lspless)
 - **QuickBASIC:** [QB64Official/vscode](https://github.com/QB64Official/vscode)
 - **Quint:** [informalsystems/quint-grammars](https://github.com/informalsystems/quint-grammars)
 - **R:** [textmate/r.tmbundle](https://github.com/textmate/r.tmbundle)

--- a/vendor/licenses/git_submodule/quarkdown-tm-grammar-lspless.dep.yml
+++ b/vendor/licenses/git_submodule/quarkdown-tm-grammar-lspless.dep.yml
@@ -1,0 +1,31 @@
+---
+name: quarkdown-tm-grammar-lspless
+version: 0a88fb0090cd17cf2f4bd342646696f879fb2100
+type: git_submodule
+homepage: https://github.com/quarkdown-labs/quarkdown-tm-grammar-lspless.git
+license: mit
+licenses:
+- sources: LICENSE.txt
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) Microsoft 2018
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/vendor/licenses/git_submodule/quarkdown-tm-grammar-lspless.dep.yml
+++ b/vendor/licenses/git_submodule/quarkdown-tm-grammar-lspless.dep.yml
@@ -9,7 +9,7 @@ licenses:
   text: |
     The MIT License (MIT)
 
-    Copyright (c) Microsoft 2018
+    Copyright (c) Microsoft 2018, Quarkdown Labs 2026
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

This PR introduces the [Quarkdown](https://github.com/iamgio/quarkdown) language, an extension of GFM which includes support for Turing-complete function calls.

This a follow up to #8002, which was closed due to not meeting adoption requirements.

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.qd+.+%7B+%7D+NOT+user%3Aiamgio (already excluding myself)
          - Note that, as with my previous PR, this search doesn't do the language justice. Quarkdown doesn't come with a static set of keywords, which makes the result count far from reality.
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [example.qd](https://github.com/iamgio/linguist/blob/b5665abbfcb18e8a63d40c34600e6c1020931fa7/samples/Quarkdown/example.qd)
    - Sample license(s): can be under the MIT license that covers Linguist
  - [x] I have included a syntax highlighting grammar: https://github.com/quarkdown-labs/quarkdown-tm-grammar-lspless
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#376d6e`
    - Rationale: [quarkdown.com](https://quarkdown.com)'s accent color (the primary brand color, `#212d2d`, was too dark on GitHub's dark mode)
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
    - No other language uses the `.qd` extension
